### PR TITLE
[#327] Add crucible tooltip for active effects

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -106,6 +106,9 @@ Hooks.once("init", async function() {
     }
   });
 
+  // Active Effect document configuration
+  CONFIG.ActiveEffect.documentClass = documents.CrucibleActiveEffect;
+
   // Actor document configuration
   CONFIG.Actor.documentClass = documents.CrucibleActor;
   CONFIG.Actor.dataModels = {

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -533,7 +533,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       // Add effect to section
       const e = {
         id: effect.id,
-        icon: effect.icon,
+        icon: effect.img,
         name: effect.name,
         tags: tags,
         uuid: effect.uuid,

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -1,4 +1,5 @@
 export {default as CrucibleActor} from "./actor.mjs"
+export {default as CrucibleActiveEffect} from "./active-effect.mjs";
 export {default as CrucibleChatMessage} from "./chat-message.mjs";
 export {default as CrucibleCombat} from "./combat.mjs";
 export {default as CrucibleCombatant} from "./combatant.mjs";

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,0 +1,73 @@
+/**
+ * An active effect subclass which handles system specific logic for active effects.
+ */
+export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect {
+  /**
+   * The Handlebars template used to render this ActiveEffect as a line item for tooltips or as a partial.
+   * @type {string}
+   */
+  static TOOLTIP_TEMPLATE = "systems/crucible/templates/tooltips/tooltip-active-effect.hbs";
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render this ActiveEffect as HTML for a tooltip card.
+   * @returns {Promise<string>}
+   */
+  async renderCard() {
+    await foundry.applications.handlebars.loadTemplates([this.constructor.TOOLTIP_TEMPLATE]);
+    return foundry.applications.handlebars.renderTemplate(this.constructor.TOOLTIP_TEMPLATE, {
+      effect: this,
+      tags: this.getTags()
+    });
+  }
+
+  /**
+   * Obtain an object of tags which describe the Effect.
+   * @returns {EffectTags}
+   */
+  getTags() {
+    const {startRound, rounds, turns} = this.duration;
+    const elapsed = game.combat ? game.combat.round - startRound : 0;
+    const pluralRules = new Intl.PluralRules(game.i18n.lang);
+    const tags = {
+      context: {
+        section: "persistent",
+      },
+      activation: {}
+    };
+    // Status tooltip tags
+    tags.statuses = this.statuses.reduce((obj, conditionId) => {
+      const cfg = CONFIG.statusEffects.find(c => c.id === conditionId);
+      if (cfg) obj[conditionId] = game.i18n.localize(cfg.name);
+      return obj;
+    }, {});
+
+    // Turn-based duration
+    if (Number.isFinite(turns)) {
+      tags.context.section = "temporary";
+      const remaining = turns - elapsed;
+      tags.context.t = remaining;
+      tags.activation.duration = `${remaining} ${game.i18n.localize(`COMBAT.DURATION.TURNS.${pluralRules.select(remaining)}`)}`;
+    }
+
+    // Round-based duration
+    else if (Number.isFinite(rounds)) {
+      tags.context.section = "temporary";
+      const remaining = rounds - elapsed;
+      tags.context.t = 1000000 * remaining;
+      tags.activation.duration = `${remaining} ${game.i18n.localize(`COMBAT.DURATION.ROUNDS.${pluralRules.select(remaining)}`)}`;
+    }
+
+    // Persistent
+    else {
+      tags.context.t = Infinity;
+      tags.activation.duration = "∞";
+    }
+
+    // Disabled Effects
+    if ( this.disabled ) tags.context.section = "disabled";
+
+    return tags;
+  }
+}

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -22,6 +22,8 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
     });
   }
 
+/* -------------------------------------------- */
+
   /**
    * Obtain an object of tags which describe the Effect.
    * @returns {EffectTags}
@@ -31,9 +33,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
     const elapsed = game.combat ? game.combat.round - startRound : 0;
     const pluralRules = new Intl.PluralRules(game.i18n.lang);
     const tags = {
-      context: {
-        section: "persistent",
-      },
+      context: {section: "persistent"},
       activation: {}
     };
     // Status tooltip tags
@@ -67,7 +67,6 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
 
     // Disabled Effects
     if ( this.disabled ) tags.context.section = "disabled";
-
     return tags;
   }
 }

--- a/module/interaction.mjs
+++ b/module/interaction.mjs
@@ -153,7 +153,7 @@ async function displayCondition(event) {
 async function displayFromUuid(event) {
   const element = event.target;
   const item = await fromUuid(element.dataset.uuid);
-  if ( !item ) return;
+  if ( typeof !item?.renderCard === "function" ) return;
   event.stopImmediatePropagation();
 
   element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation

--- a/module/interaction.mjs
+++ b/module/interaction.mjs
@@ -10,14 +10,14 @@ export function onPointerEnter(event) {
       return displayActionTooltip(event);
     case "condition":
       return displayCondition(event);
+    case "activeEffect":
     case "spell":
-      return displaySpell(event);
+    case "talent":
+      return displayFromUuid(event);
     case "knowledgeCheck":
       return displayKnowledgeCheck(event);
     case "passiveCheck":
       return displayPassiveCheck(event);
-    case "talent":
-      return displayTalentTooltip(event);
   }
 }
 
@@ -44,26 +44,6 @@ export function onPointerLeave(event) {
       delete element.dataset.tooltipHtml;
     }, 2000);
   }
-}
-
-/* -------------------------------------------- */
-
-/**
- * Display a talent card as a tooltip.
- * @param {PointerEvent} event
- * @returns {Promise<void>}
- */
-async function displayTalentTooltip(event) {
-  const element = event.target;
-  const talent = await fromUuid(element.dataset.uuid);
-  if ( !talent ) return;
-  event.stopImmediatePropagation();
-
-  element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation
-  element.dataset.tooltipHtml = await talent.renderCard();
-  element.dataset.tooltipClass = "crucible crucible-tooltip";
-  const pointerover = new event.constructor(event.type, event);
-  element.dispatchEvent(pointerover);
 }
 
 /* -------------------------------------------- */
@@ -166,18 +146,18 @@ async function displayCondition(event) {
 /* -------------------------------------------- */
 
 /**
- * Display an Iconic Spell's card as a tooltip.
+ * Display any element retrievable by an uuid which exposes a renderCard function.
  * @param {PointerEvent} event
  * @returns {Promise<void>} 
  */
-async function displaySpell(event) {
+async function displayFromUuid(event) {
   const element = event.target;
-  const spell = await fromUuid(element.dataset.uuid);
-  if ( !spell ) return;
+  const item = await fromUuid(element.dataset.uuid);
+  if ( !item ) return;
   event.stopImmediatePropagation();
 
   element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation
-  element.dataset.tooltipHtml = await spell.renderCard();
+  element.dataset.tooltipHtml = await item.renderCard();
   element.dataset.tooltipClass = "crucible crucible-tooltip";
   const pointerover = new event.constructor(event.type, event);
   element.dispatchEvent(pointerover);

--- a/templates/sheets/actor/effects.hbs
+++ b/templates/sheets/actor/effects.hbs
@@ -4,17 +4,17 @@
     {{#each effects as |section|}}
     <div class="sheet-section item-section flexcol" data-tooltip-direction="LEFT">
         <h3 class="section-header">{{section.label}}</h3>
-        <ol class="items-list">
+        <ol class="items-list" data-tooltip-direction="LEFT">
             {{#each section.effects as |effect|}}
-            <li class="line-item effect" data-effect-id="{{effect.id}}">
+            <li class="line-item effect" data-effect-id="{{effect.id}}" data-crucible-tooltip="activeEffect" data-uuid="{{effect.uuid}}">
                 <img class="icon" src="{{effect.icon}}" alt="{{effect.label}}">
                 <div class="title">
                     <h4>{{effect.name}}</h4>
                     <div class="tags">
-                        {{#each effect.tags as |label tag|}}
+                        {{#each effect.tags.activation as |label tag|}}
                         <span class="tag" data-tag="{{tag}}">{{label}}</span>
                         {{/each}}
-                        {{#each effect.statuses as |label id|}}
+                        {{#each effect.tags.statuses as |label id|}}
                         <span class="tag" data-tag="{{id}}" data-crucible-tooltip="condition" data-condition="{{id}}" data-tooltip-class="crucible crucible-tooltip">{{label}}</span>
                         {{/each}}
                     </div>

--- a/templates/tooltips/tooltip-active-effect.hbs
+++ b/templates/tooltips/tooltip-active-effect.hbs
@@ -6,7 +6,7 @@
             {{#unless tags.activation.empty}}
             <div class="tags">
                 {{#each tags.activation as |label tag|}}
-                    <span class="tag" data-tag="{{tag}}">{{label}}</span>
+                <span class="tag" data-tag="{{tag}}">{{label}}</span>
                 {{/each}}
             </div>
             {{/unless}}
@@ -15,9 +15,9 @@
 
     {{#unless tags.statuses.empty}}
     <div class="tags" data-tag-type="status">
-    {{#each tags.statuses as |label tag|}}
+        {{#each tags.statuses as |label tag|}}
         <span class="tag" data-tag="{{tag}}">{{label}}</span>
-    {{/each}}
+        {{/each}}
     </div>
     {{/unless}}
 

--- a/templates/tooltips/tooltip-active-effect.hbs
+++ b/templates/tooltips/tooltip-active-effect.hbs
@@ -1,0 +1,26 @@
+<div class="action line-item" data-effect-id="{{effect.id}}">
+    <header class="action-header">
+        <img class="icon" src="{{effect.img}}" alt="{{effect.name}}">
+        <div class="title">
+            <h4>{{effect.name}}</h4>
+            {{#unless tags.activation.empty}}
+            <div class="tags">
+                {{#each tags.activation as |label tag|}}
+                    <span class="tag" data-tag="{{tag}}">{{label}}</span>
+                {{/each}}
+            </div>
+            {{/unless}}
+        </div>
+    </header>
+
+    {{#unless tags.statuses.empty}}
+    <div class="tags" data-tag-type="status">
+    {{#each tags.statuses as |label tag|}}
+        <span class="tag" data-tag="{{tag}}">{{label}}</span>
+    {{/each}}
+    </div>
+    {{/unless}}
+
+    <div class="description">{{{effect.description}}}</div>
+
+</div>


### PR DESCRIPTION
Fixes #327

Adds tooltips for active effects.


<img width="569" height="236" alt="grafik" src="https://github.com/user-attachments/assets/52d11e1c-a9e1-4a84-9c17-7c4b99425b8c" />
