### PR TITLE
[#355] Auto-stack stackable items when dropping onto an actor's sheet who already has such an item

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -1079,6 +1079,8 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
         return;
       }
     }
+
+    // Create a new item
     item = item.clone({system: {equipped: false}}, {keepId: !isPhysical});
     if ( section === item.type ) { // Attempt equipment
       try {


### PR DESCRIPTION
Closes #355
Both the being-dragged item and the existing item must have "stackable" checked for this to work (obviously), and existing item is identified by matching `type` and `system.identifier`.