### PR TITLE
[#64] Add check to ensure no skipping training ranks

### DIFF
--- a/module/config/talent-node.mjs
+++ b/module/config/talent-node.mjs
@@ -317,6 +317,7 @@ export default class CrucibleTalentNode {
         o.label = "Level"
       }
       else if ( k.startsWith("skills.") ) o.label = SYSTEM.SKILLS[k.split(".")[1]].label;
+      else if ( k.startsWith("training.") ) o.label = SYSTEM.TALENT.TRAINING_TYPES[k.split(".")[1]].label;
       else o.label = k;
       o.tag = `${o.label} ${o.value}`;
       obj[k] = o;

--- a/module/models/item-talent.mjs
+++ b/module/models/item-talent.mjs
@@ -143,6 +143,9 @@ export default class CrucibleTalentItem extends foundry.abstract.TypeDataModel {
     for ( const node of this.nodes ) {
       Object.assign(requirements, foundry.utils.deepClone(node.requirements));
     }
+    if ( this.training.rank > 1 ) {
+      foundry.utils.setProperty(requirements, `training.${this.training.type}`, this.training.rank - 1);
+    }
     return CrucibleTalentNode.preparePrerequisites(requirements);
   }
 
@@ -229,7 +232,7 @@ export default class CrucibleTalentItem extends foundry.abstract.TypeDataModel {
 
     // Require prerequisite stats
     for ( let [k, v] of Object.entries(this.prerequisites) ) {
-      const current = foundry.utils.getProperty(actor.system, k);
+      const current = foundry.utils.getProperty(actor.system, k) ?? 0;
       if ( current < v.value ) {
         const err = game.i18n.format("TALENT.WARNINGS.Locked", {
           name: this.parent.name,


### PR DESCRIPTION
Closes #64 
e.g. you can't grab "Deception Journeyman" unless you've already got "Deception Novice"