### PR TITLE
[#524] Tighten up reversal logic for protective mirage, fix Protective Mirage & Healer effect result

### DIFF
--- a/_source/spell/Protective_Mirage_protectiveMirage.yml
+++ b/_source/spell/Protective_Mirage_protectiveMirage.yml
@@ -14,6 +14,7 @@ system:
         focus: 2
         heroism: 0
         weapon: false
+        hands: 0
       range:
         minimum: null
         maximum: null
@@ -22,19 +23,24 @@ system:
         type: self
         number: 1
         scope: 1
+        self: false
       effects:
         - name: Mirage
           scope: 1
+          result:
+            type: any
+            all: false
           statuses: []
           duration:
             turns: 10
+            rounds: null
+          system:
+            dot: []
+            maintenance: null
+            regions: []
+            summons: []
       tags:
-        - iconicSpell
-        - iconicSpell
-        - iconicSpell
-        - iconicSpell
-        - iconicSpell
-        - iconicSpell
+        - spell
         - iconicSpell
       actionHooks: []
       name: Protective Mirage
@@ -63,10 +69,10 @@ _stats:
   duplicateSource: null
   coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.2
+  systemVersion: 0.8.3
   createdTime: 1727204769939
-  modifiedTime: 1765403195009
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1767382089803
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   exportSource: null
 _id: protectiveMirage
 sort: 600000

--- a/_source/talent/Healer_healer0000000000.yml
+++ b/_source/talent/Healer_healer0000000000.yml
@@ -29,14 +29,19 @@ system:
         self: false
       effects:
         - name: Font of Life
-          scope: '2'
+          scope: 2
           result:
-            type: success
-            all: true
+            type: any
+            all: false
           statuses: []
           duration:
             turns: 3
             rounds: null
+          system:
+            dot: []
+            maintenance: null
+            regions: []
+            summons: []
       tags:
         - healing
         - health
@@ -68,7 +73,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.8.3
   createdTime: 1727311608001
-  modifiedTime: 1767195519339
+  modifiedTime: 1767382048845
   lastModifiedBy: ifaQA7jTJsr3UWFE
   exportSource: null
 folder: fOYHlZJEWUukD7yr

--- a/module/hooks/spell.mjs
+++ b/module/hooks/spell.mjs
@@ -25,7 +25,7 @@ HOOKS.protectiveMirage = {
 
     // Delete exhausted effect
     if ( duplicates <= 0 ) {
-      outcome.effects.push({_id: effect.id, _delete: true});
+      outcome.effects.push({_id: effect.id, _action: "delete"});
       return;
     }
 
@@ -33,7 +33,8 @@ HOOKS.protectiveMirage = {
     outcome.effects.push({
       _id: effect.id,
       name: `Mirage (${duplicates})`,
-      "flags.crucible.duplicates": duplicates
+      "flags.crucible.duplicates": duplicates,
+      _action: "update"
     });
   }
 }


### PR DESCRIPTION
Closes #524 
Going back and forth between:
```js
for ( const effectData of outcome.effects ) {
  const existing = this.effects.get(effectData._id);
  const forceDelete = effectData._action === "delete";
  const forceUpdate = effectData._action === "update";
  const shouldUpdate = existing && (reverse ? forceUpdate : !forceDelete);
  const shouldDelete = existing && (reverse ? !forceUpdate : forceDelete);
  if ( shouldUpdate ) toUpdate.push(effectData);
  else if ( shouldDelete ) toDelete.push(effectData._id);
  else if ( !reverse ) toCreate.push(effectData);
}
```
and
```js
for ( const effectData of outcome.effects ) {
  const existing = this.effects.get(effectData._id);
  const forceDelete = effectData._action === "delete";
  const forceUpdate = effectData._action === "update";
  if ( reverse ) {
    if ( existing && forceUpdate ) toUpdate.push(effectData);
    else if ( existing ) toDelete.push(effectData._id);
  } else {
    if ( existing && forceDelete ) toDelete.push(effectData._id);
    else if ( existing ) toUpdate.push(effectData);
    else toCreate.push(effectData);
  }
}
```
I'm not sure which is cleaner/easier to read.