### PR TITLE
[#654] add `draggable` to talents on Adversary sheet, await `super._onDragStart`

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -414,6 +414,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
           section = sections.inventory[d.section];
           break;
         case "talent":
+          if ( this.document.type === "adversary" ) d.cssClass = "draggable";
           d.tier = i.system.node?.tier || 0;
           const action = i.actions.at(0);
           if ( action ) {

--- a/templates/sheets/actor/talents.hbs
+++ b/templates/sheets/actor/talents.hbs
@@ -20,7 +20,7 @@
         <h3 class="section-header">{{section.label}}</h3>
         <ol class="items-list" data-tooltip-direction="LEFT">
             {{#each section.items as |item id|}}
-            <li class="line-item {{#if (eq @root.actor.type "adversary")}}draggable {{/if}}{{item.cssClass}}" data-crucible-tooltip="talent" data-uuid="{{item.uuid}}" data-item-id="{{item.id}}">
+            <li class="line-item {{item.cssClass}}" data-crucible-tooltip="talent" data-uuid="{{item.uuid}}" data-item-id="{{item.id}}">
                 <img class="icon" src="{{item.img}}" alt="{{item.name}}">
                 <div class="title">
                     <h4>{{item.name}}</h4>


### PR DESCRIPTION
Closes #654 
`await`ing `super._onDragStart` isn't necessary for this PR, but I noticed it, so I fixed it.