### PR TITLE
Add `CrucibleActionOutcome#metadata` and use it to resolve issue with the `Delay` action persisting the target initiative value

### DIFF
--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -118,10 +118,10 @@ HOOKS.delay = {
       },
       rejectClose: false
     });
-    if ( response ) this.outcomes.get(this.actor).initiativeDelay = response;
+    if ( response ) this.outcomes.get(this.actor).metadata.initiativeDelay = response;
   },
   async confirm() {
-    return this.actor.delay(this.outcomes.get(this.actor).initiativeDelay);
+    return this.actor.delay(this.outcomes.get(this.actor).metadata.initiativeDelay);
   }
 }
 

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -85,6 +85,7 @@ import CrucibleActionConfig from "../applications/config/action-config.mjs";
  * @property {AttackRoll[]} rolls         Any AttackRoll instances which apply to this outcome
  * @property {object} resources           Resource changes to apply to the target Actor in the form of deltas
  * @property {object} actorUpdates        Data updates to apply to the target Actor
+ * @property {object} metadata            Fallback storage for miscellaneous data that persists throughout the action lifecycle
  * @property {ActionEffect[]} effects     ActiveEffect data to create on the target Actor
  * @property {ActionSummonConfiguration[]} [summons]  Creatures summoned by this action
  * @property {boolean} [weakened]         Did the target become weakened?
@@ -966,6 +967,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       effects: [],
       resources: {},
       actorUpdates: {},
+      metadata: {},
       statusText: [],
     };
 


### PR DESCRIPTION
initiativeDelay is not saved to chat message und thus lost for the confirm action afterwards

The proposed fix instead stores the result in the basic outcome data (but might be better off in something within outcomes for random data like

metadata: {
   initiativeDelay: 11
}


Bonus: Refactor to dialogv2