### PR TITLE
[#338] Restrict non-stackable physical item quantity to 0 or 1

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -96,7 +96,6 @@ export default class CrucibleItem extends foundry.documents.Item {
     if ( isStackable ) return;
     const currQuantity = data.system?.quantity ?? this.system.quantity;
     foundry.utils.setProperty(data, "system.quantity", Math.clamp(currQuantity, 0, 1));
-    this.sheet?.render();
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Closes #338 
Had to throw in the render, otherwise an invalid quantity-only change wouldn't update to show the proper clamped value.