### PR TITLE
[#580] Add `prepareAbilities` actor hook

### DIFF
--- a/module/const/actor.mjs
+++ b/module/const/actor.mjs
@@ -294,6 +294,10 @@ export const HOOKS = Object.freeze({
   },
 
   // Data Preparation
+  prepareAbilities: {
+    group: "TALENT.HOOKS.GroupPreparation",
+    argNames: ["abilities"]
+  },
   prepareActions: {
     group: "TALENT.HOOKS.GroupPreparation",
     argNames: ["actions"]

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -251,7 +251,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
   prepareBaseData() {
     this.#clear();
     this._prepareDetails();
-    this._prepareAbilities();
+    this._prepareBaseAbilities();
     this._prepareBaseMovement();
   }
 
@@ -300,10 +300,10 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Prepare ability scores for all Actor subtypes.
+   * Prepare base ability scores for all Actor subtypes.
    * @protected
    */
-  _prepareAbilities() {}
+  _prepareBaseAbilities() {}
 
   /* -------------------------------------------- */
   /*  Embedded Document Preparation               */
@@ -745,6 +745,10 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
    */
   prepareDerivedData() {
 
+    // Abilities
+    this.parent.callActorHooks("prepareAbilities", this.abilities);
+    this._prepareAbilities();
+
     // Movement and Size
     this._prepareMovement();
     this.parent.callActorHooks("prepareMovement", this.movement);
@@ -906,6 +910,13 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
   #prepareTotalResistances() {
     for ( const r of Object.values(this.resistances) ) r.total = r.immune ? Infinity : (r.base + r.bonus);
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Preparation of derived abilities for all Actor subtypes.
+   */
+  _prepareAbilities() {}
 
   /* -------------------------------------------- */
 

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -163,10 +163,10 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
   /* -------------------------------------------- */
 
   /**
-   * Prepare abilities data for the Hero subtype specifically.
+   * Prepare base abilities data for the Hero subtype specifically.
    * @override
    */
-  _prepareAbilities() {
+  _prepareBaseAbilities() {
     const points = this.points.ability;
     const {primary, secondary} = this.details.ancestry.abilities;
 
@@ -180,7 +180,7 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
       ability.initial = 1;
       if ( a === primary ) ability.initial = SYSTEM.ANCESTRIES.primaryAbilityStart;
       else if ( a === secondary ) ability.initial = SYSTEM.ANCESTRIES.secondaryAbilityStart;
-      ability.value = Math.clamp(ability.initial + ability.base + ability.increases + ability.bonus, 0, 12);
+      ability.value = ability.initial + ability.base + ability.increases;
 
       // Track points spent
       abilityPointsBought += ability.base;
@@ -226,6 +226,16 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
       for ( const item of items[type] ) {
         this.capacity.value += (item.system.weight * item.system.quantity);
       }
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _prepareAbilities() {
+    for ( let a in SYSTEM.ABILITIES ) {
+      const ability = this.abilities[a];
+      ability.value = Math.clamp(ability.value + ability.bonus, 0, 12);
     }
   }
 


### PR DESCRIPTION
Closes #580 
Nothing changes for Adversary actors, since we never consider any `bonus` for abilities to them. Can change that, if desired. For Hero actors:
`prepareBaseData` now calls `_prepareBaseAbilities`, which is the same as it was before but doesn't clamp `ability.value` and doesn't include `ability.bonus`
`prepareDerivedData` now calls the `prepareAbilities` actor hook, then `_prepareAbilities`, which adds `ability.bonus` to each `ability.value` and clamps it between 0 and 12.
This means one can now provide bonuses to ability scores for Hero actors by either:
- Targeting `system.abilities.[ability].bonus` ( or `.value`, as before) via AE
- Modifying `abilities.[ability].bonus` or `.value` in the `prepareAbilities` hook.