### PR TITLE
Fixes the Cast Spell action to allow casting a spell when no lastSpell is present

### DIFF
--- a/module/models/spell-action.mjs
+++ b/module/models/spell-action.mjs
@@ -261,7 +261,7 @@ export default class CrucibleSpellAction extends CrucibleAction {
     // Cast New Spell
     const {runes, gestures} = actor.grimoire;
     const rune = runes.keys().next().value;
-    const gesture = gestures.keys().next().value;
+    const gesture = "touch";
     Object.assign(spellData, {
       rune,
       gesture,


### PR DESCRIPTION
Make it so that the spellcasting dialog can open for characters without a previously cast spell.

Closes #495 