### PR TITLE
[#641] Prevent inflection use while silenced

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1758,7 +1758,7 @@
   "WARNINGS": {
     "CannotAffordHands.one": "The {action} spell requires {hands} free hand to cast.",
     "CannotAffordHands.other": "The {action} spell requires {hands} free hands to cast.",
-    "Silenced": "Cannot use Inflections while Silenced."
+    "CannotUseSilenced": "Cannot use Inflections while Silenced."
   }
 },
 

--- a/module/models/spell-action.mjs
+++ b/module/models/spell-action.mjs
@@ -218,10 +218,8 @@ export default class CrucibleSpellAction extends CrucibleAction {
   /** @inheritDoc */
   _canUse() {
     super._canUse();
-
-    // Can't use an inflection while silenced
     if ( this.inflection && this.actor.statuses.has("silenced") ) {
-      throw new Error(game.i18n.localize("SPELL.WARNINGS.Silenced"));
+      throw new Error(game.i18n.localize("SPELL.WARNINGS.CannotUseSilenced"));
     }
   }
 
@@ -335,7 +333,7 @@ export default class CrucibleSpellAction extends CrucibleAction {
       tags.context.inflection = {
         label: tags.context.inflection,
         unmet: true,
-        tooltip: game.i18n.localize("SPELL.WARNINGS.Silenced")
+        tooltip: game.i18n.localize("SPELL.WARNINGS.CannotUseSilenced")
       }
     }
     return tags;


### PR DESCRIPTION
Closes #641 
Not sure if the tooltip on the unmet tag is too much, but usually when something's unmet, it's obvious why (2 hands unmet? Means I don't have 2 hands free)

<img width="480" height="636" alt="Screenshot 2026-02-05 155826" src="https://github.com/user-attachments/assets/3e8beee0-beb9-446f-b046-15fc3bc8df5d" />
