### PR TITLE
[#287] Change 'spaces' to feet for talents

### DIFF
--- a/_source/talent/Anticipate_Harm_anticipateharm00.yml
+++ b/_source/talent/Anticipate_Harm_anticipateharm00.yml
@@ -13,9 +13,9 @@ system:
         You are targeted by an area-of-effect attack, the source of which you
         can see.
       description: >-
-        You may immediately Move 1 space after the area-of-effect of the attack
-        is declared. If this movement escapes the area of the attack, you are
-        unaffected.
+        <p>You may immediately move 4 feet after the area-of-effect of the
+        attack is declared. If this movement escapes the area of the attack, you
+        are unaffected.</p>
       tags:
         - movement
         - reaction
@@ -23,27 +23,30 @@ system:
         action: 1
         focus: 1
         weapon: false
+        heroism: 0
       target:
         type: self
         number: 1
         scope: 0
+        self: false
       effects: []
-      name: ''
-      img: null
+      name: Anticipate Harm
+      img: icons/magic/movement/trail-streak-impact-blue.webp
       range:
-        maximum: 0
+        maximum: 4
         weapon: false
+        minimum: null
       actionHooks: []
   requirements: {}
 effects: []
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674961306089
-  modifiedTime: 1742936603324
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757529139242
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Clarify_Intent_clarifyintent000.yml
+++ b/_source/talent/Clarify_Intent_clarifyintent000.yml
@@ -30,7 +30,7 @@ system:
         self: false
       effects:
         - name: Clarify Intent
-          scope: 0
+          scope: 2
           statuses: []
           duration:
             turns: null
@@ -38,14 +38,7 @@ system:
       name: Clarify Intent
       img: icons/skills/targeting/crosshair-arrowhead-blue.webp
       condition: ''
-      actionHooks:
-        - hook: postActivate
-          fn: |-
-            const roll = outcome.rolls[0];
-            if ( roll.isSuccess ) {
-              roll.data.damage.multiplier = 0;
-              roll.data.damage.base = roll.data.damage.total = 1;
-            }
+      actionHooks: []
       range:
         minimum: null
         maximum: 12
@@ -61,7 +54,7 @@ _stats:
   systemVersion: 0.7.8
   coreVersion: '13.348'
   createdTime: 1677347458957
-  modifiedTime: 1757527542265
+  modifiedTime: 1758550799744
   lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.clarifyintent000
   duplicateSource: null

--- a/_source/talent/Clarify_Intent_clarifyintent000.yml
+++ b/_source/talent/Clarify_Intent_clarifyintent000.yml
@@ -9,32 +9,32 @@ system:
   actions:
     - id: clarifyIntent
       description: >-
-        You explain your intentions to an ally within 3 spaces. Make an
+        <p>You explain your intentions to an ally within 12 feet. Make an
         <strong>Diplomacy</strong> skill attack against your ally's Madness
         Threshold. If successful they gain +1 <strong>Focus</strong> and +1
-        <strong>Boon</strong> to actions made within the next Round.
+        <strong>Boon</strong> to actions made within the next Round.</p>
       tags:
         - rallying
         - focus
+        - skill
         - diplomacy
       cost:
         action: 2
         focus: 0
+        heroism: 0
+        weapon: false
       target:
         type: single
         number: 1
-        distance: 3
         scope: 2
+        self: false
       effects:
-        - duration:
+        - name: Clarify Intent
+          scope: 0
+          statuses: []
+          duration:
+            turns: null
             rounds: 1
-          changes:
-            - key: rollBonuses.boons.clarifyIntent.number
-              value: 1
-              mode: 5
-            - key: rollBonuses.boons.clarifyIntent.label
-              value: Clarify Intent
-              mode: 5
       name: Clarify Intent
       img: icons/skills/targeting/crosshair-arrowhead-blue.webp
       condition: ''
@@ -46,6 +46,10 @@ system:
               roll.data.damage.multiplier = 0;
               roll.data.damage.base = roll.data.damage.total = 1;
             }
+      range:
+        minimum: null
+        maximum: 12
+        weapon: false
 effects: []
 ownership:
   default: 0
@@ -54,11 +58,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.345'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1677347458957
-  modifiedTime: 1750875661750
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1757527542265
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.clarifyintent000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Dread_Lord_dreadlord0000000.yml
+++ b/_source/talent/Dread_Lord_dreadlord0000000.yml
@@ -13,28 +13,42 @@ system:
     - id: formidablePresence
       name: Formidable Presence
       description: >-
-        You make an Intimidation skill attack against the Willpower defense of
-        enemies within 3 spaces, dealing Void damage to Morale and causing the
-        Frightened condition for 1 Round to those whose defense you overcome.
+        <p>You make an Intimidation skill attack against the Willpower defense
+        of enemies within 12 feet, dealing Void damage to Morale and causing the
+        Frightened condition for 1 Round to those whose defense you
+        overcome.</p>
       tags:
-        - intimidation
         - willpower
         - void
         - morale
+        - skill
+        - intimidation
       cost:
         action: 1
         focus: 2
+        heroism: 0
+        weapon: false
       target:
         type: pulse
         number: 1
-        distance: 3
         scope: 3
+        self: false
+        size: 12
       effects:
-        - duration:
-            rounds: 1
+        - name: Formidable Presence
           scope: 3
           statuses:
             - frightened
+          duration:
+            turns: null
+            rounds: 1
+      img: icons/magic/death/skull-horned-worn-fire-blue.webp
+      condition: ''
+      range:
+        minimum: null
+        maximum: null
+        weapon: false
+      actionHooks: []
   actorHooks: []
   nodes:
     - sig3.presence
@@ -47,11 +61,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.345'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1675737631782
-  modifiedTime: 1749921041418
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1757528404295
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.dreadlord0000000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Arrow_gesturearrow0000.yml
+++ b/_source/talent/Gesture__Arrow_gesturearrow0000.yml
@@ -6,11 +6,9 @@ system:
   description: >-
     <p>Hurl a projectile of magical power at a distant target. This might use
     the Lightning Rune to hurl a lightning bolt, or the Shadow rune to hurl a
-    ball of devouring darkness.</p>
-
-    <p>The Arrow gesture scales using <strong>Intellect</strong> and targets a
-    <strong>single</strong> creature up to a distance of 10 spaces, dealing 10
-    base damage on a successful attack.</p>
+    ball of devouring darkness.</p><p>The Arrow gesture scales using
+    <strong>Intellect</strong> and targets a <strong>single</strong> creature up
+    to a distance of 60 feet, dealing 8 base damage on a successful attack.</p>
   actions: []
   gesture: arrow
   actorHooks: []
@@ -19,11 +17,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.5.0
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674842056708
-  modifiedTime: 1686252060235
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757523613913
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Compendium.crucible.talent.gesturearrow0000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Create_gesturecreate000.yml
+++ b/_source/talent/Gesture__Create_gesturecreate000.yml
@@ -5,15 +5,12 @@ system:
   node: wis1b
   description: >-
     <p>Coalesce arcane power into tangible form, conjuring a
-    <strong>Creation</strong> which appears in an adjacent space and joins
-    Combat at Initiative 1.</p>
-
-    <p>Your Creation is a Minion of half your own Level chosen from the Summoned
-    Creatures compendium pack corresponding to the Rune used in the spell.</p>
-
-    <p>The Creation lasts for <strong>10 Rounds</strong>. You may only have one
-    active Creation, casting another spell using the Create gesture replaces
-    your previous Creation.</p>
+    <strong>Creation</strong> which appears within 10 feet and joins Combat at
+    Initiative 1.</p><p>Your Creation is a Minion of half your own Level chosen
+    from the Summoned Creatures compendium pack corresponding to the Rune used
+    in the spell.</p><p>The Creation lasts for <strong>10 Rounds</strong>. You
+    may only have one active Creation, casting another spell using the Create
+    gesture replaces your previous Creation.</p>
   actions: []
   gesture: create
   actorHooks: []
@@ -22,11 +19,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.5.0
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674842056708
-  modifiedTime: 1686255844919
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757523775093
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Compendium.crucible.talent.gesturecreate000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Fan_gesturefan000000.yml
+++ b/_source/talent/Gesture__Fan_gesturefan000000.yml
@@ -7,11 +7,9 @@ system:
     <p>Focus the essence of a rune into a sweeping or splintered arc to strike
     multiple targets in close proximity. If used with Earth, this might hurl a
     spray of stone in an arc, while using it with Kinesis might carve a slice
-    across multiple foes.</p>
-
-    <p>The Fan gesture scales using <strong>Intellect</strong> and targets a 120
-    degree cone with distance 1, dealing 6 base damage on a successful
-    attack.</p>
+    across multiple foes.</p><p>The Fan gesture scales using
+    <strong>Intellect</strong> and targets a 120 degree, 6 foot cone, dealing 6
+    base damage on a successful attack.</p>
   actions: []
   gesture: fan
   actorHooks: []
@@ -20,11 +18,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.5.0
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674842056708
-  modifiedTime: 1686252136778
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757524290050
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Compendium.crucible.talent.gesturefan000000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Influence_gestureinfluence.yml
+++ b/_source/talent/Gesture__Influence_gestureinfluence.yml
@@ -6,13 +6,10 @@ system:
   description: >-
     <p>Intensify an arcane phenomenon at close range. Influence could be used
     with the Flame rune to set a target ablaze or with the Stasis rune to sap
-    their Morale.</p>
-
-    <p>The Influence gesture is a more powerful evolution of the basic Touch
-    gesture that is learned with any Rune.</p>
-
-    <p>The Influence gesture scales using <strong>Presence</strong> and targets
-    a <strong>single</strong> adjacent creature, dealing 12 base damage on a
+    their Morale.</p><p>The Influence gesture is a more powerful evolution of
+    the basic Touch gesture that is learned with any Rune.</p><p>The Influence
+    gesture scales using <strong>Presence</strong> and targets a
+    <strong>single</strong> adjacent creature, dealing 10 base damage on a
     successful attack.</p>
   actions: []
   gesture: influence
@@ -22,11 +19,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.5.0
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674842056708
-  modifiedTime: 1686255817791
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757524093675
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Compendium.crucible.talent.gestureinfluence
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Pulse_gesturepulse0000.yml
+++ b/_source/talent/Gesture__Pulse_gesturepulse0000.yml
@@ -8,11 +8,9 @@ system:
     <p>Emit a burst of Runic power in a circular wave that travels outward, with
     you at its center. A Pulse of Spirit might be used to bolster Morale for
     your allies, while a Death pulse might be used to deal Corruption damage to
-    a group of enemies gathered around you.</p>
-
-    <p>The Pulse gesture scales using <strong>Presence</strong> and targets a
-    360 degree radius with distance 1, dealing 6 base damage on a successful
-    attack.</p>
+    a group of enemies gathered around you.</p><p>The Pulse gesture scales using
+    <strong>Presence</strong> and targets a 360 degree, 6 foot radius, dealing 6
+    base damage on a successful attack.</p>
   actions: []
   gesture: pulse
   actorHooks: []
@@ -25,11 +23,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1684686470274
-  modifiedTime: 1742935338540
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757524309684
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Ray_gestureray000000.yml
+++ b/_source/talent/Gesture__Ray_gestureray000000.yml
@@ -7,10 +7,9 @@ system:
     <p>Focus the power of a Rune into a single point, expelling its energy into
     a ranged beam which rapidly travels a short distance to a targeted area. If
     used with Life this might restore the HP of a distant ally steadily over
-    time, while Frost might emit a beam that freezes a target in place.</p>
-
-    <p>The Ray gesture scales using <strong>Wisdom</strong> and targets a line
-    emanating from the caster at distance 6, dealing 6 base damage on a
+    time, while Frost might emit a beam that freezes a target in
+    place.</p><p>The Ray gesture scales using <strong>Wisdom</strong> and
+    targets a 30 foot line emanating from the caster, dealing 6 base damage on a
     successful attack.</p>
   actions: []
   gesture: ray
@@ -23,11 +22,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.5.0
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1675608839856
-  modifiedTime: 1686252836131
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757524355911
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.gestureray000000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Step_gesturestep00000.yml
+++ b/_source/talent/Gesture__Step_gesturestep00000.yml
@@ -5,11 +5,10 @@ system:
   node: dex2b
   description: >-
     <p>Infuse runic power into a movement, crossing physical and spatial
-    boundaries. Move 4 spaces in a straight line, dealing minor damage to
-    enemies or applying restoration to allies in your path.</p>
-
-    <p>The Step gesture scales with <strong>Dexterity</strong>, targets a line
-    with distance 4, dealing 4 base damage on a successful attack.</p>
+    boundaries. Move 20 feet in a straight line, dealing minor damage to enemies
+    or applying restoration to allies in your path.</p><p>The Step gesture
+    scales with <strong>Dexterity</strong> and targets a 20 foot line, dealing 2
+    base damage on a successful attack.</p>
   actions: []
   gesture: step
   actorHooks: []
@@ -18,11 +17,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674842056708
-  modifiedTime: 1747841791140
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757524435645
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Compendium.crucible.talent.gesturestep00000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Gesture__Strike_gesturestrike000.yml
+++ b/_source/talent/Gesture__Strike_gesturestrike000.yml
@@ -6,10 +6,9 @@ system:
   description: >-
     <p>Empower a close-range attack with the essence of a Rune. This rune
     performs a melee weapon attack targeting the defense and dealing damage of
-    the Rune used in the spell.</p>
-
-    <p>The Strike gesture scales using <strong>Strength</strong> and targets a
-    <strong>single</strong> adjacent creature, dealing 12 base damage on a
+    the Rune used in the spell.</p><p>The Strike gesture scales using
+    <strong>Strength</strong> and targets a <strong>single</strong> adjacent
+    creature, dealing base damage according to your equipped weapon on a
     successful attack.</p>
   actions: []
   gesture: strike
@@ -21,11 +20,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.344'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674842056708
-  modifiedTime: 1748551939966
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757525105226
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Compendium.crucible.talent.gesturearrowcopy
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Intimidator_intimidator00000.yml
+++ b/_source/talent/Intimidator_intimidator00000.yml
@@ -11,22 +11,32 @@ system:
     - id: intimidate
       name: Intimidate
       description: >-
-        You physically intimidate an enemy that is within your engagement range,
-        performing an Intimidation skill attack against your target. On a
-        success they sustain Void damage to Morale.
+        <p>You physically intimidate an enemy that is within your engagement
+        range, performing an Intimidation skill attack against your target. On a
+        success they sustain Void damage to Morale.</p>
       tags:
-        - intimidation
         - void
         - morale
+        - skill
+        - intimidation
       cost:
         action: 1
         focus: 1
+        heroism: 0
+        weapon: false
       target:
         type: single
         number: 1
-        distance: 1
         scope: 0
+        self: false
       effects: []
+      img: icons/magic/death/skull-humanoid-crown-white-blue.webp
+      condition: ''
+      range:
+        minimum: null
+        maximum: null
+        weapon: false
+      actionHooks: []
   requirements: {}
 effects: []
 folder: 2MFixpDJ379KOogE
@@ -37,11 +47,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.345'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1676839298208
-  modifiedTime: 1750875661750
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1757527711369
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Rallying_Cry_rallyingcry00000.yml
+++ b/_source/talent/Rallying_Cry_rallyingcry00000.yml
@@ -9,27 +9,42 @@ system:
   actions:
     - id: rallyingCry
       description: >-
-        You emit a courageous bellow that inspires Allies within 3 spaces of you
-        to remain stalwart in the face of danger. You perform an Intimidation
-        skill test against the Madness threshold of your allies. On a success,
-        affected allies become Resolute for one Round.
+        <p>You emit a courageous bellow that inspires Allies within 12 feet of
+        you to remain stalwart in the face of danger. You perform an
+        Intimidation skill test against the Madness threshold of your allies. On
+        a success, affected allies become Resolute for one Round.</p>
       tags:
-        - intimidation
-        - rallying
         - harmless
+        - rallying
+        - skill
+        - intimidation
       cost:
         action: 1
         focus: 1
+        heroism: 0
+        weapon: false
       target:
         type: pulse
         number: 1
-        distance: 3
         scope: 2
+        self: false
+        size: 12
       effects:
-        - duration:
-            rounds: 1
+        - name: Rallying Cry
+          scope: 0
           statuses:
             - resolute
+          duration:
+            turns: null
+            rounds: 1
+      name: Rallying Cry
+      img: icons/creatures/abilities/mouth-teeth-human.webp
+      condition: ''
+      range:
+        minimum: null
+        maximum: null
+        weapon: false
+      actionHooks: []
   actorHooks: []
 effects: []
 ownership:
@@ -39,11 +54,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.345'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1675737507781
-  modifiedTime: 1750875661750
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1757527854988
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.rallyingcry00000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Recognize_Spellcraft_recognizespellcr.yml
+++ b/_source/talent/Recognize_Spellcraft_recognizespellcr.yml
@@ -3,10 +3,10 @@ type: talent
 img: icons/magic/perception/hand-eye-fire-blue.webp
 system:
   description: >-
-    You can interpret the arcane incantations of others to discern the nature of
-    their spellcraft. When an enemy within 10 spaces that you can see and hear
+    <p>You can interpret the arcane incantations of others to discern the nature
+    of their spellcraft. When an enemy within 40 feet that you can see and hear
     begins casting a spell, you can identify its Rune if you have mastered that
-    Rune.
+    Rune.</p>
   actions: []
   requirements: {}
   node: int2b
@@ -18,11 +18,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1675644092055
-  modifiedTime: 1742935853662
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757527335735
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.recognizespellcr
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Shield_Charge_shieldcharge0000.yml
+++ b/_source/talent/Shield_Charge_shieldcharge0000.yml
@@ -7,10 +7,10 @@ flags: {}
 system:
   node: toustr1
   description: >-
-    A defensive technique in which you drive forward, slamming and pushing foes
-    out of your path. You charge up to 6 spaces in a straight line and perform
-    an offhand shield <strong>Strike</strong> against each successive foe along
-    your path.
+    <p>A defensive technique in which you drive forward, slamming and pushing
+    foes out of your path. You charge up to 20 feet in a straight line and
+    perform an offhand shield <strong>Strike</strong> against each successive
+    foe along your path.</p>
   actions:
     - id: shieldCharge
       description: >-
@@ -48,11 +48,11 @@ system:
     - toustr2
 _stats:
   systemId: crucible
-  systemVersion: 0.7.2
-  coreVersion: '13.345'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1674942420012
-  modifiedTime: 1749311061728
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1757529410227
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Strategic_Repositioning_strategicreposit.yml
+++ b/_source/talent/Strategic_Repositioning_strategicreposit.yml
@@ -6,9 +6,9 @@ system:
   description: >-
     <p>You are always thinking ahead about where to position yourself should
     danger loom. Before <strong>Turn 1</strong> of a Combat encounter, provided
-    that you are not Unaware, you may immediately move <strong>1 Space</strong>
-    in any permitted direction.</p><p>If multiple combatants have this feature,
-    repositioning occurs in reverse order of Initiative.</p>
+    that you are not Unaware, you may immediately move 4 feet<strong>
+    </strong>in any permitted direction.</p><p>If multiple combatants have this
+    feature, repositioning occurs in reverse order of Initiative.</p>
   actions: []
   requirements: {}
 effects: []
@@ -19,11 +19,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.7.8
+  coreVersion: '13.348'
   createdTime: 1675741470187
-  modifiedTime: 1742937126583
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1757529178135
+  lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.strategicreposit
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Strategic_Repositioning_strategicreposit.yml
+++ b/_source/talent/Strategic_Repositioning_strategicreposit.yml
@@ -6,9 +6,9 @@ system:
   description: >-
     <p>You are always thinking ahead about where to position yourself should
     danger loom. Before <strong>Turn 1</strong> of a Combat encounter, provided
-    that you are not Unaware, you may immediately move 4 feet<strong>
-    </strong>in any permitted direction.</p><p>If multiple combatants have this
-    feature, repositioning occurs in reverse order of Initiative.</p>
+    that you are not Unaware, you may immediately move 4 feet in any permitted
+    direction.</p><p>If multiple combatants have this feature, repositioning
+    occurs in reverse order of Initiative.</p>
   actions: []
   requirements: {}
 effects: []
@@ -22,7 +22,7 @@ _stats:
   systemVersion: 0.7.8
   coreVersion: '13.348'
   createdTime: 1675741470187
-  modifiedTime: 1757529178135
+  modifiedTime: 1758547185781
   lastModifiedBy: R0gVyyuhVNAYjuaY
   compendiumSource: Item.strategicreposit
   duplicateSource: null

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -90,6 +90,27 @@ HOOKS.blastFlask = {
 
 /* -------------------------------------------- */
 
+HOOKS.clarifyIntent = {
+  async postActivate(outcome) {
+    const roll = outcome.rolls[0];
+    if ( roll?.isSuccess ) {
+      roll.data.damage.multiplier = 0;
+      roll.data.damage.base = roll.data.damage.total = 1;
+      roll.data.damage.resource = "focus";
+    }
+
+    const effect = outcome.effects[0];
+    if ( !effect ) return;
+    effect.changes ||= [];
+    effect.changes.push(
+      {key: "system.rollBonuses.boons.clarifyIntent.number", mode: 5, value: 1},
+      {key: "system.rollBonuses.boons.clarifyIntent.label", mode: 5, value: this.name}
+    );
+  }
+}
+
+/* -------------------------------------------- */
+
 HOOKS.delay = {
   canUse() {
     if ( game.combat?.combatant?.actor !== this.actor ) {


### PR DESCRIPTION
Closes #287 except for the Berserker point.

The following talents still mention spaces:
- Inflection: Pull & Inflection: Push. They both say 1 space (closer/away). Since there's no implementation I wasn't sure whether that should be changed to 4 feet for each.
- Extoll Deeds: Text says "within 6 spaces", but the action is currently configured as a 10ft pulse (i.e. within 2.5 spaces). Wasn't sure whether the data was wrong or the talent was rebalanced.

Mismatch in numbers:
- Iramancer doesn't give the +2 damage to all spell attacks that it says it should; dunno if that's a missing implementation or a rebalance.