### PR TITLE
[#239] Changing the Scene while the Talent Tree is displayed breaks talent tree tooltips

### DIFF
--- a/module/canvas/tree/talent-hud.mjs
+++ b/module/canvas/tree/talent-hud.mjs
@@ -167,7 +167,6 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
       position.left += target.node.x;
       position.top += target.node.y;
     }
-    console.log(position);
     return this.render({force: true, position});
   }
 

--- a/module/canvas/tree/talent-hud.mjs
+++ b/module/canvas/tree/talent-hud.mjs
@@ -127,12 +127,10 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
     const existing = document.getElementById(content.id);
     if ( existing ) {
       content.replaceChildren(); // Always clear
-      super._replaceHTML(result, content, options);
+      return super._replaceHTML(result, content, options);
     }
-    else {
-      const hud = document.getElementById("hud");
-      hud.appendChild(content);
-    }    
+    const hud = document.getElementById("hud");
+    hud.appendChild(content);
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/tree/talent-hud.mjs
+++ b/module/canvas/tree/talent-hud.mjs
@@ -124,8 +124,15 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
 
   /** @override */
   _replaceHTML(result, content, options) {
-    content.replaceChildren(); // Always clear
-    super._replaceHTML(result, content, options);
+    const existing = document.getElementById(content.id);
+    if ( existing ) {
+      content.replaceChildren(); // Always clear
+      super._replaceHTML(result, content, options);
+    }
+    else {
+      const hud = document.getElementById("hud");
+      hud.appendChild(content);
+    }    
   }
 
   /* -------------------------------------------- */
@@ -160,6 +167,7 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
       position.left += target.node.x;
       position.top += target.node.y;
     }
+    console.log(position);
     return this.render({force: true, position});
   }
 


### PR DESCRIPTION
Fixes #239

Analysis:
Changing Scenes resets #hud element removing the tooltip hud. Tooltip Hud App still thinks it is in the DOM and never reattaches

Solution:
Check if still is in dom in _replaceHTML