### PR TITLE
[#375] Actually set fallback compendium pack sources correctly

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -467,7 +467,7 @@ Hooks.once("setup", function() {
   // Update compendium sources from settings
   const currSources = Object.entries(game.settings.get("crucible", "compendiumSources")).reduce((acc, [type, sources]) => {
     acc[type] = sources.filter(p => game.packs.has(p));
-    if ( !acc[type].size ) acc[type] = crucible.CONST.COMPENDIUM_PACKS[type];
+    if ( !acc[type].size ) acc[type] = [crucible.CONST.COMPENDIUM_PACKS[type]];
     return acc;
   }, {});
   crucible.CONFIG.packs = currSources;


### PR DESCRIPTION
Partially addresses #375
Might be nice to clean/validate on the settings-side rather than _only_ when setting `crucible.CONFIG.packs`. Though that might be core territory for `ArrayField`s/`SetField`s.