### PR TITLE
Only show "no unlocked iconic slots" text when actually true

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -610,7 +610,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       iconicSpells: {
         label: game.i18n.format(iconicSpells.label, {slots: iconicSlots}),
         known: iconicSpells.items,
-        emptyLabel: game.i18n.localize("ACTOR.SECTIONS.ICONIC.none")
+        emptyLabel: iconicSlots ? "" : game.i18n.localize("ACTOR.SECTIONS.ICONIC.none")
       }
     }
 


### PR DESCRIPTION
Before:
<img width="657" height="105" alt="image" src="https://github.com/user-attachments/assets/5c49d8f4-f11d-43b9-80b2-597616ca158f" />

After:
<img width="668" height="76" alt="image" src="https://github.com/user-attachments/assets/f541a7c1-0f37-46b9-96c4-8b31b25ca992" />
