### PR TITLE
[#299] Backgrounds can now grant languages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -578,6 +578,10 @@
       "label": "Knowledge Areas",
       "hint": "Configure knowledge areas that this Background provides automatically. Typically, a Background features two knowledge areas."
     },
+    "languages": {
+      "label": "Known Languages",
+      "hint": "Configure languages that this Background provides automatically."
+    },
     "skills": {
       "label": "Granted Skills",
       "hint": "Configure skills which this Background provides automatically with novice training. Typically, a Background has training in two skills."

--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -271,7 +271,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
    * @protected
    */
   async _initializeBackground(background) {
-    const {knowledge, skills, talents, schema} = background.item.system;
+    const {knowledge, skills, talents, schema, languages} = background.item.system;
 
     // Knowledge Areas
     const knowledgeTags = Array.from(knowledge.map(knowledgeId => {
@@ -281,6 +281,16 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
     if ( knowledgeTags.length ) background.features.push({
       label: schema.getField("knowledge").label,
       tags: knowledgeTags
+    });
+
+    // Languages
+    const languageTags = Array.from(languages.map(languageId => {
+      const l = SYSTEM.ACTOR.LANGUAGES[languageId];
+      return {text: `Language: ${l?.label || l}`};
+    }))
+    if ( languageTags.length ) background.features.push({
+      label: schema.getField("languages").label,
+      tags: languageTags
     });
 
     // Skills

--- a/module/applications/sheets/item-background-sheet.mjs
+++ b/module/applications/sheets/item-background-sheet.mjs
@@ -16,4 +16,25 @@ export default class CrucibleBackgroundItemSheet extends CrucibleActorDetailsIte
   static {
     this._initializeItemSheetClass()
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    return Object.assign(context, {
+      languages: this.#prepareLanguages()
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  #prepareLanguages() {
+    const categories = SYSTEM.ACTOR.LANGUAGE_CATEGORIES;
+    const options = [];
+    for ( const [value, {label, category}] of Object.entries(SYSTEM.ACTOR.LANGUAGES) ) {
+      options.push({value, label, group: categories[category]?.label});
+    }
+    return options;
+  }
 }

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -135,6 +135,9 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
     // Default Background data
     this.details.background ||= this.schema.getField("details.background").initialize({});
 
+    // Add Background languages
+    this.details.languages = this.details.languages.union(this.details.background.languages ?? new Set());
+
     // Threat level
     const adv = this.advancement;
     Object.assign(adv, {threatFactor: 1, threatLevel: adv.level, threat: adv.level});

--- a/module/models/item-background.mjs
+++ b/module/models/item-background.mjs
@@ -16,6 +16,7 @@ export default class CrucibleBackgroundItem extends foundry.abstract.TypeDataMod
       description: new fields.HTMLField({required: true, blank: true}),
       identifier: new ItemIdentifierField(),
       knowledge: new fields.SetField(new fields.StringField({choices: () => crucible.CONFIG.knowledge})),
+      languages: new fields.SetField(new fields.StringField()),
       skills: new fields.SetField(new fields.StringField({required: true, choices: SYSTEM.SKILLS})),
       talents: new fields.SetField(new fields.DocumentUUIDField({type: "Item"})),
       ui: new fields.SchemaField({

--- a/templates/sheets/item/background-config.hbs
+++ b/templates/sheets/item/background-config.hbs
@@ -11,5 +11,6 @@
         <legend>{{localize "BACKGROUND.SHEET.SKILLS"}}</legend>
         {{formGroup fields.skills value=source.system.skills stacked=true type="checkboxes"}}
         {{formGroup fields.knowledge value=source.system.knowledge sort=true}}
+        {{formGroup fields.languages value=source.system.languages options=languages}}
     </fieldset>
 </section>


### PR DESCRIPTION
Three things of consideration here:
1. `CrucibleBackgroundItemSheet##prepareLanguages` is identical to `CrucibleBaseActorSheet##prepareLanguages` - may be worth a helper if it shows up in any more spots.
2. Dunno whether it belongs under the `skills` fieldset in the background item config, bet doesn't look bad there.
3. The `CrucibleHeroActor#_prepareDetails` change to include background languages works as expected (plays nice with the enricher). When displaying known languages, we'll have to ensure that we either split out background-granted languages as a separate, non-editable list, or have a non-edit-mode version which pulls from the document, rather than the source, otherwise background-granted languages won't show up. In other words my 
```hbs
{{formGroup fields.details.fields.languages value=source.system.details.languages options=languages}}
```
is a no-go, unless it's locked behind an edit toggle or something.