### PR TITLE
[#636] `crawl`-action movement no longer removes `prone` status

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -352,8 +352,10 @@ export const TAGS = {
 
       // Remove prone condition upon movement confirmation if non-crawl action
       if ( this.actor.statuses.has("prone") ) {
-        const movementPath = this.token?.movementHistory.filter(m => m.movementId === self.movement) ?? [];
-        if ( movementPath.some(m => m.action !== "crawl") ) await this.actor.toggleStatusEffect("prone", {active: false});
+        const movementHistory = this.token?.movementHistory ?? [];
+        if ( !movementHistory.every(m => (m.movementId !== self.movement) || (m.action === "crawl")) ) {
+          await this.actor.toggleStatusEffect("prone", {active: false});
+        }
       }
     }
   },


### PR DESCRIPTION
Closes #636 
Not sure if there's a better way to say "did any of this movement not use crawl" but I think this works.