### PR TITLE
[#658] Change default DCs to be more accurate, make player-initiated skill rolls appear with unknown result until set

### DIFF
--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -27,7 +27,7 @@ export function addChatMessageContextOptions(html, options) {
         <div class="form-group slim">
             <label>DC Target</label>
             <div class="form-fields">
-                <input type="number" name="dc" value="${roll.data.dc ?? 15}" autofocus>
+                <input type="number" name="dc" value="${roll.data.dc || 15}" autofocus>
             </div>
         </div>`
       });

--- a/module/const/dice.mjs
+++ b/module/const/dice.mjs
@@ -1,13 +1,13 @@
 
 
 export const checkDifficulties = {
-  10: "DICE.DIFFICULTIES.Trivial",
-  15: "DICE.DIFFICULTIES.Easy",
-  20: "DICE.DIFFICULTIES.Moderate",
-  25: "DICE.DIFFICULTIES.Challenging",
-  30: "DICE.DIFFICULTIES.Difficult",
-  35: "DICE.DIFFICULTIES.Formidable",
-  45: "DICE.DIFFICULTIES.Impossible"
+  9: "DICE.DIFFICULTIES.Trivial",
+  12: "DICE.DIFFICULTIES.Easy",
+  15: "DICE.DIFFICULTIES.Moderate",
+  19: "DICE.DIFFICULTIES.Challenging",
+  24: "DICE.DIFFICULTIES.Difficult",
+  30: "DICE.DIFFICULTIES.Formidable",
+  36: "DICE.DIFFICULTIES.Impossible"
 };
 
 

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -56,7 +56,7 @@ export default class StandardCheck extends Roll {
     ability: 0,
     banes: {},
     boons: {},
-    dc: 20,
+    dc: 15,
     enchantment: 0,
     skill: 0,
     type: "general",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -453,10 +453,11 @@ export default class CrucibleActor extends Actor {
    * @param {boolean} [options.passive]
    * @returns {PassiveCheck|StandardCheck}
    */
-  getSkillCheck(skillId, {banes=0, boons=0, dc=20, passive=false}={}) {
+  getSkillCheck(skillId, {banes=0, boons=0, dc=0, passive=false}={}) {
     const skill = this.system.skills[skillId];
     if ( !skill ) throw new Error(`Invalid skill ID ${skillId}`);
     const {boons: systemBoons={}, banes: systemBanes={}} = this.system.rollBonuses;
+    if ( game.user.isGM ) dc ||= 15;
 
     // Prepare check data
     const rollData = {

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -349,7 +349,7 @@ function enrichCounterspell([match, terms]) {
   } catch(err) {
     return new Text(match);
   }
-  const {rune, gesture, inflection, dc="20"} = parsed;
+  const {rune, gesture, inflection, dc="15"} = parsed;
   const dataset = {rune, gesture, dc};
   if ( inflection ) dataset.inflection = inflection;
 


### PR DESCRIPTION
Closes #658 
- `chat.mjs` change is so that setting a 0-DC (aka unknown DC) message defaults to 15 in the dialog, instead of to 0.
- Since the GM can actually set the DC when rolling or requesting, for GMs we continue to default to "Moderate" (now 15), but for non-GMs default DC is 0, resulting in "Unknown" result text & no red or green highlighting, until/if GM modifies the DC
- Also defaulted counterspells to 15, instead of 20. I don't expect that to come up much, figure folks (certainly us) will usually be providing DCs to the enricher.