### PR TITLE
Ensure weapon-cost spells don't double-report action cost

### DIFF
--- a/module/hooks/spellcraft.mjs
+++ b/module/hooks/spellcraft.mjs
@@ -153,6 +153,7 @@ HOOKS.strike = {
     const mh = this.actor.equipment.weapons.mainhand;
     this.scaling = mh.config.category.scaling.split(".");
     this.damage.base = mh.system.damage.base;
+    this.usage.strikes = [mh];
   }
 }
 

--- a/module/models/spell-action.mjs
+++ b/module/models/spell-action.mjs
@@ -204,7 +204,6 @@ export default class CrucibleSpellAction extends CrucibleAction {
     if ( this.cost.weapon ) {
       const w = this.actor.equipment.weapons.mainhand;
       this.cost.action += (w?.system.actionCost || 0);
-      this.usage.strikes = [w];
     }
 
     // Zero cost for un-composed spells


### PR DESCRIPTION
Typically we don't see `W` in the action use dialog because `W`-cost actions always have a `strike` tag of their own somewhere up the line (and the `strike` tag takes care of setting `usage.strikes`, which is checked in `CrucibleAction#getTags`). Strike-gestured spells are the exception, so specifically adding that to usage when necessary will ensure we show, for instance, `3` instead of `W+3`.