### PR TITLE
Allow "negative" currency `award`s, separate `milestone` enricher, add award/milestone summary chat cards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -505,15 +505,28 @@
 "AWARD": {
   "TOOLTIPS": {
     "Currency": "Award Currency",
-    "Milestone": "Award Milestone",
-    "CurrencyMilestone": "Award Currency and Milestone"
+    "Milestone": "Award Milestone(s)"
   },
   "Each": "each",
   "Milestone": {
     "one": "Milestone",
     "other": "Milestones"
   },
+  "SUMMARIES": {
+    "Cost": "{award} cost paid by:",
+    "CostSplit": "{award} cost split between:",
+    "Gain": "{award} granted to:",
+    "GainSplit": "{award} split between:",
+    "TABLE": {
+      "Label": "Currency",
+      "Formula": "Formula",
+      "Total": "Total"
+    }
+  },
+  "TitleCost": "Choose Contributor(s)",
+  "TitleGain": "Choose Recipient(s)",
   "WARNINGS": {
+    "CannotAfford": "The following actors cannot afford the cost of this enricher: {actors}",
     "InvalidTerms": "Unable to parse {terms} as valid award terms.",
     "RequiresGM": "You must be a Gamemaster to use Award enrichers."
   }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -82,7 +82,7 @@ export default class CrucibleChatMessage extends ChatMessage {
    */
   static onRenderHTML(message, html, _messageData) {
     const flags = message.flags.crucible || {};
-    if ( flags.action || (message.rolls[0] instanceof crucible.api.dice.StandardCheck) ) {
+    if ( flags.action || flags.isAwardSummary || (message.rolls[0] instanceof crucible.api.dice.StandardCheck) ) {
       html.classList.add("crucible");
       html.querySelector(".message-content").classList.add("themed", "theme-dark");
     }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -5,7 +5,7 @@ export function registerEnrichers() {
   CONFIG.TextEditor.enrichers.push(
     {
       id: "award",
-      pattern: /\[\[\/award ([\w\s]+)]]/g,
+      pattern: /\[\[\/award ([-\w\s]+)]]/g,
       enricher: enrichAward,
       onRender: renderAward
     },
@@ -46,6 +46,12 @@ export function registerEnrichers() {
       id: "crucibleSpell",
       pattern: /@Spell\[([\w.]+)]/g,
       enricher: enrichSpell
+    },
+    {
+      id: "milestone",
+      pattern: /\[\[\/milestone( \d+)?\]\]/g,
+      enricher: enrichMilestone,
+      onRender: renderMilestone
     },
     {
       id: "reference",
@@ -113,14 +119,13 @@ function enrichDND5ESkill([match, terms]) {
 /**
  * Parse an award's terms into an object representing what should be gained
  * @param {string} terms
- * @returns {{currency: Record<string, string>, milestones: number | undefined, each: boolean}}
+ * @returns {{currency: Record<string, string>, each: boolean}}
  * @throws {Error}
  */
 function parseAwardTerms(terms) {
   const pattern = new RegExp(/^(.+?)(\D+)$/);
   const currency = {};
   const invalid = [];
-  let milestones;
   let each = false;
   for ( const part of terms.split(" ") ) {
     if ( !part ) continue;
@@ -129,7 +134,6 @@ function parseAwardTerms(terms) {
     try {
       new Roll(amount);
       if ( label in crucible.CONFIG.currency ) currency[label] = amount;
-      else if ( ["milestone", "milestones"].includes(label) ) milestones = Number(amount);
       else if ( part === "each" ) each = true;
       else throw new Error();
     } catch(err) {
@@ -141,7 +145,25 @@ function parseAwardTerms(terms) {
     terms: game.i18n.getListFormatter().format(invalid.map(i => `"${i}"`))
   }));
 
-  return { currency, milestones, each }
+  return { currency, each }
+}
+
+/**
+ * Transform a currency object (currency key to amount) into a list of HTML entries for well-formatted display
+ * @param {Record<string, string>} currency Currency object
+ * @param {boolean} [forcePositive=false]   Whether to return positive-formatted text (to avoid double-negatives)
+ * @returns 
+ */
+function formatAwardEntries(currency, forcePositive=false) {
+  const entries = [];
+  for ( const [currencyKey, amount] of Object.entries(currency) ) {
+    const {icon, abbreviation} = crucible.CONFIG.currency[currencyKey];
+    if ( icon ) {
+      const i = `<i class="currency ${currencyKey}" style="background-image: url(${icon});"></i>`;
+      entries.push(i, forcePositive ? Math.abs(amount) : amount);
+    } else entries.push(forcePositive ? Math.abs(amount) : amount, abbreviation);
+  }
+  return entries;
 }
 
 /**
@@ -156,42 +178,21 @@ function enrichAward([match, terms]) {
   } catch(err) {
     return new Text(match);
   }
-  const {currency, milestones, each} = parsed;
-  const entries = [];
+  const {currency, each} = parsed;
   const dataset = {};
-  let tooltip;
 
   // Award Currency
-  for ( const [currencyKey, amount] of Object.entries(currency) ) {
-    const {icon, abbreviation} = crucible.CONFIG.currency[currencyKey];
-    if ( icon ) {
-      const i = `<i class="currency ${currencyKey}" style="background-image: url(${icon});"></i>`;
-      entries.push(i, amount);
-    }
-    else entries.push(amount, abbreviation);
-    tooltip = "AWARD.TOOLTIPS.Currency";
-  }
+  for ( const [currencyKey, amount] of Object.entries(currency) ) dataset[`currency.${currencyKey}`] = amount;
+  dataset.each = each;
+  const entries = formatAwardEntries(currency);
   if ( entries.length && each ) entries.push(game.i18n.localize("AWARD.Each"));
-
-  // Award Milestones
-  if ( milestones ) {
-    if ( entries.length ) {
-      entries.push(game.i18n.localize("and"));
-      tooltip = "AWARD.TOOLTIPS.CurrencyMilestone";
-    }
-    else tooltip = "AWARD.TOOLTIPS.Milestone";
-    const plurals = new Intl.PluralRules(game.i18n.lang);
-    const label = game.i18n.localize("AWARD.Milestone." + plurals.select(milestones));
-    entries.push(milestones, label);
-    dataset.milestones = milestones;
-  }
 
   // Return the enriched content tag
   const tag = document.createElement("enriched-content");
   tag.classList.add("award");
   Object.assign(tag.dataset, dataset);
   tag.innerHTML = entries.join(" ");
-  tag.setAttribute("aria-label", game.i18n.localize(tooltip));
+  tag.setAttribute("aria-label", game.i18n.localize("AWARD.TOOLTIPS.Currency"));
   tag.toggleAttribute("data-tooltip", true);
   return tag;
 }
@@ -199,7 +200,7 @@ function enrichAward([match, terms]) {
 /* -------------------------------------------- */
 
 /**
- * Add interactivity to a rendered hazard enrichment.
+ * Add interactivity to a rendered award enrichment.
  * @param {HTMLElement} element
  */
 function renderAward(element) {
@@ -210,13 +211,17 @@ function renderAward(element) {
 
 async function onClickAward(event) {
   event.preventDefault();
-  if ( !game.user.isGM ) return ui.notifications.warn("AWARD.WARNINGS.RequiresGM", { localize: true })
+  if ( !game.user.isGM ) return ui.notifications.warn("AWARD.WARNINGS.RequiresGM", { localize: true });
 
-  const { currency, milestones, each } = foundry.utils.expandObject({...event.currentTarget.dataset});
+  const { currency, each: eachString } = foundry.utils.expandObject({...event.currentTarget.dataset});
+  const each = eachString === "true";
+
+  const rolls = [];
 
   for ( const [key, formula] of Object.entries(currency) ) {
     const roll = await new Roll(`${formula}`).evaluate();
     currency[key] = roll.total;
+    if ( !roll.isDeterministic ) rolls.push({roll, formula, label: crucible.CONFIG.currency[key]?.label ?? key});
   }
 
   let currencyEach = crucible.api.documents.CrucibleActor.convertCurrency(currency);
@@ -247,7 +252,7 @@ async function onClickAward(event) {
     input: anyActorInput
   });
   const response = await foundry.applications.api.DialogV2.input({
-    window: {title: "Choose Recipient(s)", icon: "fa-solid fa-trophy"},
+    window: {title: game.i18n.localize(`AWARD.Title${currencyEach < 0 ? "Cost" : "Gain"}`), icon: "fa-solid fa-trophy"},
     content: `\
     ${partyMember.outerHTML}${anyActor.outerHTML}
     `,
@@ -257,18 +262,98 @@ async function onClickAward(event) {
 
   // Iterate over actor targets
   const targets = new Set([...response.partyMember, ...response.anyActor]);
-  if ( each !== "true" ) currencyEach = Math.floor(currencyEach / targets.size);
+  if ( !each ) currencyEach = Math.floor(currencyEach / targets.size);
+  if ( currencyEach < 0 ) {
+    const cannotAfford = targets.map(id => game.actors.get(id)).filter(a => a.system.currency < -currencyEach).map(a => a.name);
+    if ( cannotAfford.size ) return ui.notifications.warn(game.i18n.format("AWARD.WARNINGS.CannotAfford", {actors: Array.from(cannotAfford).join(", ")}));
+  }
   for ( const actorId of targets ) {
     const actor = game.actors.get(actorId);
     const startingCurrency = actor.system.currency;
     const newCurrency = Math.max(startingCurrency + currencyEach, 0);
-    const startingMilestones = actor.system._source.advancement.milestones;
-    const newMilestones = Math.max(startingMilestones + Number(milestones), 0);
     actor.update({
-      "system.advancement.milestones": newMilestones,
       "system.currency": newCurrency
     });
   }
+
+  const currencyEntries = formatAwardEntries(currency, true);
+  await ChatMessage.implementation.create({
+    content: `
+    <section class="crucible">
+      <div class="award-chat">
+        ${game.i18n.format(`AWARD.SUMMARIES.${(currencyEach < 0) ? "Cost" : "Gain"}${each ? "" : "Split"}`, {award: currencyEntries.join(" ")})}
+      </div>
+      <ul><li>${Array.from(targets.map(t => game.actors.get(t).name)).join("</li><li>")}</li></ul>
+      ${rolls.length ? `
+      <table class="award-summary-table">
+        <thead>
+          <tr>
+            <th class="award-summary-label">${game.i18n.localize("AWARD.SUMMARIES.TABLE.Label")}</th>
+            <th class="award-summary-formula">${game.i18n.localize("AWARD.SUMMARIES.TABLE.Formula")}</th>
+            <th class="award-summary-total">${game.i18n.localize("AWARD.SUMMARIES.TABLE.Total")}</th>
+          </tr>
+        </thead>
+        <tbody>
+        ${rolls.map(({roll, label, formula}) => `
+          <tr class="award-summary-row">
+            <td class="award-summary-label">${label}</td>
+            <td class="award-summary-formula">${formula}</td>
+            <td class="award-summary-total">${roll.total}</td>
+          </tr>
+        `
+        )}
+        </tbody>
+      </table>
+      ` : ""}
+    </section>
+    `,
+    rolls: rolls.map(r => r.roll),
+    speaker: {user: game.user},
+    flags: {crucible: {isAwardSummary: true}}
+  });
+}
+
+/* -------------------------------------------- */
+/*  Milestones                                  */
+/* -------------------------------------------- */
+
+/**
+ * Enrich a Milestone award with the format [[/milestone]] or [[/milestone {quantity}]]
+ * @param {string} match
+ * @param {string} terms 
+ * @returns 
+ */
+function enrichMilestone([match, term]) {
+  const quantity = Number.isNumeric(term) ? Number(term) : 1;
+  const plurals = new Intl.PluralRules(game.i18n.lang);
+
+  const tag = document.createElement("enriched-content");
+  tag.classList.add("milestone");
+  tag.dataset.quantity = quantity;
+  tag.innerHTML = `${quantity} ${game.i18n.localize("AWARD.Milestone." + plurals.select(quantity))}`;
+  tag.setAttribute("aria-label", game.i18n.localize("AWARD.TOOLTIPS.Milestone"));
+  tag.toggleAttribute("data-tooltip", true);
+  return tag;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Add interactivity to a rendered milestone enrichment.
+ * @param {HTMLElement} element 
+ */
+function renderMilestone(element) {
+  element.addEventListener("click", onClickMilestone);
+}
+
+/* -------------------------------------------- */
+
+async function onClickMilestone(event) {
+  event.preventDefault();
+  if ( !crucible.party ) return ui.notifications.warn("AWARD.WARNINGS.NoParty", { localize: true });
+
+  const quantity = event.currentTarget.dataset.quantity;
+  await crucible.party.system.awardMilestoneDialog(quantity);
 }
 
 /* -------------------------------------------- */

--- a/styles/chat.less
+++ b/styles/chat.less
@@ -53,6 +53,22 @@
   button.confirm {
     margin-top: 0.5rem;
   }
+
+  // Award currency summary
+  .award-chat {
+    display: inline-flex;
+    height: 1.5em;
+    line-height: 0;
+    gap: 4px;
+    margin: -3px -1px;
+    align-items: center;
+
+    i.currency {
+      width: 16px;
+      height: 16px;
+      margin-right: -4px;
+    }
+  }
 }
 
 

--- a/styles/crucible.css
+++ b/styles/crucible.css
@@ -2654,7 +2654,8 @@ crucible-currency > input {
 enriched-content.skill-check,
 enriched-content.passive-check,
 enriched-content.hazard-check,
-enriched-content.award {
+enriched-content.award,
+enriched-content.milestone {
   --color-background: #000000;
   --color-background-hover: #000000;
   --color-border: #000000;
@@ -2676,7 +2677,8 @@ enriched-content.award {
 enriched-content.skill-check:before,
 enriched-content.passive-check:before,
 enriched-content.hazard-check:before,
-enriched-content.award:before {
+enriched-content.award:before,
+enriched-content.milestone:before {
   content: "\f6d2";
   font-family: var(--font-awesome);
   opacity: 0.5;
@@ -2686,20 +2688,23 @@ enriched-content.award:before {
 enriched-content.skill-check:hover,
 enriched-content.passive-check:hover,
 enriched-content.hazard-check:hover,
-enriched-content.award:hover {
+enriched-content.award:hover,
+enriched-content.milestone:hover {
   background: var(--color-background-hover);
   border-color: var(--color-border-hover);
 }
 enriched-content.skill-check:hover:before,
 enriched-content.passive-check:hover:before,
 enriched-content.hazard-check:hover:before,
-enriched-content.award:hover:before {
+enriched-content.award:hover:before,
+enriched-content.milestone:hover:before {
   opacity: 1;
 }
 enriched-content.skill-check.exp,
 enriched-content.passive-check.exp,
 enriched-content.hazard-check.exp,
-enriched-content.award.exp {
+enriched-content.award.exp,
+enriched-content.milestone.exp {
   --color-background: #2c3921;
   --color-background-hover: #365021;
   --color-border: #5b9e26;
@@ -2708,7 +2713,8 @@ enriched-content.award.exp {
 enriched-content.skill-check.kno,
 enriched-content.passive-check.kno,
 enriched-content.hazard-check.kno,
-enriched-content.award.kno {
+enriched-content.award.kno,
+enriched-content.milestone.kno {
   --color-background: #1a1a37;
   --color-background-hover: #242453;
   --color-border: #4848ac;
@@ -2717,7 +2723,8 @@ enriched-content.award.kno {
 enriched-content.skill-check.soc,
 enriched-content.passive-check.soc,
 enriched-content.hazard-check.soc,
-enriched-content.award.soc {
+enriched-content.award.soc,
+enriched-content.milestone.soc {
   --color-background: #3a184a;
   --color-background-hover: #4d2368;
   --color-border: #752f9f;
@@ -2726,13 +2733,15 @@ enriched-content.award.soc {
 enriched-content.skill-check.passive-check,
 enriched-content.passive-check.passive-check,
 enriched-content.hazard-check.passive-check,
-enriched-content.award.passive-check {
+enriched-content.award.passive-check,
+enriched-content.milestone.passive-check {
   cursor: var(--cursor-help, help);
 }
 enriched-content.skill-check.knowledge-check,
 enriched-content.passive-check.knowledge-check,
 enriched-content.hazard-check.knowledge-check,
-enriched-content.award.knowledge-check {
+enriched-content.award.knowledge-check,
+enriched-content.milestone.knowledge-check {
   --color-background: #1a1a37;
   --color-background-hover: #242453;
   --color-border: #4848ac;
@@ -2741,14 +2750,16 @@ enriched-content.award.knowledge-check {
 enriched-content.skill-check.knowledge-check:before,
 enriched-content.passive-check.knowledge-check:before,
 enriched-content.hazard-check.knowledge-check:before,
-enriched-content.award.knowledge-check:before {
+enriched-content.award.knowledge-check:before,
+enriched-content.milestone.knowledge-check:before {
   content: "\e0c0";
   font-weight: 900;
 }
 enriched-content.skill-check.language-check,
 enriched-content.passive-check.language-check,
 enriched-content.hazard-check.language-check,
-enriched-content.award.language-check {
+enriched-content.award.language-check,
+enriched-content.milestone.language-check {
   --color-background: #3a184a;
   --color-background-hover: #4d2368;
   --color-border: #752f9f;
@@ -2757,14 +2768,16 @@ enriched-content.award.language-check {
 enriched-content.skill-check.language-check:before,
 enriched-content.passive-check.language-check:before,
 enriched-content.hazard-check.language-check:before,
-enriched-content.award.language-check:before {
+enriched-content.award.language-check:before,
+enriched-content.milestone.language-check:before {
   content: "\f086";
   font-weight: 900;
 }
 enriched-content.skill-check.hazard-check,
 enriched-content.passive-check.hazard-check,
 enriched-content.hazard-check.hazard-check,
-enriched-content.award.hazard-check {
+enriched-content.award.hazard-check,
+enriched-content.milestone.hazard-check {
   --color-background: #2b0606;
   --color-background-hover: #681212;
   --color-border: #9c1212;
@@ -2773,7 +2786,13 @@ enriched-content.award.hazard-check {
 enriched-content.skill-check.award,
 enriched-content.passive-check.award,
 enriched-content.hazard-check.award,
-enriched-content.award.award {
+enriched-content.award.award,
+enriched-content.milestone.award,
+enriched-content.skill-check.milestone,
+enriched-content.passive-check.milestone,
+enriched-content.hazard-check.milestone,
+enriched-content.award.milestone,
+enriched-content.milestone.milestone {
   --color-background: #243437;
   --color-background-hover: #163037;
   --color-border: #9ea5a7;
@@ -2782,14 +2801,26 @@ enriched-content.award.award {
 enriched-content.skill-check.award:before,
 enriched-content.passive-check.award:before,
 enriched-content.hazard-check.award:before,
-enriched-content.award.award:before {
+enriched-content.award.award:before,
+enriched-content.milestone.award:before,
+enriched-content.skill-check.milestone:before,
+enriched-content.passive-check.milestone:before,
+enriched-content.hazard-check.milestone:before,
+enriched-content.award.milestone:before,
+enriched-content.milestone.milestone:before {
   content: "\f091";
   font-weight: 900;
 }
 enriched-content.skill-check.award i.currency,
 enriched-content.passive-check.award i.currency,
 enriched-content.hazard-check.award i.currency,
-enriched-content.award.award i.currency {
+enriched-content.award.award i.currency,
+enriched-content.milestone.award i.currency,
+enriched-content.skill-check.milestone i.currency,
+enriched-content.passive-check.milestone i.currency,
+enriched-content.hazard-check.milestone i.currency,
+enriched-content.award.milestone i.currency,
+enriched-content.milestone.milestone i.currency {
   width: 16px;
   height: 16px;
   margin-right: -4px;
@@ -2914,6 +2945,19 @@ enriched-content.spell:before {
 }
 .crucible.chat-message button.confirm {
   margin-top: 0.5rem;
+}
+.crucible.chat-message .award-chat {
+  display: inline-flex;
+  height: 1.5em;
+  line-height: 0;
+  gap: 4px;
+  margin: -3px -1px;
+  align-items: center;
+}
+.crucible.chat-message .award-chat i.currency {
+  width: 16px;
+  height: 16px;
+  margin-right: -4px;
 }
 /* -------------------------------------------- */
 /*  Chat Actions                                */

--- a/styles/journal.less
+++ b/styles/journal.less
@@ -150,7 +150,8 @@
 enriched-content.skill-check,
 enriched-content.passive-check,
 enriched-content.hazard-check,
-enriched-content.award {
+enriched-content.award,
+enriched-content.milestone {
   --color-background: #000000;
   --color-background-hover: #000000;
   --color-border: #000000;
@@ -243,7 +244,8 @@ enriched-content.award {
   }
 
   // Awards
-  &.award {
+  &.award,
+  &.milestone {
     --color-background: #243437;
     --color-background-hover: #163037;
     --color-border: #9ea5a7;


### PR DESCRIPTION
Haven't tried to account for a mix of positive & negative values in an award, though it should "just work," if some maniac tries it. Depending on how much future improvements we put into negative award enrichers, it may make sense to make them their own "cost" enricher. 

Also fixed awarding milestones (unrelated to enricher).