### PR TITLE
Fix bug in `bodyBlock` hook

### DIFF
--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -122,7 +122,7 @@ HOOKS.bodyBlock = {
   canUse() {
     const targetAction = ChatMessage.implementation.getLastAction();
     for ( const outcome of targetAction.outcomes.values() ) {
-      if ( outcome.target.uuid !== actor.uuid ) continue;
+      if ( outcome.target.uuid !== this.actor.uuid ) continue;
       if ( !targetAction.tags.has("melee") ) {
         throw new Error("You may only use Body Block against an incoming melee attack.");
       }


### PR DESCRIPTION
Wonder if we should also handle the confirmation bit of this similarly to counterspell. Only difference would be that instead of just marking it negated, we might want to update the outcome retroactively to "blocked," which would be a more involved process.