### PR TITLE
[#313] Add guard to `CrucibleTalentTreeTalent##onPointerOver` to ensure tooltip only procs if talent tree is the topmost element under the pointer

### DIFF
--- a/module/canvas/tree/talent-tree-talent.mjs
+++ b/module/canvas/tree/talent-tree-talent.mjs
@@ -85,6 +85,7 @@ export default class CrucibleTalentTreeTalent extends CrucibleTalentIcon {
   /* -------------------------------------------- */
 
   #onPointerOver(event) {
+    if ( document.elementFromPoint(event.globalX, event.globalY)?.id !== "crucible-talent-tree" ) return;
     event.stopPropagation();
     this.scale.set(1.2, 1.2);
     game.system.tree.hud.activate(this);


### PR DESCRIPTION
Closes #313 
`CrucibleTalentTreeNode##onPointerOver` has this check, which is why the same behavior isn't observed there.
Didn't add to `#onPointerOut` because hovering a window above the tree _should_ be grounds for de-tooltipping.