### PR TITLE
[#440] Make `hasTargets` false if summon-type action and already placed template

### DIFF
--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -95,7 +95,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
       hasActionTags: !tags.action.empty,
       hasContextTags: !tags.context.empty,
       hasDice: this.action.usage.hasDice ?? false,
-      hasTargets: !["self", "none"].includes(this.action.target.type),
+      hasTargets: this.#requiresTemplate || !["self", "none", "summon"].includes(this.action.target.type),
       requiresTemplate: this.#requiresTemplate,
       weaponChoice: this.#prepareWeaponChoice(),
       targets: this.#prepareTargets()


### PR DESCRIPTION
Closes #440 
`hasTargets` must be true prior to the template being placed (to see the "Place Template" button), but should be false afterwards, since otherwise it'll erroneously read a red "No Targets."