### PR TITLE
[#435] Allow focus spending on `strike`-tagged actions when enraged

### DIFF
--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1271,8 +1271,9 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     // Cannot spend focus
     if ( this.cost.focus ) {
       let focusBlock = "";
+      const allowEnragedFocus = this.actor.talentIds.has("iramancer0000000") || this.tags.has("strike");
       if ( statuses.has("broken") ) focusBlock = "broken";
-      else if ( statuses.has("enraged") && !this.actor.talentIds.has("iramancer0000000") ) focusBlock = "enraged";
+      else if ( statuses.has("enraged") && !allowEnragedFocus ) focusBlock = "enraged";
       if ( focusBlock ) throw new Error(game.i18n.format("ACTION.WarningCannotSpendFocus", {
         name: this.actor.name,
         status: game.i18n.localize(`ACTIVE_EFFECT.STATUSES.${focusBlock.titleCase()}`)


### PR DESCRIPTION
Closes #435 
Went with the more generic solution of "disallow focus expenditure on non-strike actions." This means in addition to Berserk Strike, someone enraged can use something like Executioner's Strike, Ruthless Momentum, or Reactive Strike. Feels satisfactory for the time being, I think. It does mean that one couldn't use, for instance, Intimidate, but I'm not sure there's an easy line to draw between what someone enraged can and can't expend focus to do (only strikes means no intimidate, only _disallowing_ spells means second wind is fine, which I think it shouldn't be).