### PR TITLE
[#118] Add tooltip cards for Iconic Spells

### DIFF
--- a/module/interaction.mjs
+++ b/module/interaction.mjs
@@ -10,6 +10,8 @@ export function onPointerEnter(event) {
       return displayActionTooltip(event);
     case "condition":
       return displayCondition(event);
+    case "spell":
+      return displaySpell(event);
     case "knowledgeCheck":
       return displayKnowledgeCheck(event);
     case "passiveCheck":
@@ -156,6 +158,26 @@ async function displayCondition(event) {
   if ( !page ) return;
   const html = `<h3 class="tooltip-title divider">${page.name}</h3>${page.text.content}`;
   element.dataset.tooltipHtml = await CONFIG.ux.TextEditor.enrichHTML(html);
+  element.dataset.tooltipClass = "crucible crucible-tooltip";
+  const pointerover = new event.constructor(event.type, event);
+  element.dispatchEvent(pointerover);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Display an Iconic Spell's card as a tooltip.
+ * @param {PointerEvent} event
+ * @returns {Promise<void>} 
+ */
+async function displaySpell(event) {
+  const element = event.target;
+  const spell = await fromUuid(element.dataset.uuid);
+  if ( !spell ) return;
+  event.stopImmediatePropagation();
+
+  element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation
+  element.dataset.tooltipHtml = await spell.renderCard();
   element.dataset.tooltipClass = "crucible crucible-tooltip";
   const pointerover = new event.constructor(event.type, event);
   element.dispatchEvent(pointerover);

--- a/templates/sheets/actor/spells.hbs
+++ b/templates/sheets/actor/spells.hbs
@@ -4,9 +4,9 @@
     {{#each spells as |section id|}}
     <div class="sheet-section item-section flexcol">
         <h3 class="section-header">{{section.label}}</h3>
-        <ol class="items-list">
+        <ol class="items-list" data-tooltip-direction="LEFT">
             {{#each section.known as |item|}}
-            <li class="line-item" data-component="{{item.id}}" {{#if item.isItem}}data-item-id="{{item.id}}"{{/if}}>
+            <li class="line-item" data-component="{{item.id}}" {{#if item.isItem}}data-crucible-tooltip="spell" data-uuid="{{item.uuid}}" data-item-id="{{item.id}}"{{/if}}>
                 <img class="icon" src="{{item.img}}" alt="{{item.name}}">
                 <div class="title">
                     <h4>{{item.name}}</h4>

--- a/templates/sheets/item/spell-card.hbs
+++ b/templates/sheets/item/spell-card.hbs
@@ -1,0 +1,14 @@
+<div class="crucible-item-card line-item spell" data-uuid="{{uuid}}">
+    <header class="flexrow">
+        <img class="icon" src="{{img}}" title="{{name}}"/>
+        <div class="title">
+            <h2>{{name}}</h2>
+            <div class="spell-tags tags prerequisites">
+                {{~#each prerequisites as |req|}}
+                <span class="tag {{#unless req.met}}unmet{{/unless}}">{{req.tag}}</span>
+                {{/each~}}
+            </div>
+        </div>
+    </header>
+    {{> "systems/crucible/templates/sheets/item/spell-summary.hbs"}}
+</div>

--- a/templates/sheets/item/spell-inline.hbs
+++ b/templates/sheets/item/spell-inline.hbs
@@ -1,0 +1,13 @@
+<div class="crucible-item-inline line-item spell" data-uuid="{{uuid}}" data-crucible-tooltip="spell">
+    <img class="icon" src="{{img}}" alt="{{name}}">
+    <div class="title">
+        <h4>{{name}}</h4>
+        {{#if tags}}
+        <div class="tags">
+            {{#each tags}}
+            <span class="tag">{{this}}</span>
+            {{/each}}
+        </div>
+        {{/if}}
+    </div>
+</div>

--- a/templates/sheets/item/spell-summary.hbs
+++ b/templates/sheets/item/spell-summary.hbs
@@ -1,0 +1,67 @@
+<section class="description">
+    {{{descriptionHTML}}}
+</section>
+
+{{#if actions.length}}
+<section class="actions">
+    <h3 class="divider">Actions</h3>
+    {{#each actions as |action|}}
+    <div class="action line-item" data-action-id="{{this.id}}">
+        <header class="action-header">
+            <img class="icon" src="{{action.img}}" alt="{{action.name}}">
+            <div class="title">
+                <h4>{{action.name}}</h4>
+                {{#unless tags.activation.empty}}
+                <div class="tags">
+                    {{#each tags.activation as |label tag|}}
+                    <span class="tag" data-tag="{{tag}}">{{label}}</span>
+                    {{/each}}
+                </div>
+                {{/unless}}
+            </div>
+        </header>
+
+        {{#unless tags.action.empty}}
+        <div class="tags" data-tag-type="action">
+            {{#each tags.action as |label tag|}}
+            <span class="tag" data-tag="{{tag}}">{{label}}</span>
+            {{/each}}
+        </div>
+        {{/unless}}
+
+        {{#unless tags.context.empty}}
+        <div class="tags" data-tag-type="context">
+            {{#each tags.context as |label|}}
+            <span class="tag">{{label}}</span>
+            {{/each}}
+        </div>
+        {{/unless}}
+
+        {{#if action.condition}}
+        <p class="condition activation">
+            <strong>{{localize "ACTION.Condition"}}:</strong> <em>{{action.condition}}</em>
+        </p>
+        {{/if}}
+
+        <div class="description">{{{action.description}}}</div>
+
+        {{#if action.effects.length}}
+        <ol class="effects">
+            {{#each action.effects as |effect|}}
+            <li class="effect line-item">
+                <div class="title">
+                    <h4>Effect: <span class="effect-name">{{action.name}}</span></h4>
+                </div>
+                <div class="effect-tags tags">
+                    {{#each effect.tags as |label tag|}}
+                    <span class="tag" data-tag="{{tag}}">{{label}}</span>
+                    {{/each}}
+                </div>
+            </li>
+            {{/each}}
+        </ol>
+        {{/if}}
+    </div>
+{{/each}}
+</section>
+{{/if}}


### PR DESCRIPTION
Closes #118 
There's definitely some room for abstraction - `spell-summary.hbs` and `talent-summary.hbs` are identical, save for the fact that the latter has a section for which (if any) iconic spells it grants.