### PR TITLE
[#273] Fix Texteditor deprecations

### DIFF
--- a/module/applications/sheets/item-actor-details-sheet.mjs
+++ b/module/applications/sheets/item-actor-details-sheet.mjs
@@ -124,7 +124,7 @@ export default class CrucibleActorDetailsItemSheet extends CrucibleBaseItemSheet
    * @returns {Promise<*>}
    */
   async #onDropTalent(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = CONFIG.ux.TextEditor.getDragEventData(event);
     const talents = this.document.system.talents;
     if ( (data.type !== "Item") || talents.has(data.uuid) ) return;
     const talent = await fromUuid(data.uuid);

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -179,7 +179,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
             tab: context.tabs.description,
             field: context.fields.description,
             publicSrc: src,
-            publicHTML: await CONFIG.ux.TextEditor.enrichHTML(src, editorOptions)
+            publicHTML: await editorCls.enrichHTML(src, editorOptions)
           }
         }
         break;

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -307,7 +307,7 @@ export default class StandardCheckDialog extends DialogV2 {
    * @returns {Promise<void>}
    */
   async #onDropActor(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = CONFIG.ux.TextEditor.getDragEventData(event);
     if ( data.type !== "Actor" ) return;
     const actor = await fromUuid(data.uuid);
     if ( actor.pack ) return;


### PR DESCRIPTION
Fixes #273 

Deprecation warning suggests to use 

foundry.applications.ux.TextEditor.implementation

but crucible in general uses at multiple locations:

CONFIG.ux.TextEditor

potential fix could also be using the default suggestion instead and replacing all occurences everywhere 