### PR TITLE
[#290] Add "known language" enricher

### DIFF
--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -20,6 +20,11 @@ export function registerEnrichers() {
       pattern: /\[\[\/knowledge (\w+)]]/g,
       enricher: enrichKnowledge
     },
+    { // Language Test
+      id: "crucibleLanguage",
+      pattern: /\[\[\/language (\w+)]]/g,
+      enricher: enrichLanguage
+    },
     { // D&D5e Skill Checks
       id: "dnd5eSkill",
       pattern: /\[\[\/skill ([\w\s]+)]]/g,
@@ -282,6 +287,25 @@ function enrichKnowledge([match, knowledgeId]) {
   tag.dataset.crucibleTooltip = "knowledgeCheck";
   tag.dataset.knowledgeId = knowledgeId;
   tag.innerHTML = `Knowledge: ${knowledge.label}`;
+  return tag;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Enrich a language check with format [[/language {languageId}]]
+ * @param {string} match              The full matched string
+ * @param {string} knowledgeId        The matched knowledge ID
+ * @returns {HTMLSpanElement|string}
+ */
+function enrichLanguage([match, languageId]) {
+  const language = SYSTEM.ACTOR.LANGUAGES[languageId];
+  if ( !language ) return new Text(match);
+  const tag = document.createElement("enriched-content");
+  tag.classList.add("language-check", "passive-check", "group-check");
+  tag.dataset.crucibleTooltip = "languageCheck";
+  tag.dataset.languageId = languageId;
+  tag.innerHTML = `Language: ${language.label}`;
   return tag;
 }
 

--- a/module/interaction.mjs
+++ b/module/interaction.mjs
@@ -14,6 +14,8 @@ export function onPointerEnter(event) {
       return displaySpell(event);
     case "knowledgeCheck":
       return displayKnowledgeCheck(event);
+    case "languageCheck":
+      return displayLanguageCheck(event);
     case "passiveCheck":
       return displayPassiveCheck(event);
     case "talent":
@@ -134,6 +136,28 @@ async function displayKnowledgeCheck(event) {
   element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation
 
   const check = async (group, actor) => ({success: actor.hasKnowledge(knowledgeId)});
+  element.dataset.tooltipHtml = await crucible.party.system.renderGroupCheckTooltip(check, {title: element.innerText});
+  element.dataset.tooltipClass = "crucible crucible-tooltip wide";
+  const pointerover = new event.constructor(event.type, event);
+  element.dispatchEvent(pointerover);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * On pointerenter, display a dynamic tooltip for the group language check.
+ * @param {PointerEvent} event 
+ * @returns {Promise<void>}
+ */
+async function displayLanguageCheck(event) {
+  const element = event.target;
+  const languageId = element.dataset.languageId;
+  const language = SYSTEM.ACTOR.LANGUAGES[languageId];
+  if ( !language || !crucible.party ) return;
+  event.stopImmediatePropagation();
+  element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation
+
+  const check = async (group, actor) => ({success: actor.system.details.languages.has(languageId)});
   element.dataset.tooltipHtml = await crucible.party.system.renderGroupCheckTooltip(check, {title: element.innerText});
   element.dataset.tooltipClass = "crucible crucible-tooltip wide";
   const pointerover = new event.constructor(event.type, event);

--- a/styles/crucible.css
+++ b/styles/crucible.css
@@ -2695,6 +2695,20 @@ enriched-content.hazard-check.knowledge-check:before {
   content: "\e0c0";
   font-weight: 900;
 }
+enriched-content.skill-check.language-check,
+enriched-content.passive-check.language-check,
+enriched-content.hazard-check.language-check {
+  --color-background: #3a184a;
+  --color-background-hover: #4d2368;
+  --color-border: #752f9f;
+  --color-border-hover: #ab3fe8;
+}
+enriched-content.skill-check.language-check:before,
+enriched-content.passive-check.language-check:before,
+enriched-content.hazard-check.language-check:before {
+  content: "\f086";
+  font-weight: 900;
+}
 enriched-content.skill-check.hazard-check,
 enriched-content.passive-check.hazard-check,
 enriched-content.hazard-check.hazard-check {

--- a/styles/journal.less
+++ b/styles/journal.less
@@ -217,6 +217,18 @@ enriched-content.hazard-check {
     }
   }
 
+  // Language Checks
+  &.language-check {
+    --color-background: #3a184a;
+    --color-background-hover: #4d2368;
+    --color-border: #752f9f;
+    --color-border-hover: #ab3fe8;
+    &:before {
+      content: "\f086";
+      font-weight: 900;
+    }
+  }
+
   // Hazard Checks
   &.hazard-check {
     --color-background: #2b0606;


### PR DESCRIPTION
Closes #290 
`[[/language common]]` for instance.

Only wonder whether we should have a `hasLanguage` helper like `hasKnowledge` - but so far I can't think of anywhere else it'd come up except for `displayLanguageCheck`, so left it out.