### PR TITLE
[#527] Ensure window minimization is `await`ed before allowing template placement

### DIFF
--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -247,7 +247,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
         minimizedWindows.push(app);
       }
     }
-    await Promise.all(minimizedWindows.map(app => app.minimize()));
+    await Promise.allSettled(minimizedWindows.map(app => app.minimize()));
 
     // Store preview template data
     this.#targetTemplate = {


### PR DESCRIPTION
Closes #527. Root issue here may be an issue of calling `maximize` on the action use dialog while it's mid-`minimize`, but this solution feels appropriate regardless.