### PR TITLE
Only apply prototype token defaults on actor creation if data isn't provided

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2314,9 +2314,7 @@ export default class CrucibleActor extends Actor {
         Object.assign(prototypeTokenDefaults, {"sight.enabled": true, actorLink: true, disposition: 1});
         break;
       case "adversary":
-        prototypeTokenDefaults["sight.enabled"] = false;
-        prototypeTokenDefaults.actorLink = false;
-        prototypeTokenDefaults.disposition = -1;
+        Object.assign(prototypeTokenDefaults, {"sight.enabled": false, actorLink: false, disposition: -1});
         break;
     }
     updates.prototypeToken = {};


### PR DESCRIPTION
For actors created via the UI, will still define these defaults. Now an actor created programmatically (for instance, via Adventure import) that _has_ values already won't have them clobbered.