### PR TITLE
Add leveled talents to schema for all actor details items

### DIFF
--- a/module/applications/sheets/item-archetype-sheet.mjs
+++ b/module/applications/sheets/item-archetype-sheet.mjs
@@ -121,19 +121,6 @@ export default class CrucibleArchetypeItemSheet extends CrucibleBackgroundItemSh
 
   /* -------------------------------------------- */
 
-  // TODO 541
-  /** @override */
-  async _prepareTalents() {
-    const talents = this.document.system.talents;
-    const promises = talents.map(async ({item: uuid}) => {
-      const talent = (await fromUuid(uuid)) ?? await new Item.implementation({type: "talent", name: "INVALID"});
-      return talent.renderInline({showRemove: this.isEditable});
-    });
-    return Promise.all(promises);
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritdoc */
   async _onRender(context, options) {
     await super._onRender(context, options);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1765,9 +1765,8 @@ export default class CrucibleActor extends Actor {
     // Remove existing talents
     const existing = this.system.details[type];
     let deleteItemIds = new Set();
-    for ( const uuid of (existing?.talents || []) ) {
-      // TODO 541
-      const talentId = foundry.utils.parseUuid(uuid.item ?? uuid)?.documentId;
+    for ( const {item: uuid} of (existing?.talents || []) ) {
+      const talentId = foundry.utils.parseUuid(uuid)?.documentId;
       if ( this.items.has(talentId) ) deleteItemIds.add(talentId);
     }
 
@@ -1812,9 +1811,8 @@ export default class CrucibleActor extends Actor {
         ...(detail.talents || []),
         ...(skillTalents ? (detail.skills || []).map(skillId => SYSTEM.SKILLS[skillId]?.talents[1]) : [])
       ];
-      for ( const uuid of talentUuids ) {
-        // TODO 541
-        const talent = await fromUuid(uuid.item ?? uuid);
+      for ( const {item: uuid, level} of talentUuids ) {
+        const talent = await fromUuid(uuid);
         if ( !talent ) continue;
         if ( this.items.has(talent.id) ) deleteItemIds.delete(talent.id); // Talent already owned
         else updateItems.push(this._cleanItemData(talent));               // Add new Talent

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -347,9 +347,8 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     const maybePermanentTalentIds = new Set();
     for ( const s of permanentTalentSources ) {
       if ( s?.talents ) {
-        for ( const uuid of s.talents ) {
-          // TODO 541
-          const {documentId} = foundry.utils.parseUuid(uuid.item ?? uuid);
+        for ( const {item: uuid, level} of s.talents ) {
+          const {documentId} = foundry.utils.parseUuid(uuid);
           maybePermanentTalentIds.add(documentId);
         }
       }

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -300,6 +300,7 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
   static migrateData(source) {
     source = super.migrateData(source);
     if ( source.details?.ancestry ) CrucibleAncestryItem.migrateData(source.details.ancestry);
+    if ( source.details?.background ) CrucibleBackgroundItem.migrateData(source.details.background);
     return source;
   }
 }

--- a/module/models/item-ancestry.mjs
+++ b/module/models/item-ancestry.mjs
@@ -30,7 +30,10 @@ export default class CrucibleAncestryItem extends foundry.abstract.TypeDataModel
         resistance: new fields.StringField({...reqChoice, choices: SYSTEM.DAMAGE_TYPES}),
         vulnerability: new fields.StringField({...reqChoice, choices: SYSTEM.DAMAGE_TYPES})
       }, {validate: CrucibleAncestryItem.#validateResistances}),
-      talents: new fields.SetField(new fields.DocumentUUIDField({type: "Item"})),
+      talents: new fields.ArrayField(new fields.SchemaField({
+        item: new fields.DocumentUUIDField({type: "Item"}),
+        level: new fields.NumberField({required: true, nullable: true, integer: true, initial: null})
+      })),
       ui: new fields.SchemaField({
         color: new fields.ColorField()
       })
@@ -142,6 +145,12 @@ export default class CrucibleAncestryItem extends foundry.abstract.TypeDataModel
   /** @inheritDoc */
   static migrateData(source) {
     source = super.migrateData(source);
+
+    if ( source.talents?.length ) {
+      if ( typeof source.talents[0] === "string") {
+        source.talents = source.talents.map(t => ({item: t, level: null}));
+      }
+    }
 
     /** @deprecated since 0.7.0 until 0.8.0 */
     const {primary, secondary, resistance, vulnerability, size, stride} = source;

--- a/module/models/item-background.mjs
+++ b/module/models/item-background.mjs
@@ -18,7 +18,10 @@ export default class CrucibleBackgroundItem extends foundry.abstract.TypeDataMod
       knowledge: new fields.SetField(new fields.StringField({choices: () => crucible.CONFIG.knowledge})),
       languages: new fields.SetField(new fields.StringField()),
       skills: new fields.SetField(new fields.StringField({required: true, choices: SYSTEM.SKILLS})),
-      talents: new fields.SetField(new fields.DocumentUUIDField({type: "Item"})),
+      talents: new fields.ArrayField(new fields.SchemaField({
+        item: new fields.DocumentUUIDField({type: "Item"}),
+        level: new fields.NumberField({required: true, nullable: true, integer: true, initial: null})
+      })),
       ui: new fields.SchemaField({
         color: new fields.ColorField()
       })
@@ -27,4 +30,21 @@ export default class CrucibleBackgroundItem extends foundry.abstract.TypeDataMod
 
   /** @override */
   static LOCALIZATION_PREFIXES = ["BACKGROUND"];
+
+  /* -------------------------------------------- */
+  /*        Deprecations and Compatibility        */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static migrateData(source) {
+    source = super.migrateData(source);
+
+    if ( source.talents?.length ) {
+      if ( typeof source.talents[0] === "string") {
+        source.talents = source.talents.map(t => ({item: t, level: null}));
+      }
+    }
+
+    return source;
+  }
 }

--- a/module/models/item-taxonomy.mjs
+++ b/module/models/item-taxonomy.mjs
@@ -33,7 +33,10 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
         });
         return obj;
       }, {}), {validate: CrucibleTaxonomyItem.#validateResistances}),
-      talents: new fields.SetField(new fields.DocumentUUIDField({type: "Item"})),
+      talents: new fields.ArrayField(new fields.SchemaField({
+        item: new fields.DocumentUUIDField({type: "Item"}),
+        level: new fields.NumberField({required: true, nullable: true, integer: true, initial: null})
+      })),
       characteristics: new fields.SchemaField({
         equipment: new fields.BooleanField(),
         spells: new fields.BooleanField()
@@ -91,6 +94,12 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
   /** @inheritDoc */
   static migrateData(source) {
     source = super.migrateData(source);
+
+    if ( source.talents?.length ) {
+      if ( typeof source.talents[0] === "string") {
+        source.talents = source.talents.map(t => ({item: t, level: null}));
+      }
+    }
 
     const abilities = source.abilities;
     if ( abilities ) {


### PR DESCRIPTION
All actor details items (Ancestry, Archetype, Background, Taxonomy) now have the capacity to store talents alongside what level they should be granted at. Currently, level isn't taken into consideration at all.
Next steps:
- UI treatment for specifying level
- Logic for granting only level-appropriate talents, re-applying details items on advancement