### PR TITLE
[#503] Fix granted talents in taxonomies/backgrounds/ancestries & taxonomy migration code

### DIFF
--- a/_source/ancestry/Giantkin_giantkin00000000.yml
+++ b/_source/ancestry/Giantkin_giantkin00000000.yml
@@ -20,16 +20,16 @@ system:
   stride: 10
   identifier: giantkin
   talents:
-    - Compendium.crucible.talent.Item.runeearth0000000
+    - Compendium.crucible.talent.Item.runeEarth0000000
   ui:
     color: '#acd7dd'
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.8.3
+  coreVersion: '13.351'
   createdTime: 1674942420030
-  modifiedTime: 1746803315619
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1767206160545
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/ancestry/Gnome_gnome00000000000.yml
+++ b/_source/ancestry/Gnome_gnome00000000000.yml
@@ -19,16 +19,16 @@ system:
   stride: 8
   identifier: gnome
   talents:
-    - Compendium.crucible.talent.Item.runelightning000
+    - Compendium.crucible.talent.Item.runeLightning000
   ui:
     color: '#afa2c3'
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.8.3
+  coreVersion: '13.351'
   createdTime: 1674942420027
-  modifiedTime: 1746803325486
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1767206195009
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/ancestry/Orcish_orcish0000000000.yml
+++ b/_source/ancestry/Orcish_orcish0000000000.yml
@@ -20,16 +20,16 @@ system:
   stride: 10
   identifier: orcish
   talents:
-    - Compendium.crucible.talent.Item.heavystrike00000
+    - Compendium.crucible.talent.Item.heavyWeaponTrain
   ui:
     color: '#c14425'
 _stats:
   systemId: crucible
-  systemVersion: 0.7.0-dev
-  coreVersion: '13.342'
+  systemVersion: 0.8.3
+  coreVersion: '13.351'
   createdTime: 1674942420029
-  modifiedTime: 1746803361519
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1767206559777
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/background/Physician_physician0000000.yml
+++ b/_source/background/Physician_physician0000000.yml
@@ -14,7 +14,7 @@ system:
     - science
   talents:
     - Compendium.crucible.talent.Item.talismanWeaponTr
-    - Compendium.crucible.talent.Item.runelife00000000
+    - Compendium.crucible.talent.Item.runeLife00000000
   identifier: physician
   ui:
     color: '#fe4d4d'
@@ -27,11 +27,11 @@ effects: []
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.7.8
-  coreVersion: '13.347'
+  systemVersion: 0.8.3
+  coreVersion: '13.351'
   createdTime: 1677350949941
-  modifiedTime: 1756083997933
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1767206235346
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/background/Scholar_scholar000000000.yml
+++ b/_source/background/Scholar_scholar000000000.yml
@@ -14,8 +14,8 @@ system:
     - arcana
     - science
   talents:
-    - Compendium.crucible.talent.Item.mechanicalTraini
-    - Compendium.crucible.talent.Item.runekinesis00000
+    - Compendium.crucible.talent.Item.mechanicalWeapon
+    - Compendium.crucible.talent.Item.runeKinesis00000
   identifier: scholar
   ui:
     color: '#7ad6d0'
@@ -26,11 +26,11 @@ system:
     - common
 _stats:
   systemId: crucible
-  systemVersion: 0.7.8
-  coreVersion: '13.347'
+  systemVersion: 0.8.3
+  coreVersion: '13.351'
   createdTime: 1674942420028
-  modifiedTime: 1756084001973
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1767206345025
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/background/Wanderer_wanderer00000000.yml
+++ b/_source/background/Wanderer_wanderer00000000.yml
@@ -16,7 +16,7 @@ system:
     - athletics
     - wilderness
   talents:
-    - Compendium.crucible.talent.Item.projectileTraini
+    - Compendium.crucible.talent.Item.projectileWeapon
     - Compendium.crucible.talent.Item.precisionshot000
   identifier: wanderer
   ui:
@@ -28,11 +28,11 @@ system:
     - common
 _stats:
   systemId: crucible
-  systemVersion: 0.7.8
-  coreVersion: '13.347'
+  systemVersion: 0.8.3
+  coreVersion: '13.351'
   createdTime: 1674942420012
-  modifiedTime: 1756084022044
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1767206660224
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/taxonomy/Earth_Elemental_earthElemental00.yml
+++ b/_source/taxonomy/Earth_Elemental_earthElemental00.yml
@@ -43,7 +43,7 @@ system:
     size: 4
     stride: 10
   talents:
-    - Compendium.crucible.talent.Item.runeearth0000000
+    - Compendium.crucible.talent.Item.runeEarth0000000
     - Compendium.crucible.adversary-talents.Item.acidAbsorption00
   identifier: earthElemental
 effects: []
@@ -54,11 +54,11 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.350'
+  coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.1
-  modifiedTime: 1763060075037
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  systemVersion: 0.8.3
+  modifiedTime: 1767205860892
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   exportSource: null
 _id: earthElemental00
 sort: 100000

--- a/_source/taxonomy/Fire_Elemental_fireElemental000.yml
+++ b/_source/taxonomy/Fire_Elemental_fireElemental000.yml
@@ -37,7 +37,7 @@ system:
     size: 4
     stride: 10
   talents:
-    - Compendium.crucible.talent.Item.runeflame0000000
+    - Compendium.crucible.talent.Item.runeFlame0000000
     - Compendium.crucible.adversary-talents.Item.fireAbsorption00
   identifier: fireElemental
 effects: []
@@ -48,11 +48,11 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.350'
+  coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.1
-  modifiedTime: 1763060080165
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  systemVersion: 0.8.3
+  modifiedTime: 1767205895594
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   exportSource: null
 _id: fireElemental000
 sort: 200000

--- a/_source/taxonomy/Frost_Elemental_frostElemental00.yml
+++ b/_source/taxonomy/Frost_Elemental_frostElemental00.yml
@@ -37,7 +37,7 @@ system:
   talents:
     - Compendium.crucible.adversary-talents.Item.coldAbsorption00
     - Compendium.crucible.adversary-talents.Item.amorphous0000000
-    - Compendium.crucible.talent.Item.runefrost0000000
+    - Compendium.crucible.talent.Item.runeFrost0000000
     - Compendium.crucible.adversary-talents.Item.aqueousTransmiss
   identifier: frostElemental
 effects: []
@@ -48,11 +48,11 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.350'
+  coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.1
-  modifiedTime: 1763060084323
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  systemVersion: 0.8.3
+  modifiedTime: 1767205982867
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   exportSource: null
 _id: frostElemental00
 sort: 400000

--- a/_source/taxonomy/Storm_Elemental_stormElemental00.yml
+++ b/_source/taxonomy/Storm_Elemental_stormElemental00.yml
@@ -43,7 +43,7 @@ system:
     size: 4
     stride: 10
   talents:
-    - Compendium.crucible.talent.Item.runelightning000
+    - Compendium.crucible.talent.Item.runeLightning000
     - Compendium.crucible.adversary-talents.Item.electricityAbsor
   identifier: stormElemental
 effects: []
@@ -54,11 +54,11 @@ flags: {}
 _stats:
   compendiumSource: null
   duplicateSource: null
-  coreVersion: '13.350'
+  coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.1
-  modifiedTime: 1763060088080
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  systemVersion: 0.8.3
+  modifiedTime: 1767206038425
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   exportSource: null
 _id: stormElemental00
 sort: 300000

--- a/module/const/talents.mjs
+++ b/module/const/talents.mjs
@@ -156,5 +156,7 @@ export const TALENT_ID_MIGRATIONS = {
   wrestler00000000: "Compendium.crucible.talent.Item.unarmedCombatTra",
   shieldBash000000: "Compendium.crucible.talent.Item.shieldCombatTrai",
   lunge00000000000: "Compendium.crucible.talent.Item.lightWeaponTrain",
-  rapidreload00000: "Compendium.crucible.talent.Item.mechanicalWeapon"
+  rapidreload00000: "Compendium.crucible.talent.Item.mechanicalWeapon",
+  mechanicalTraini: "Compendium.crucible.talent.Item.mechanicalWeapon",
+  projectileTraini: "Compendium.crucible.talent.Item.projectileWeapon"
 }

--- a/module/models/item-taxonomy.mjs
+++ b/module/models/item-taxonomy.mjs
@@ -93,12 +93,14 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
     source = super.migrateData(source);
 
     const abilities = source.abilities;
-    const sum = Object.values(abilities).reduce((t, n) => t + n, 0);
-    /** @deprecated since 0.7.3 */
-    if ( sum === 18 ) source.abilities = Object.keys(SYSTEM.ABILITIES).reduce((obj, a) => {
-      obj[a] = 2;
-      return obj;
-    }, {});
+    if ( abilities ) {
+      const sum = Object.values(abilities).reduce((t, n) => t + n, 0);
+      /** @deprecated since 0.7.3 */
+      if ( sum === 18 ) source.abilities = Object.keys(SYSTEM.ABILITIES).reduce((obj, a) => {
+        obj[a] = 2;
+        return obj;
+      }, {});
+    }
 
     /** @deprecated since 0.7.3 */
     if ( source.size && !source.movement?.size ) {
@@ -116,7 +118,7 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
 
     /** @deprecated since 0.8.1 */
     for ( const damageType of Object.values(SYSTEM.DAMAGE_TYPES) ) {
-      if ( Number.isNumeric(source.resistances[damageType.id]) ) {
+      if ( Number.isNumeric(source.resistances?.[damageType.id]) ) {
         source.resistances[damageType.id] = {
           value: source.resistances[damageType.id],
           immune: false


### PR DESCRIPTION
Closes #503 
Change to taxonomy migration code is just for partial updates.
Of note: Urchin, Soldier, and Merchant each initially granted 2 talents, but now the second of each (Lunge for Urchin & Merchant, Heavy Strike for Soldier) is granted as part of the first (Light Weapon Training, Heavy Weapon Training) - those'll need another Talent to grant instead.