### PR TITLE
Remove special Impetus logic in favor of `hastened` condition being granted

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -152,11 +152,12 @@ export default class CrucibleCombat extends foundry.documents.Combat {
         _id: impetusId,
         name: "Impetus",
         icon: "icons/magic/movement/trail-streak-zigzag-yellow.webp",
-        changes: [{key: "system.status.impetus", value: 1, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE}],
+        statuses: ["hastened"],
         duration: {
           combat: this.id,
           rounds: 0,
-          turns: 1
+          turns: 1,
+          startRound: this.round
         }
       }
       if ( firstActor.effects.has(impetusId) ) await firstActor.updateEmbeddedDocuments("ActiveEffect", [impetus]);

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -777,7 +777,6 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     if ( statuses.has("stunned") ) r.action.max -= 4;
     else if ( statuses.has("staggered") ) r.action.max -= 2;
     if ( statuses.has("hastened") ) r.action.max += 1;
-    if ( this.status.impetus ) r.action.max += 1; // TODO impetus should just give the hastened condition
     if ( isWeakened ) r.action.max -= 2;
     if ( isIncapacitated ) r.action.max = 0;
     r.action.max = Math.max(r.action.max, 0);


### PR DESCRIPTION
I also added `startRound: this.round`, otherwise the existing effect (if there is one) would get removed anyway because of a 0-round duration. 
The actual solution to that might be different - impetus has a duration of 1 turn. Does that mean it should _expire_ at the end of 1 turn? The docs on `CrucibleActor##updateEndTurnEffects` say "Effects with a duration specified in Turns expire at the end of the Actor's turn once the duration has elapsed." Not sure if the duration should be counted as elapsed at the end of the combatant's turn. I suppose the question is actually two-fold:
1. Does "Turns" duration mean "After this combatant has had X turns" or "After X turns have passed"? My initial thinking was the latter, but I think currently it's implemented as the former (i.e. the only difference between Rounds and Turns is that Rounds expires at the _start_ of a turn, and Turns expires at the _end_ of a turn)
2. Does the turn that a "Turns"-duration effect is applied count as a turn? i.e. should a 1-Turn duration effect expire immediately after the turn ends?