### PR TITLE
[#476] Add `acquireTargets` hook for marking targets invalid in dialog

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -376,11 +376,9 @@ export const TAGS = {
     label: "ACTION.TagFlanking",
     tooltip: "ACTION.TagFlankingTooltip",
     category: "context",
-    preActivate(targets) {
-      for ( const {actor} of targets ) {
-        if ( !actor.statuses.has("flanked") ) {
-          throw new Error(`${this.name} requires a flanked target. Target "${actor.name}" is not flanked.`);
-        }
+    acquireTargets(targets) {
+      for ( const target of targets ) {
+        if ( !target.actor.statuses.has("flanked") ) target.error ??= `${this.name} requires a flanked target. Target "${target.actor.name}" is not flanked.`;
       }
     },
   },

--- a/module/const/system.mjs
+++ b/module/const/system.mjs
@@ -110,9 +110,13 @@ export const ACTION_HOOKS = Object.freeze({
     argNames: [],
     argLabels: []
   },
+  acquireTargets: {
+    argNames: ["targets"],
+    argLabels: ["targets: ActionUseTarget[]"]
+  },
   preActivate: {
     argNames: ["targets"],
-    argLabels: ["targets: ActionTarget[]"],
+    argLabels: ["targets: ActionUseTarget[]"],
     async: true
   },
   roll: {

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -693,9 +693,9 @@ HOOKS.revive = {
     this.scaling = Array.from(runeScaling.union(gestureScaling));
     this.usage.bonuses.ability = this.actor.getAbilityBonus(this.scaling);
   },
-  preActivate(targets) {
-    if ( (targets.length !== 1) || !targets[0].actor?.statuses.has("dead") ) {
-      throw new Error(`${this.name} requires a Dead target.`);
+  acquireTargets(targets) {
+    for ( const target of targets ) {
+      if ( !target.actor.system.isDead ) target.error ??= `${this.name} requires a Dead target.`;
     }
   },
   async roll(outcome) {
@@ -751,9 +751,9 @@ HOOKS.spellband = {
 /* -------------------------------------------- */
 
 HOOKS.thrash = {
-  preActivate(targets) {
-    if ( targets.some(target => !target.actor?.statuses.has("restrained")) ) {
-      throw new Error("You can only perform Thrash against a target that you have Restrained.");
+  acquireTargets(targets) {
+    for ( const target of targets ) {
+      if ( !target.actor.statuses.has("restrained") ) target.error ??= `You can only perform ${this.name} against a target that you have Restrained.`;
     }
   }
 }
@@ -792,10 +792,10 @@ HOOKS.unshakeablePoise = {
 /* -------------------------------------------- */
 
 HOOKS.uppercut = {
-  preActivate(targets) {
+  acquireTargets(targets) {
     const lastAction = this.actor.lastConfirmedAction;
-    if ( !lastAction?.outcomes.has(targets[0].actor) ) {
-      throw new Error(`${this.name} must attack the same target as the Strike which it follows.`);
+    for ( const target of targets ) {
+      if ( !lastAction?.outcomes.has(target.actor) ) target.error ??= `${this.name} must attack the same target as the Strike which it follows.`;
     }
   }
 }
@@ -832,10 +832,10 @@ HOOKS.vampiricBite = {
 /* -------------------------------------------- */
 
 HOOKS.wildStrike = {
-  preActivate(targets) {
+  acquireTargets(targets) {
     const lastAction = this.actor.lastConfirmedAction;
-    if ( !lastAction?.outcomes.has(targets[0].actor) ) {
-      throw new Error(`${this.name} must attack the same target as the Strike which it follows.`);
+    for ( const target of targets ) {
+      if ( !lastAction?.outcomes.has(target.actor) ) target.error ??= `${this.name} must attack the same target as the Strike which it follows.`;
     }
     // TODO somehow require this to use a different weapon than the prior confirmed strike
   }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -850,6 +850,11 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       }
     }
 
+    // Call acquireTargets action hook
+    for ( const test of this._tests() ) {
+      if ( test.acquireTargets instanceof Function ) test.acquireTargets.call(this, targets);
+    }
+
     // Throw an error if any target had an error
     for ( const target of targets ) {
       if ( target.error && strict ) throw new Error(target.error);


### PR DESCRIPTION
Closes #476 

General intended use here is to iterate through `targets` and set each target's `error` as necessary. 
Since this is called inside `CrucibleAction#acquireTargets`, the first time (pre-use, during the dialog) `strict` is `false`, and therefore the errors are purely informative. If an error remains when the action is _actually_ used, since `strict` is `true`, it will block usage with a notification. This effectively lets up sub out certain `preActivate` hooks for `acquireTargets` hooks (with a bit of modification).
All talents which were previously using `preActivate` just to cancel in the case of invalid targets now use `acquireTargets` instead, which provides live feedback when targeting with the action use dialog up.
Can probably swap `CrucibleCounterspellAction#acquireTargets` to just use a hook on counterspell now, but will leave that be for now since I'm already touching that code in another PR.