### PR TITLE
Added settings for extending character creation

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -83,6 +83,7 @@ Hooks.once("init", async function() {
               folder = folder.folder;
             }
             potentialPacks[pack.metadata.id] = name;
+            break;
           }
         }
       }

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -70,83 +70,51 @@ Hooks.once("init", async function() {
   /**
    * Configurable properties of the system which affect its behavior.
    */
-  game.settings.register("crucible", "usedAncestries", {
-    name: "SETTINGS.UsedAncestriesName",
-    hint: "SETTINGS.UsedAncestriesHint",
-    scope: "world",
-    config: true,
-    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
+  function itemPacksByType(type) {
       let potentialPacks = {};
       for (const pack of game.packs) {
         if (pack.metadata.type !== "Item") continue;
         for (const item of pack.index) {
-          if (item.type === "ancestry") {
+          if (item.type === type) {
             potentialPacks[pack.metadata.id] = pack.metadata.id;
           }
         }
       }
       return potentialPacks;
-    }})),
+  }
+  game.settings.register("crucible", "ancestrySources", {
+    name: "SETTINGS.AncestrySourcesName",
+    hint: "SETTINGS.AncestrySourcesHint",
+    scope: "world",
+    config: true,
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => itemPacksByType("ancestry")})),
     default: [SYSTEM.COMPENDIUM_PACKS.ancestry],
     requiresReload: true,
   });
-  game.settings.register("crucible", "usedBackgrounds", {
-    name: "SETTINGS.UsedBackgroundsName",
-    hint: "SETTINGS.UsedBackgroundsHint",
+  game.settings.register("crucible", "backgroundSources", {
+    name: "SETTINGS.BackgroundSourcesName",
+    hint: "SETTINGS.BackgroundSourcesHint",
     scope: "world",
     config: true,
-    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
-      let potentialPacks = {};
-      for (const pack of game.packs) {
-        if (pack.metadata.type !== "Item") continue;
-        for (const item of pack.index) {
-          if (item.type === "background") {
-            potentialPacks[pack.metadata.id] = pack.metadata.id;
-          }
-        }
-      }
-      return potentialPacks;
-    }})),
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => itemPacksByType("background")})),
     default: [SYSTEM.COMPENDIUM_PACKS.background],
     requiresReload: true,
   });
-  game.settings.register("crucible", "usedSpells", {
-    name: "SETTINGS.UsedSpellsName",
-    hint: "SETTINGS.UsedSpellsHint",
+  game.settings.register("crucible", "spellSources", {
+    name: "SETTINGS.SpellSourcesName",
+    hint: "SETTINGS.SpellSourcesHint",
     scope: "world",
     config: true,
-    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
-      let potentialPacks = {};
-      for (const pack of game.packs) {
-        if (pack.metadata.type !== "Item") continue;
-        for (const item of pack.index) {
-          if (item.type === "spell") {
-            potentialPacks[pack.metadata.id] = pack.metadata.id;
-          }
-        }
-      }
-      return potentialPacks;
-    }})),
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => itemPacksByType("spell")})),
     default: [SYSTEM.COMPENDIUM_PACKS.spell],
     requiresReload: true,
   });
-  game.settings.register("crucible", "usedTalents", {
-    name: "SETTINGS.UsedTalentsName",
-    hint: "SETTINGS.UsedTalentsHint",
+  game.settings.register("crucible", "talentSources", {
+    name: "SETTINGS.TalentSourcesName",
+    hint: "SETTINGS.TalentSourcesHint",
     scope: "world",
     config: true,
-    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
-      let potentialPacks = {};
-      for (const pack of game.packs) {
-        if (pack.metadata.type !== "Item") continue;
-        for (const item of pack.index) {
-          if (item.type === "talent") {
-            potentialPacks[pack.metadata.id] = pack.metadata.id;
-          }
-        }
-      }
-      return potentialPacks;
-    }})),
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => itemPacksByType("talent")})),
     default: [SYSTEM.COMPENDIUM_PACKS.talent],
     requiresReload: true,
   });
@@ -157,10 +125,10 @@ Hooks.once("init", async function() {
      * @type {Record<string, Set<string>>}
      */
     packs: {
-      ancestry: game.settings.get("crucible", "usedAncestries"),
-      background: game.settings.get("crucible", "usedBackgrounds"),
-      spell: game.settings.get("crucible", "usedSpells"),
-      talent: game.settings.get("crucible", "usedTalents"),
+      ancestry: game.settings.get("crucible", "ancestrySources"),
+      background: game.settings.get("crucible", "backgroundSources"),
+      spell: game.settings.get("crucible", "spellSources"),
+      talent: game.settings.get("crucible", "talentSources"),
     },
     /**
      * The character creation sheet class which should be registered

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -76,7 +76,13 @@ Hooks.once("init", async function() {
         if (pack.metadata.type !== "Item") continue;
         for (const item of pack.index) {
           if (item.type === type) {
-            potentialPacks[pack.metadata.id] = pack.metadata.id;
+            let name = pack.metadata.label;
+            let folder = pack.folder;
+            while (folder) {
+              name = `${folder.name} -> ${name}`
+              folder = folder.folder;
+            }
+            potentialPacks[pack.metadata.id] = name;
           }
         }
       }

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -70,16 +70,97 @@ Hooks.once("init", async function() {
   /**
    * Configurable properties of the system which affect its behavior.
    */
+  game.settings.register("crucible", "usedAncestries", {
+    name: "SETTINGS.UsedAncestriesName",
+    hint: "SETTINGS.UsedAncestriesHint",
+    scope: "world",
+    config: true,
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
+      let potentialPacks = {};
+      for (const pack of game.packs) {
+        if (pack.metadata.type !== "Item") continue;
+        for (const item of pack.index) {
+          if (item.type === "ancestry") {
+            potentialPacks[pack.metadata.id] = pack.metadata.id;
+          }
+        }
+      }
+      return potentialPacks;
+    }})),
+    default: [SYSTEM.COMPENDIUM_PACKS.ancestry],
+    requiresReload: true,
+  });
+  game.settings.register("crucible", "usedBackgrounds", {
+    name: "SETTINGS.UsedBackgroundsName",
+    hint: "SETTINGS.UsedBackgroundsHint",
+    scope: "world",
+    config: true,
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
+      let potentialPacks = {};
+      for (const pack of game.packs) {
+        if (pack.metadata.type !== "Item") continue;
+        for (const item of pack.index) {
+          if (item.type === "background") {
+            potentialPacks[pack.metadata.id] = pack.metadata.id;
+          }
+        }
+      }
+      return potentialPacks;
+    }})),
+    default: [SYSTEM.COMPENDIUM_PACKS.background],
+    requiresReload: true,
+  });
+  game.settings.register("crucible", "usedSpells", {
+    name: "SETTINGS.UsedSpellsName",
+    hint: "SETTINGS.UsedSpellsHint",
+    scope: "world",
+    config: true,
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
+      let potentialPacks = {};
+      for (const pack of game.packs) {
+        if (pack.metadata.type !== "Item") continue;
+        for (const item of pack.index) {
+          if (item.type === "spell") {
+            potentialPacks[pack.metadata.id] = pack.metadata.id;
+          }
+        }
+      }
+      return potentialPacks;
+    }})),
+    default: [SYSTEM.COMPENDIUM_PACKS.spell],
+    requiresReload: true,
+  });
+  game.settings.register("crucible", "usedTalents", {
+    name: "SETTINGS.UsedTalentsName",
+    hint: "SETTINGS.UsedTalentsHint",
+    scope: "world",
+    config: true,
+    type: new foundry.data.fields.SetField(new foundry.data.fields.StringField({ required: true, choices: () => {
+      let potentialPacks = {};
+      for (const pack of game.packs) {
+        if (pack.metadata.type !== "Item") continue;
+        for (const item of pack.index) {
+          if (item.type === "talent") {
+            potentialPacks[pack.metadata.id] = pack.metadata.id;
+          }
+        }
+      }
+      return potentialPacks;
+    }})),
+    default: [SYSTEM.COMPENDIUM_PACKS.talent],
+    requiresReload: true,
+  });
+  
   crucible.CONFIG = {
     /**
      * Configuration of compendium packs which are used as sources for system workflows.
      * @type {Record<string, Set<string>>}
      */
     packs: {
-      ancestry: new Set([SYSTEM.COMPENDIUM_PACKS.ancestry]),
-      background: new Set([SYSTEM.COMPENDIUM_PACKS.background]),
-      spell: new Set([SYSTEM.COMPENDIUM_PACKS.spell]),
-      talent: new Set([SYSTEM.COMPENDIUM_PACKS.talent]),
+      ancestry: game.settings.get("crucible", "usedAncestries"),
+      background: game.settings.get("crucible", "usedBackgrounds"),
+      spell: game.settings.get("crucible", "usedSpells"),
+      talent: game.settings.get("crucible", "usedTalents"),
     },
     /**
      * The character creation sheet class which should be registered

--- a/lang/en.json
+++ b/lang/en.json
@@ -823,6 +823,15 @@
 "SETTINGS.AutoConfirmSelf": "Self-Target Actions Only",
 "SETTINGS.AutoConfirmAll": "Auto-Confirm All Actions",
 
+"SETTINGS.AncestrySourcesName": "Ancestry Sources",
+"SETTINGS.AncestrySourcesHint": "Which packs will be used as sources of ancestries during character creation.",
+"SETTINGS.BackgroundSourcesName": "Background Sources",
+"SETTINGS.BackgroundSourcesHint": "Which packs will be used as sources of backgrounds during character creation.",
+"SETTINGS.SpellSourcesName": "Spell Sources",
+"SETTINGS.SpellSourcesHint": "Which packs will be used as sources of iconic spells.",
+"SETTINGS.TalentSourcesName": "Talent Sources",
+"SETTINGS.TalentSourcesHint": "Which packs will be used as sources of talents for the talent tree.",
+
 "SKILL": {
   "CATEGORY": {
     "EXPLORATION": {

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -37,7 +37,7 @@ export const COMPENDIUM_PACKS = Object.freeze({
   ancestry: "crucible.ancestry",
   archetype: "crucible.archetype",
   background: "crucible.background",
-  spell: "crucible.spells",
+  spell: "crucible.spell",
   talent: "crucible.talent",
   taxonomy: "crucible.taxonomy"
 });


### PR DESCRIPTION
The way it currently works is
- The indexes of all the item packs are iterated through to find the packs that contain items appropriate for a given setting.
- The built-in packs are used as defaults for the settings.
- The packs are displayed using their paths in the format `folder -> subfolder -> pack`.
- All the settings are marked as requiring a reload because, at least the talent tree doesn't get updated otherwise.
Please let me know if any changes are needed to the logic, the code style, or anything else.