### PR TITLE
[#345] Consolidate `defendXAttack` hooks to one `defendAttack` hook

### DIFF
--- a/_source/pregens/Duurath_iLUfMcYjAbZFY4CJ.yml
+++ b/_source/pregens/Duurath_iLUfMcYjAbZFY4CJ.yml
@@ -1024,45 +1024,6 @@ items:
     ownership:
       default: 0
     _key: '!actors.items!iLUfMcYjAbZFY4CJ.bulwark000000000'
-  - name: Testudo
-    type: talent
-    _id: testudo000000000
-    img: icons/skills/melee/shield-block-gray-yellow.webp
-    system:
-      description: >-
-        You are highly skilled in using shields to adopt a defensive posture.
-        You gain double the benefit of the <strong>Guarded</strong> condition
-        against <strong>Weapon Attacks</strong> while wielding a shield.
-      actions: []
-      actorHooks:
-        - hook: defendWeaponAttack
-          fn: >-
-            if ( this.statuses.has("guarded") && this.equipment.weapons.shield )
-            rollData.banes.testudo = {label: "Testudo", number: 1};
-      iconicSpells: 0
-      training:
-        type: ''
-        rank: null
-      nodes:
-        - tou0a
-      rune: ''
-      gesture: ''
-      inflection: ''
-    effects: []
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      exportSource: null
-      coreVersion: '13.350'
-      systemId: crucible
-      systemVersion: 0.7.9
-      lastModifiedBy: null
-    folder: 8Vb0F5R7DMUrvhfw
-    sort: -25000
-    ownership:
-      default: 0
-    _key: '!actors.items!iLUfMcYjAbZFY4CJ.testudo000000000'
   - name: Hold Fast
     type: talent
     _id: holdfast00000000
@@ -1621,6 +1582,44 @@ items:
     ownership:
       default: 0
     _key: '!actors.items!iLUfMcYjAbZFY4CJ.shieldCombatProf'
+  - name: Testudo
+    type: talent
+    _id: testudo000000000
+    img: icons/skills/melee/shield-block-gray-yellow.webp
+    system:
+      description: >-
+        You are highly skilled in using shields to adopt a defensive posture.
+        You gain double the benefit of the <strong>Guarded</strong> condition
+        against <strong>Weapon Attacks</strong> while wielding a shield.
+      actions: []
+      actorHooks: []
+      nodes:
+        - tou0a
+      rune: ''
+      gesture: ''
+      inflection: ''
+      iconicSpells: 0
+      training:
+        type: ''
+        rank: null
+    effects: []
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.crucible.talent.Item.testudo000000000
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.350'
+      systemId: crucible
+      systemVersion: 0.8.0
+      createdTime: 1761595030572
+      modifiedTime: 1761595030572
+      lastModifiedBy: p3lgSv60AK7ndmAK
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      p3lgSv60AK7ndmAK: 3
+    _key: '!actors.items!iLUfMcYjAbZFY4CJ.testudo000000000'
 effects: []
 flags:
   core: {}

--- a/_source/spell/Protective_Mirage_protectiveMirage.yml
+++ b/_source/spell/Protective_Mirage_protectiveMirage.yml
@@ -53,13 +53,14 @@ system:
   inflections:
     - eluding
   actorHooks:
-    - hook: defendWeaponAttack
-      fn: >-
-        const effect = this.effects.get("protectiveMirage"); if ( !effect )
-        return; const duplicates = effect.flags.crucible?.duplicates ?? 3;
-        rollData.banes.mirage = {label: "Protective Mirage", number: duplicates
-        * 2};
-    - hook: applyActionOutcome
+    - hook: defendAttack
+      fn: |-
+        if ( !action.tags.has("strike") ) return;
+        const effect = this.effects.get("protectiveMirage");
+        if ( !effect ) return;
+        const duplicates = effect.flags.crucible?.duplicates ?? 3;
+        rollData.banes.mirage = {label: item.name, number: duplicates * 2};
+    - hook: confirmActionOutcome
       fn: |-
         const effect = this.effects.get("protectiveMirage");
         if ( !effect ) return;
@@ -96,10 +97,10 @@ _stats:
   duplicateSource: null
   coreVersion: '13.350'
   systemId: crucible
-  systemVersion: 0.6.0
+  systemVersion: 0.8.0
   createdTime: 1727204769939
-  modifiedTime: 1759877572783
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1761594127724
+  lastModifiedBy: p3lgSv60AK7ndmAK
   exportSource: null
 _id: protectiveMirage
 sort: 300000

--- a/_source/talent/Planned_Defense_planneddefense00.yml
+++ b/_source/talent/Planned_Defense_planneddefense00.yml
@@ -10,18 +10,7 @@ system:
     <strong>Initiative</strong> order suffers 1 Bane to their spell or weapon
     attacks against you.
   actions: []
-  actorHooks:
-    - hook: defendWeaponAttack
-      fn: |-
-        const ac = this.combatant;
-        const oc = origin.combatant;
-        if ( ac?.initiative > oc?.initiative ) 
-          rollData.banes.plannedDefense = {label: "Planned Defense", number: 1};
-    - hook: defendSpellAttack
-      fn: >-
-        const ac = this.combatant; const oc = origin.combatant; if (
-        ac?.initiative > oc?.initiative ) rollData.banes.plannedDefense =
-        {label: "Planned Defense", number: 1};
+  actorHooks: []
 effects: []
 folder: BevAJzzLeFbSaVic
 sort: 50000
@@ -31,11 +20,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.8.0
+  coreVersion: '13.350'
   createdTime: 1685214851183
-  modifiedTime: 1742935786344
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1761593546972
+  lastModifiedBy: p3lgSv60AK7ndmAK
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Still_Lake_stilllake0000000.yml
+++ b/_source/talent/Still_Lake_stilllake0000000.yml
@@ -10,11 +10,7 @@ system:
     against you from any of the <strong>Social</strong> skills are made with
     <strong>2 Banes</strong>.</p>
   actions: []
-  actorHooks:
-    - hook: defendSkillAttack
-      fn: >-
-        if ( CONFIG.SYSTEM.SKILLS[action.usage.skillId].category === "soc" )
-        rollData.banes.stillLake = {label: "Still Lake", number: 2};
+  actorHooks: []
   nodes:
     - wis2b
 effects: []
@@ -26,11 +22,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.344'
+  systemVersion: 0.8.0
+  coreVersion: '13.350'
   createdTime: 1685821347312
-  modifiedTime: 1748552160638
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1761594725063
+  lastModifiedBy: p3lgSv60AK7ndmAK
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Testudo_testudo000000000.yml
+++ b/_source/talent/Testudo_testudo000000000.yml
@@ -9,20 +9,16 @@ system:
     gain double the benefit of the <strong>Guarded</strong> condition against
     <strong>Weapon Attacks</strong> while wielding a shield.
   actions: []
-  actorHooks:
-    - hook: defendWeaponAttack
-      fn: >-
-        if ( this.statuses.has("guarded") && this.equipment.weapons.shield )
-        rollData.banes.testudo = {label: "Testudo", number: 1};
+  actorHooks: []
 effects: []
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.8.0
+  coreVersion: '13.350'
   createdTime: 1674840825101
-  modifiedTime: 1747840922166
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1761594314378
+  lastModifiedBy: p3lgSv60AK7ndmAK
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/module/config/actor.mjs
+++ b/module/config/actor.mjs
@@ -251,15 +251,7 @@ export const HOOKS = Object.freeze({
     group: "TALENT.HOOKS.GROUP_ACTION",
     argNames: ["action", "outcome", "self"]
   },
-  defendSkillAttack: {
-    group: "TALENT.HOOKS.GROUP_ACTION",
-    argNames: ["action", "origin", "rollData"]
-  },
-  defendSpellAttack: {
-    group: "TALENT.HOOKS.GROUP_ACTION",
-    argNames: ["spell", "origin", "rollData"]
-  },
-  defendWeaponAttack: {
+  defendAttack: {
     group: "TALENT.HOOKS.GROUP_ACTION",
     argNames: ["action", "origin", "rollData"]
   },

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -616,7 +616,7 @@ export default class CrucibleActor extends Actor {
     // Call talent hooks
     this.callActorHooks("prepareStandardCheck", rollData);
     this.callActorHooks("prepareSpellAttack", spell, target, rollData);
-    target.callActorHooks("defendSpellAttack", spell, this, rollData); // TODO migrate to defendAttack
+    target.callActorHooks("defendAttack", spell, this, rollData);
 
     // Create the Attack Roll instance
     const roll = new AttackRoll(rollData);
@@ -730,7 +730,7 @@ export default class CrucibleActor extends Actor {
     // Apply talent hooks
     this.callActorHooks("prepareStandardCheck", rollData);
     this.callActorHooks("prepareSkillAttack", action, target, rollData);
-    target.callActorHooks("defendSkillAttack", action, this, rollData); // TODO migrate to "defendAttack"
+    target.callActorHooks("defendAttack", action, this, rollData);
 
     // Create and evaluate the skill attack roll
     const roll = new game.system.api.dice.AttackRoll(rollData);
@@ -793,7 +793,7 @@ export default class CrucibleActor extends Actor {
     // Call talent hooks
     this.callActorHooks("prepareStandardCheck", rollData);
     this.callActorHooks("prepareWeaponAttack", action, target, rollData);
-    target.callActorHooks("defendWeaponAttack", action, this, rollData); // TODO migrate to "defendAttack"
+    target.callActorHooks("defendAttack", action, this, rollData);
 
     // Create and evaluate the AttackRoll instance
     const roll = new AttackRoll(rollData);

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -119,6 +119,17 @@ HOOKS.lesserregenerati = {
 
 /* -------------------------------------------- */
 
+HOOKS.planneddefense00 = {
+  defendAttack(item, action, origin, rollData) {
+    if ( !["spell", "strike"].some(tag => action.tags.has(tag)) ) return;
+    const ac = this.combatant;
+    const oc = origin.combatant;
+    if ( ac?.initiative > oc?.initiative ) rollData.banes.plannedDefense = {label: item.name, number: 1};
+  }
+}
+
+/* -------------------------------------------- */
+
 HOOKS.preparedness0000 = {
   preActivateAction(item, action, _targets) {
     if ( action.id !== "equipWeapon" ) return;
@@ -162,14 +173,24 @@ HOOKS.spellblade000000 = {
 /* -------------------------------------------- */
 
 HOOKS.spellmute0000000 = {
-  defendSpellAttack(item, spell, origin, rollData) {
-    rollData.banes.spellmute = {label: item.name, number: 2};
+  defendAttack(item, action, origin, rollData) {
+    if ( action.tags.has("spell") ) rollData.banes.spellmute = {label: item.name, number: 2};
   },
-  prepareActions(actions) {
+  prepareActions(_item, actions) {
     for ( const [id, action] of Object.entries(actions) ) {
       if ( action.tags.has("spell") ) delete actions[id];
     }
     delete actions.cast;
+  }
+}
+
+/* -------------------------------------------- */
+
+HOOKS.stilllake0000000 = {
+  defendAttack(item, action, _origin, rollData) {
+    if ( !action.tags.has("skill") ) return;
+    if ( CONFIG.SYSTEM.SKILLS[action.usage.skillId].category !== "soc" ) return;
+    rollData.banes.stillLake = {label: item.name, number: 2};
   }
 }
 
@@ -181,6 +202,16 @@ HOOKS.stronggrip000000 = {
     if ( weapons.twoHanded ) {
       weapons.freeHands += 1;
       weapons.spellHands += 1;
+    }
+  }
+}
+
+/* -------------------------------------------- */
+
+HOOKS.testudo000000000 = {
+  defendAttack(item, action, _origin, rollData) {
+    if ( action.tags.has("strike") && this.statuses.has("guarded") && this.equipment.weapons.shield ) {
+      rollData.banes.testudo = {label: item.name, number: 1};
     }
   }
 }


### PR DESCRIPTION
Closes #345 
As part of this, I moved the hooks of the affected talents which weren't currently in `hooks/talent.mjs` into there. Left the hooks on for Protective Mirage, though. Re-exported lv-6 Duurath because he had the old Testudo. 
Only one legacy hook remains in the pack data, and it's inside the playtest 1 adventure (it's the aforementioned Testudo on Duurath) so I figured not worth touching currently, especially since it won't cause any issues in functionality. 