### PR TITLE
[#629] Update Backgrounds & Archetypes with valid talents

### DIFF
--- a/_source/archetype/Archer_archer0000000000.yml
+++ b/_source/archetype/Archer_archer0000000000.yml
@@ -12,9 +12,12 @@ system:
     toughness: 2
     dexterity: 4
   talents:
-    - Compendium.crucible.talent.Item.precisionshot000
-    - Compendium.crucible.talent.Item.evasiveshot00000
-    - Compendium.crucible.talent.Item.projectileTraini
+    - item: Compendium.crucible.talent.Item.precisionshot000
+      level: null
+    - item: Compendium.crucible.talent.Item.evasiveshot00000
+      level: null
+    - item: Compendium.crucible.talent.Item.projectileWeapon
+      level: null
   identifier: archer
 effects: []
 folder: 6Up7ddrphLept3RW
@@ -25,11 +28,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.8.7
   coreVersion: '13.351'
   createdTime: 1685738036284
-  modifiedTime: 1767927161067
-  lastModifiedBy: QPs9IwGEu5DxD700
+  modifiedTime: 1770233960482
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/archetype/Berserker_berserker0000000.yml
+++ b/_source/archetype/Berserker_berserker0000000.yml
@@ -11,10 +11,12 @@ system:
     toughness: 4
     dexterity: 2
   talents:
-    - Compendium.crucible.talent.Item.heavystrike00000
-    - Compendium.crucible.talent.Item.thickskin0000000
-    - Compendium.crucible.talent.Item.berserker0000000
-    - Compendium.crucible.talent.Item.heavyWeaponTrain
+    - item: Compendium.crucible.talent.Item.thickskin0000000
+      level: null
+    - item: Compendium.crucible.talent.Item.berserker0000000
+      level: null
+    - item: Compendium.crucible.talent.Item.heavyWeaponTrain
+      level: null
   identifier: berserker
 effects: []
 folder: 6Up7ddrphLept3RW
@@ -25,11 +27,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.8.7
   coreVersion: '13.351'
   createdTime: 1684888350310
-  modifiedTime: 1767927161067
-  lastModifiedBy: QPs9IwGEu5DxD700
+  modifiedTime: 1770235978192
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/archetype/Grappler_grappler00000000.yml
+++ b/_source/archetype/Grappler_grappler00000000.yml
@@ -14,11 +14,14 @@ system:
     toughness: 4
     dexterity: 1
   talents:
-    - Compendium.crucible.talent.Item.powerfulphysique
-    - Compendium.crucible.talent.Item.wrestler00000000
-    - Compendium.crucible.talent.Item.legsweep00000000
-    - Compendium.crucible.talent.Item.concussiveblows0
-    - Compendium.crucible.talent.Item.unarmedCombatTra
+    - item: Compendium.crucible.talent.Item.powerfulphysique
+      level: null
+    - item: Compendium.crucible.talent.Item.legsweep00000000
+      level: null
+    - item: Compendium.crucible.talent.Item.concussiveblows0
+      level: null
+    - item: Compendium.crucible.talent.Item.unarmedCombatTra
+      level: null
   identifier: grappler
   skills:
     - athletics
@@ -33,11 +36,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.8.7
   coreVersion: '13.351'
   createdTime: 1685831675455
-  modifiedTime: 1768428592108
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1770235990351
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/archetype/Protector_protector0000000.yml
+++ b/_source/archetype/Protector_protector0000000.yml
@@ -14,11 +14,14 @@ system:
     toughness: 3
     dexterity: 1
   talents:
-    - Compendium.crucible.talent.Item.shieldCombatTrai
-    - Compendium.crucible.talent.Item.bulwark000000000
-    - Compendium.crucible.talent.Item.intercept0000000
-    - Compendium.crucible.talent.Item.holdfast00000000
-    - Compendium.crucible.talent.Item.shieldBash000000
+    - item: Compendium.crucible.talent.Item.shieldCombatTrai
+      level: null
+    - item: Compendium.crucible.talent.Item.bulwark000000000
+      level: null
+    - item: Compendium.crucible.talent.Item.intercept0000000
+      level: null
+    - item: Compendium.crucible.talent.Item.holdfast00000000
+      level: null
   skills:
     - athletics
     - medicine
@@ -36,10 +39,10 @@ _stats:
   exportSource: null
   coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.8.7
   createdTime: 1765037016031
-  modifiedTime: 1767927161067
-  lastModifiedBy: QPs9IwGEu5DxD700
+  modifiedTime: 1770235999398
+  lastModifiedBy: ifaQA7jTJsr3UWFE
 _id: protector0000000
 sort: 400000
 _key: '!items!protector0000000'

--- a/_source/archetype/Scout_archetypeScout00.yml
+++ b/_source/archetype/Scout_archetypeScout00.yml
@@ -14,11 +14,16 @@ system:
     toughness: 3
     dexterity: 3
   talents:
-    - Compendium.crucible.talent.Item.preparedness0000
-    - Compendium.crucible.talent.Item.assessstrength00
-    - Compendium.crucible.talent.Item.precisionshot000
-    - Compendium.crucible.talent.Item.lunge00000000000
-    - Compendium.crucible.talent.Item.projectileTraini
+    - item: Compendium.crucible.talent.Item.preparedness0000
+      level: null
+    - item: Compendium.crucible.talent.Item.assessstrength00
+      level: null
+    - item: Compendium.crucible.talent.Item.precisionshot000
+      level: null
+    - item: Compendium.crucible.talent.Item.projectileWeapon
+      level: null
+    - item: Compendium.crucible.talent.Item.lightWeaponTrain
+      level: null
   skills:
     - athletics
     - awareness
@@ -37,9 +42,9 @@ _stats:
   exportSource: null
   coreVersion: '13.351'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.8.7
   createdTime: 1751388804848
-  modifiedTime: 1767927161067
-  lastModifiedBy: QPs9IwGEu5DxD700
+  modifiedTime: 1770236128679
+  lastModifiedBy: ifaQA7jTJsr3UWFE
 sort: 800000
 _key: '!items!archetypeScout00'

--- a/_source/background/Merchant_merchant00000000.yml
+++ b/_source/background/Merchant_merchant00000000.yml
@@ -14,8 +14,10 @@ system:
     - society
     - diplomacy
   talents:
-    - Compendium.crucible.talent.Item.lightWeaponTrain
-    - Compendium.crucible.talent.Item.lunge00000000000
+    - item: Compendium.crucible.talent.Item.lightWeaponTrain
+      level: null
+    - item: Compendium.crucible.talent.Item.preparedness0000
+      level: null
   identifier: merchant
   ui:
     color: '#dac372'
@@ -26,11 +28,11 @@ system:
     - common
 _stats:
   systemId: crucible
-  systemVersion: 0.8.6
-  coreVersion: '13.347'
+  systemVersion: 0.8.7
+  coreVersion: '13.351'
   createdTime: 1674942420028
-  modifiedTime: 1756083988003
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1770236077295
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/background/Soldier_soldier000000000.yml
+++ b/_source/background/Soldier_soldier000000000.yml
@@ -15,8 +15,10 @@ system:
     - athletics
     - intimidation
   talents:
-    - Compendium.crucible.talent.Item.heavyWeaponTrain
-    - Compendium.crucible.talent.Item.heavystrike00000
+    - item: Compendium.crucible.talent.Item.heavyWeaponTrain
+      level: null
+    - item: Compendium.crucible.talent.Item.truegrit00000000
+      level: null
   identifier: soldier
   ui:
     color: '#f08e4c'
@@ -27,11 +29,11 @@ system:
     - common
 _stats:
   systemId: crucible
-  systemVersion: 0.8.6
-  coreVersion: '13.347'
+  systemVersion: 0.8.7
+  coreVersion: '13.351'
   createdTime: 1674942420015
-  modifiedTime: 1756084010605
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1770236069607
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/background/Urchin_urchin0000000000.yml
+++ b/_source/background/Urchin_urchin0000000000.yml
@@ -15,8 +15,10 @@ system:
     - stealth
     - deception
   talents:
-    - Compendium.crucible.talent.Item.lightWeaponTrain
-    - Compendium.crucible.talent.Item.lunge00000000000
+    - item: Compendium.crucible.talent.Item.lightWeaponTrain
+      level: null
+    - item: Compendium.crucible.talent.Item.backstab00000000
+      level: null
   identifier: urchin
   ui:
     color: '#84d7b7'
@@ -27,11 +29,11 @@ system:
     - common
 _stats:
   systemId: crucible
-  systemVersion: 0.8.6
-  coreVersion: '13.347'
+  systemVersion: 0.8.7
+  coreVersion: '13.351'
   createdTime: 1674942420027
-  modifiedTime: 1756084018447
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1770236050631
+  lastModifiedBy: ifaQA7jTJsr3UWFE
   compendiumSource: null
   duplicateSource: null
   exportSource: null


### PR DESCRIPTION
Closes #629 
### Backgrounds:
- Merchant: **Lunge** -> **Preparedness**
- Urchin: **Lunge** -> **Backstab**
- Soldier: **Heavy Strike** -> **True Grit**

### Archetypes:
- Archer: Fix **Projectile Weapon Training**
- Berserker: Remove invalid **Heavy Strike** (granted by **Heavy Weapon Training**)
- Grappler: Remove invalid **Wrestler** (granted by **Unarmed Combat Training**)
- Protector: Remove invalid **Shield Bash** (granted by **Shield Combat Training**)
- Scout: Fix **Projectile Weapon Training**
- Scout: **Lunge** -> **Light Weapon Training**