### PR TITLE
[#289] Add data model & config for languages known

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -203,10 +203,10 @@
         "height.label": "Height",
         "pronouns.label": "Pronouns",
         "weight.label": "Weight"
+      },
+      "languages": {
+        "label": "Known Languages"
       }
-    },
-    "languages": {
-      "label": "Known Languages"
     },
     "movement": {
       "size": {
@@ -800,8 +800,14 @@
 "KEYBINDINGS.ConfirmAction": "Confirm Action",
 "KEYBINDINGS.ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken.",
 
+"LANGUAGE_CATEGORIES": {
+  "NONSPOKEN": "Non-Spoken Languages",
+  "SPOKEN": "Spoken Languages"
+},
+
 "LANGUAGES": {
-  "COMMON": "Common"
+  "COMMON": "Common",
+  "SIGN": "Sign"
 },
 
 "LOOT": {

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -648,12 +648,9 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     const categories = SYSTEM.ACTOR.LANGUAGE_CATEGORIES;
     const options = [];
     for ( const [value, {label, category}] of Object.entries(SYSTEM.ACTOR.LANGUAGES) ) {
-      const currOption = { value, label };
-      if ( category && categories[category] ) currOption.group = categories[category];
-      options.push(currOption);
+      options.push({value, label, group: categories[category]?.label});
     }
-    const groups = options.reduce((acc, {group}) => (group && !acc.includes(group)) ? acc.concat(group) : acc, []);
-    return { options, groups };
+    return options;
   }
 
   /* -------------------------------------------- */

--- a/module/config/actor.mjs
+++ b/module/config/actor.mjs
@@ -139,9 +139,16 @@ export const TRAVEL_PACES = freezeEnum({
 
 /**
  * Categories a language can (optionally) belong to
- * @type {Record<string, string>}
+ * @type {Record<string, {label: string}>}
  */
-export const LANGUAGE_CATEGORIES = {};
+export const LANGUAGE_CATEGORIES = {
+  nonSpoken: {
+    label: "LANGUAGE_CATEGORIES.NONSPOKEN"
+  },
+  spoken: {
+    label: "LANGUAGE_CATEGORIES.SPOKEN"
+  }
+};
 
 /**
  * Languages a creature can know
@@ -149,7 +156,12 @@ export const LANGUAGE_CATEGORIES = {};
  */
 export const LANGUAGES = {
   common: {
-    label: "LANGUAGES.COMMON"
+    label: "LANGUAGES.COMMON",
+    category: "spoken"
+  },
+  sign: {
+    label: "LANGUAGES.SIGN",
+    category: "nonSpoken"
   }
 };
 

--- a/module/models/actor-adversary.mjs
+++ b/module/models/actor-adversary.mjs
@@ -39,7 +39,8 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
         appearance: new fields.HTMLField(),
         public: new fields.HTMLField(),
         private: new fields.HTMLField()
-      })
+      }),
+      languages: new fields.SetField(new fields.StringField({blank: false}))
     });
 
     // Adversaries do not track ability advancement

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -111,9 +111,6 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     // Status
     schema.status = new fields.ObjectField({nullable: true, initial: null});
     schema.favorites = new fields.SetField(new fields.StringField({blank: false}));
-
-    // Languages
-    schema.languages = new fields.SetField(new fields.StringField({blank: false}));
     return schema;
   }
 

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -49,7 +49,8 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
         weight: new fields.StringField(),
         public: new fields.HTMLField(),
         private: new fields.HTMLField()
-      })
+      }),
+      languages: new fields.SetField(new fields.StringField({blank: false}))
     });
     return schema;
   }


### PR DESCRIPTION
Handles some of #289 
Also threw in the context prep in `CrucibleBaseActorSheet`. As-is, once a spot is determined for this to live, the multiselect could just be 
```hbs
{{formGroup fields.languages value=source.system.languages options=languages.options groups=languages.groups}}
```
Actually, should `languages` and `languageCategories` be adde to `crucible.CONFIG`?