### PR TITLE
[#241] Automate skill use for Assess Strength & Intuit Weakness

### DIFF
--- a/module/config/actor.mjs
+++ b/module/config/actor.mjs
@@ -2,20 +2,53 @@ import {freezeEnum} from "./enum.mjs";
 
 /**
  * Creature types supported by the system.
- * @type {Record<string, string>}
+ * @type {Record<string, {label: string, knowledgeSkill: string}>}
  */
 export const CREATURE_CATEGORIES = {
-  beast: "TAXONOMY.CATEGORIES.BEAST",
-  celestial: "TAXONOMY.CATEGORIES.CELESTIAL",
-  construct: "TAXONOMY.CATEGORIES.CONSTRUCT",
-  dragon: "TAXONOMY.CATEGORIES.DRAGON",
-  elemental: "TAXONOMY.CATEGORIES.ELEMENTAL",
-  giant: "TAXONOMY.CATEGORIES.GIANT",
-  humanoid: "TAXONOMY.CATEGORIES.HUMANOID",
-  monstrosity: "TAXONOMY.CATEGORIES.MONSTROSITY",
-  ooze: "TAXONOMY.CATEGORIES.OOZE",
-  outsider: "TAXONOMY.CATEGORIES.OUTSIDER",
-  undead: "TAXONOMY.CATEGORIES.UNDEAD"
+  beast: {
+    label: "TAXONOMY.CATEGORIES.BEAST",
+    knowledgeSkill: "medicine"
+  },
+  celestial: {
+    label: "TAXONOMY.CATEGORIES.CELESTIAL",
+    knowledgeSkill: "arcana"
+  },
+  construct: {
+    label: "TAXONOMY.CATEGORIES.CONSTRUCT",
+    knowledgeSkill: "science"
+  },
+  dragon: {
+    label: "TAXONOMY.CATEGORIES.DRAGON",
+    knowledgeSkill: "arcana"
+  },
+  elemental: {
+    label: "TAXONOMY.CATEGORIES.ELEMENTAL",
+    knowledgeSkill: "arcana"
+  },
+  giant: {
+    label: "TAXONOMY.CATEGORIES.GIANT",
+    knowledgeSkill: "medicine"
+  },
+  humanoid: {
+    label: "TAXONOMY.CATEGORIES.HUMANOID",
+    knowledgeSkill: "medicine"
+  },
+  monstrosity: {
+    label: "TAXONOMY.CATEGORIES.MONSTROSITY",
+    knowledgeSkill: "science"
+  },
+  ooze: {
+    label: "TAXONOMY.CATEGORIES.OOZE",
+    knowledgeSkill: "arcana"
+  },
+  outsider: {
+    label: "TAXONOMY.CATEGORIES.OUTSIDER",
+    knowledgeSkill: "arcana"
+  },
+  undead: {
+    label: "TAXONOMY.CATEGORIES.UNDEAD",
+    knowledgeSkill: "science"
+  }
 };
 
 /**

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -40,6 +40,22 @@ HOOKS.alchemistsFire = {
 
 /* -------------------------------------------- */
 
+HOOKS.assessStrength = {
+  configure() {
+    const targetCategory = this.acquireTargets({strict: false})[0]?.actor.system.details.taxonomy?.category;
+    const skill = SYSTEM.ACTOR.CREATURE_CATEGORIES[targetCategory]?.knowledgeSkill;
+    if (!skill) return;
+    SYSTEM.ACTION.TAGS[skill]?.initialize.call(this);
+  },
+  async roll(outcome) {
+    const skill = this.usage.skillId;
+    if (!skill) return;
+    await SYSTEM.ACTION.TAGS[skill]?.roll.call(this, outcome);
+  }
+}
+
+/* -------------------------------------------- */
+
 HOOKS.berserkStrike = {
   prepare() {
     const health = this.actor.resources.health;
@@ -141,6 +157,22 @@ HOOKS.healingTonic = {
     effect._id = SYSTEM.EFFECTS.getEffectId(this.id);
     foundry.utils.setProperty(effect, "flags.crucible.dot.health", -amount);
     outcome.resources.health = (outcome.resources.health || 0) + amount;
+  }
+}
+
+/* -------------------------------------------- */
+
+HOOKS.intuitWeakness = {
+  configure() {
+    const targetCategory = this.acquireTargets({strict: false})[0]?.actor.system.details.taxonomy?.category;
+    const skill = SYSTEM.ACTOR.CREATURE_CATEGORIES[targetCategory]?.knowledgeSkill;
+    if (!skill) return;
+    SYSTEM.ACTION.TAGS[skill]?.initialize.call(this);
+  },
+  async roll(outcome) {
+    const skill = this.usage.skillId;
+    if (!skill) return;
+    await SYSTEM.ACTION.TAGS[skill]?.roll.call(this, outcome);
   }
 }
 


### PR DESCRIPTION
Closes #241 
Notes:
- I don't love using a tag's `initialize` inside the `configure` hook, but short of pulling out the logic to use there it feels like the best way to set skill prior to rendering the config dialog, but after initiating the item use with a target.
- Happy to move the temporary mapping of creature category -> knowledge skill elsewhere, or modify the actual mappings (just kinda went with my gut).
- In theory, could just have `HOOKS.intuitWeakness = HOOKS.assessStrength`, I think, since the hooks for both are the same. Since at some point though, the other part of each talent might be added (the revealing of resistances/vulnerabilities), probably still makes sense to keep them separate.
- Currently there's a different bug in the repo - `CrucibleActor#skillAttack` is referencing `spell.usage` instead of `action.usage` - didn't put it in this PR since it's entirely possible you fix it prior to merging this, but if you test this out without that fix it'll hit an error.