### PR TITLE
Fully clear `_state` when restarting creation, store name separately on restart for use during initialization

### DIFF
--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -142,7 +142,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
    * The Actor's name, stored only when restarting character creation
    * @type {string|null}
    */
-  #characterName = null;
+  #characterName = this._clone.name;
 
   /* -------------------------------------------- */
 
@@ -191,7 +191,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
    * @protected
    */
   async _initializeState() {
-    this._state.name = this.#characterName || this._clone.name;
+    this._state.name = this.#characterName;
     this.#characterName = null;
     this.#complete = false;
     const promises = [];


### PR DESCRIPTION
`HeroCreationSheet##characterName` is `null` by default. It's set to whatever `this._state.name` is when reset, and back to `null` after being fetched for state initialization. If it's _not_ null, `this._state.name` isn't set during `_configureRenderOptions`, that way we don't follow up a refresh with a nonempty `_state`.