### PR TITLE
[#647] Block `summon`-tagged action use if `usage.summons` not properly configured

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -661,6 +661,7 @@
 "ACTION.WarningRequireTemplate": "You must place a Measured Template to indicate the area of effect of {action}.",
 "ACTION.WarningMinimumRange": "A selected target is closer than the minimum range of {min} feet.",
 "ACTION.WarningMaximumRange": "A selected target is further than the maximum range of {max} feet.",
+"ACTION.WarningMisconfiguredSummon": "The action {action} does not have a properly configured Summon target.",
 "ACTION.WarningNoAbility": "{actor} has no {ability} score, and therefore cannot use {action}.",
 "ACTION.WarningUnimplementedTarget": "Automation for target type {type} for action {name} is not yet supported, you must manually target affected tokens.",
 

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -493,6 +493,11 @@ export const TAGS = {
     label: "ACTION.TagSummon",
     tooltip: "ACTION.TagSummonTooltip",
     category: "special",
+    canUse() {
+      if ( !this.usage.summons?.length || this.usage.summons.some(s => !s.actorUuid) ) {
+        throw new Error(game.i18n.format("ACTION.WarningMisconfiguredSummon", { action: this.name }));
+      }
+    },
     async postActivate(outcome) {
       if ( (outcome.target !== this.actor) || !outcome.summons?.length ) return;
       for ( const summon of outcome.summons ) {


### PR DESCRIPTION
Closes #647 
Basic requirements: At least 1 entry in `usage.summons`, and every entry in `usage.summons` has `actorUuid`.