### PR TITLE
[#403] Change `canUse` on spell tag to `preActivate`, ensuring the "Use Spell" dialog can always be opened, but invalid usage is still blocked

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -441,7 +441,6 @@ export const TAGS = {
       this.usage.actorStatus.hasCast = true;
       this.usage.isAttack = true;
       this.usage.isRanged = (this.gesture.target.type !== "self") && (this.range.maximum > 1);
-      this.usage.scaling = [this.rune.scaling, this.gesture.scaling];
     },
     preActivate() {
       if ( this.cost.hands > this.actor.equipment.weapons.spellHands ) {


### PR DESCRIPTION
Closes #403 
I think it could be neat to have certain activation tags have the `unmet` class in the case that their prerequisites aren't met. Should only really come up specifically when dealing with spells, since the choices made can vary both action, focus, and hands costs, but would be nice if you could see, for instance, "2 hands" lit up red in the config menu instead of just being blocked upon casting. But that feels like another issue.