### PR TITLE
Ensure self-targeting non-roll actions still apply effects

### DIFF
--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1188,7 +1188,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       case "successCritical":
       case "failure":
       case "failureCritical":
-        if ( isSelfScope && !hasRolls ) {
+        if ( isSelfScope && !outcome.isTarget && !hasRolls ) {
           return this.outcomes.values().filter(o => !o.self).some(o => checkOutcome(o));
         }
         return checkOutcome(outcome);


### PR DESCRIPTION
Something like the Defend action would previously not have applied the effect, since it has no roll and is self-scoped.
The other way to go about this is to check whether there _are_ any non-self outcomes, and if not simply check the sole outcome anyway. But I think it's a fair assumption to make that if self is a target, even without rolls, they should be treated just as any other target (scope allowing).