### PR TITLE
Remove accidental use of `spell` in `CrucibleActor#skillAttack`

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -696,8 +696,8 @@ export default class CrucibleActor extends Actor {
 
     // TODO get rid of action.usage here in favor of outcome.usage
     let {bonuses, damageType, restoration, resource, skillId} = action.usage;
-    const boons = {...spell.usage.boons, ...outcome.usage.boons};
-    const banes = {...spell.usage.banes, ...outcome.usage.banes};
+    const boons = {...action.usage.boons, ...outcome.usage.boons};
+    const banes = {...action.usage.banes, ...outcome.usage.banes};
     let defenseType = outcome.usage.defenseType || action.usage.defenseType;
     let dc;
     if ( defenseType in target.defenses ) dc = target.defenses[defenseType].total;


### PR DESCRIPTION
Let me know if you'd like a corresponding issue for easy fixes like these.