### PR TITLE
Only enable Hit Box if microgrid is active

### DIFF
--- a/module/canvas/grid/hit-box-shader.mjs
+++ b/module/canvas/grid/hit-box-shader.mjs
@@ -394,7 +394,7 @@ export default class CrucibleHitBoxShader extends foundry.canvas.rendering.shade
 
       bool targeted = ((vAnimationTypes & TARGETED) != 0U);
       bool hovered = ((vAnimationTypes & HOVERED) != 0U);
-      bool controlled= ((vAnimationTypes & CONTROLLED) != 0U);
+      bool controlled = ((vAnimationTypes & CONTROLLED) != 0U);
     
       float thicknessPx = max(thickness * zoomScale, 0.0);
       float borderPx = max(dashBorderPixels * zoomScale, 0.0);
@@ -454,7 +454,7 @@ export default class CrucibleHitBoxShader extends foundry.canvas.rendering.shade
       }
 
       // CELL FADING OPTION
-      if ( (vAnimationTypes & CELLFADEFILL) != 0U || ((hovered && !controlled) || targeted) ){
+      if ( (vAnimationTypes & CELLFADEFILL) != 0U || (hovered || targeted) ){
         float cA = cellFade(vNormGrid) * fxMask;
         accumulateOver(outColor, vVertexColor.rgb, vVertexColor.a * cA);
       }

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -88,6 +88,7 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   /** @inheritDoc */
   async _draw(options){
     await super._draw(options);
+    if ( !canvas.scene.useMicrogrid ) return;
     this.constructor.#voidContainer.visible = false;
     this.constructor.#voidContainer.addChild(this.border);
     this.constructor.#voidContainer.addChild(this.targetArrows);
@@ -104,13 +105,16 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   /* -------------------------------------------- */
 
   /** @override */
-  _refreshBorder() {} // no-op
+  _refreshBorder() {
+    if ( !canvas.scene.useMicrogrid ) super._refreshBorder();
+  }
 
   /* -------------------------------------------- */
 
   /** @inheritDoc */
   _refreshVisibility() {
     super._refreshVisibility();
+    if ( !canvas.scene.useMicrogrid ) return;
     this.#hbCache.animationTypes.toggleState("controlled", this.controlled);
     this.#hbCache.animationTypes.toggleState("hovered", this.hover || this.layer.highlightObjects);
     if ( this.isVisible ) CrucibleTokenObject.visibleTokens.add(this);
@@ -121,6 +125,7 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
 
   /** @override */
   _refreshTarget() {
+    if ( !canvas.scene.useMicrogrid ) return super._refreshTarget();
     this._drawTargetPips();
     const isTargetedByUser = (this.targeted.size > 0) && this.targeted.has(game.user);
     this.#hbCache.animationTypes.toggleState("targeted", isTargetedByUser);


### PR DESCRIPTION
+ only enable Hit Box if microgrid is active
+ enable checkers animation when a token is hovered and controlled.