### PR TITLE
First pass at v14 changes

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -766,24 +766,6 @@ function registerDevelopmentHooks() {
   Hooks.on("preCreateItem", (item, data, options, _user) => {
     if ( options.keepId === false ) return;
 
-    // Maintain IDs when importing from a compendium
-    // TODO this can be removed in V14
-    if ( options.fromCompendium ) {
-      const {id} = foundry.utils.parseUuid(item._stats.compendiumSource);
-      if ( id ) {
-        item.updateSource({_id: id});
-        options.keepId = true;
-      }
-      return;
-    }
-
-    // Keep existing _id while exporting into a compendium pack
-    // TODO this can be removed in V14
-    if ( item.pack && !item.parent && item.id ) {
-      options.keepId = true;
-      return;
-    }
-
     // Generate a new ID
     if ( !item.parent && !item.id ) {
       item.updateSource({_id: generateId(item.name, 16)});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,9 @@ export default [
           return obj;
         }, {}),
         ...[
+          "_del",
+          "_loc",
+          "_replace",
           "ActiveEffect",
           "Actor",
           "canvas",
@@ -33,7 +36,6 @@ export default [
           "CONFIG",
           "CONST",
           "Folder",
-          "FormDataExtended",
           "foundry",
           "fromUuid",
           "fromUuidSync",
@@ -45,9 +47,7 @@ export default [
           "JournalEntry",
           "Macro",
           "PIXI",
-          "PreciseText",
           "ProseMirror",
-          "Ray",
           "Roll",
           "Scene",
           "TokenDocument",

--- a/module/applications/sheets/item-archetype-sheet.mjs
+++ b/module/applications/sheets/item-archetype-sheet.mjs
@@ -252,7 +252,7 @@ export default class CrucibleArchetypeItemSheet extends CrucibleBackgroundItemSh
 
     // Force replace ability progression
     if ( fields.abilities.validate(submitData.system.abilities) === undefined ) {
-      submitData.system["==abilities"] = submitData.system.abilities;
+      submitData.system.abilities = _replace(submitData.system.abilities);
     }
     delete submitData.system.abilities;
     return submitData;

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -291,7 +291,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
    * @protected
    */
   _getSubmitData(event) {
-    const fd = new FormDataExtended(this.element);
+    const fd = new foundry.applications.ux.FormDataExtended(this.element);
     return this._prepareSubmitData(event, this.element, fd);
   }
 

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -118,25 +118,4 @@ export function configure() {
   for ( const [id, cfg] of Object.entries(TRAVEL_PACES) ) {
     CONFIG.Token.movement.actions[id] = {...cfg, canSelect: groupOnly};
   }
-
-  // TODO this can be removed in V14
-  if ( foundry.utils.isNewerVersion("14.351", game.release.version) ) {
-    const doubleCost = () => cost => cost * 2;
-    const noCost = () => () => 0;
-    const walkTerrain = ({walk}) => walk;
-    const noTerrain = () => 1;
-    const actions = CONFIG.Token.movement.actions;
-    actions.step.getCostFunction = doubleCost;
-    actions.step.deriveTerrainDifficulty = walkTerrain;
-    actions.crawl.getCostFunction = doubleCost;
-    actions.crawl.deriveTerrainDifficulty = walkTerrain;
-    actions.jump.getCostFunction = doubleCost;
-    actions.climb.getCostFunction = doubleCost;
-    actions.climb.deriveTerrainDifficulty = walkTerrain;
-    actions.swim.getCostFunction = doubleCost;
-    actions.blink.deriveTerrainDifficulty = noTerrain;
-    actions.displace.deriveTerrainDifficulty = noTerrain;
-    actions.displace.getCostFunction = noCost;
-    actions.displace.canSelect = () => false;
-  }
 }

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -264,21 +264,6 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
 
   /* -------------------------------------------- */
 
-  /**
-   * TODO This method extension can be removed in V14 as it will be handled by Foundry core.
-   * @inheritDoc
-   */
-  _modifyAnimationMovementSpeed(speed, options={}) {
-    speed = super._modifyAnimationMovementSpeed(speed, options);
-    if ( foundry.utils.isNewerVersion("14.351", game.release.version) ) {
-      const actionConfig = CONFIG.Token.movement.actions[options.action];
-      return speed * (actionConfig.speedMultiplier ?? 1);
-    }
-    return speed;
-  }
-
-  /* -------------------------------------------- */
-
   /** @override */
   _getShiftedPosition(dx, dy, dz) {
     if ( !canvas.scene.useMicrogrid ) return super._getShiftedPosition(dx, dy, dz);

--- a/module/canvas/tree/talent-tree.mjs
+++ b/module/canvas/tree/talent-tree.mjs
@@ -208,7 +208,7 @@ export default class CrucibleTalentTree extends PIXI.Container {
     const textStyle = CONFIG.canvasTextStyle.clone();
     textStyle.fontFamily = "AwerySmallcaps";
     for ( const [i, abilityId] of CrucibleTalentTree.#SEXTANT_ABILITIES.entries() ) {
-      const text = this.addChild(new PreciseText("12", textStyle));
+      const text = this.addChild(new foundry.canvas.containers.PreciseText("12", textStyle));
       text.anchor.set(0.5, 0.5);
       const angle = 30 + (i * 60);
       const r = foundry.canvas.geometry.Ray.fromAngle(0, 0, Math.toRadians(angle), 220);

--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -11,14 +11,14 @@ export function addChatMessageContextOptions(html, options) {
 
   // Assign difficulty for skill checks
   options.push({
-    name: game.i18n.localize("DICE.SetDifficulty"),
+    label: game.i18n.localize("DICE.SetDifficulty"),
     icon: '<i class="fas fa-bullseye"></i>',
-    condition: li => {
+    visible: li => {
       const message = game.messages.get(li.dataset.messageId);
       const flags = message.flags.crucible || {};
       return message.isRoll && flags.skill;
     },
-    callback: async li => {
+    onClick: async (_, li) => {
       const message = game.messages.get(li.dataset.messageId);
       const roll = message.rolls[0];
       const formData = await foundry.applications.api.DialogV2.input({
@@ -38,14 +38,14 @@ export function addChatMessageContextOptions(html, options) {
 
   // Confirm Action usage
   options.push({
-    name: game.i18n.localize("DICE.Confirm"),
+    label: game.i18n.localize("DICE.Confirm"),
     icon: '<i class="fas fa-hexagon-check"></i>',
-    condition: li => {
+    visible: li => {
       const message = game.messages.get(li.dataset.messageId);
       const flags = message.flags.crucible || {};
       return flags.action && !flags.confirmed;
     },
-    callback: async li => {
+    onClick: async (_, li) => {
       const message = game.messages.get(li.dataset.messageId);
       return CrucibleAction.confirmMessage(message);
     }
@@ -53,14 +53,14 @@ export function addChatMessageContextOptions(html, options) {
 
   // Reverse damage
   options.push({
-    name: game.i18n.localize("DICE.Reverse"),
+    label: game.i18n.localize("DICE.Reverse"),
     icon: '<i class="fas fa-hexagon-xmark"></i>',
-    condition: li => {
+    visible: li => {
       const message = game.messages.get(li.dataset.messageId);
       const flags = message.flags.crucible || {};
       return flags.action && flags.confirmed;
     },
-    callback: async li => {
+    onClick: async (_, li) => {
       const message = game.messages.get(li.dataset.messageId);
       return CrucibleAction.confirmMessage(message, {reverse: true});
     }

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -28,7 +28,7 @@ export function bleeding(actor, {ability="dexterity", amount, turns=3, damageTyp
   return {
     _id: getEffectId("Bleeding"),
     name: "Bleeding",
-    icon: "icons/skills/wounds/blood-spurt-spray-red.webp",
+    img: "icons/skills/wounds/blood-spurt-spray-red.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["bleeding"],
@@ -54,7 +54,7 @@ export function burning(actor, {ability="intellect", amount, turns=3}={}) {
   return {
     _id: getEffectId("Burning"),
     name: "Burning",
-    icon: "icons/magic/fire/projectile-smoke-swirl-red.webp",
+    img: "icons/magic/fire/projectile-smoke-swirl-red.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["burning"],
@@ -84,7 +84,7 @@ export function freezing(actor, {ability="wisdom", amount, turns=1}={}) {
   return {
     _id: getEffectId("Freezing"),
     name: "Freezing",
-    icon: "icons/magic/water/orb-ice-web.webp",
+    img: "icons/magic/water/orb-ice-web.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["freezing", "slowed"],
@@ -110,7 +110,7 @@ export function confused(actor, {ability="intellect", amount, turns=2}={}) {
   return {
     _id: getEffectId("Confused"),
     name: "Confused",
-    icon: "icons/magic/air/air-burst-spiral-pink.webp",
+    img: "icons/magic/air/air-burst-spiral-pink.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["confused", "disoriented"],
@@ -136,7 +136,7 @@ export function corroding(actor, {ability="wisdom", amount, turns=3}={}) {
   return {
     _id: getEffectId("Corroding"),
     name: "Corroding",
-    icon: "icons/magic/earth/orb-stone-smoke-teal.webp",
+    img: "icons/magic/earth/orb-stone-smoke-teal.webp",
     duration: {turns},
     origin: actor.uuid,
     system: {
@@ -162,7 +162,7 @@ export function decay(actor, {ability="wisdom", amount, turns=3}={}) {
   return {
     _id: getEffectId("Decaying"),
     name: "Decaying",
-    icon: "icons/magic/unholy/strike-beam-blood-red-purple.webp",
+    img: "icons/magic/unholy/strike-beam-blood-red-purple.webp",
     duration: {turns},
     origin: actor.uuid,
     system: {
@@ -183,7 +183,7 @@ export function entropy(actor) {
   return {
     _id: getEffectId("Entropy"),
     name: "Entropy",
-    icon: "icons/magic/unholy/orb-swirling-teal.webp",
+    img: "icons/magic/unholy/orb-swirling-teal.webp",
     duration: {turns: 1},
     origin: actor.uuid,
     statuses: ["frightened"],
@@ -205,7 +205,7 @@ export function irradiated(actor) {
   return {
     _id: getEffectId("Irradiated"),
     name: "Irradiated",
-    icon: "icons/magic/light/beams-rays-orange-purple-large.webp",
+    img: "icons/magic/light/beams-rays-orange-purple-large.webp",
     duration: {turns: 1},
     origin: actor.uuid,
     system: {
@@ -234,7 +234,7 @@ export function mending(actor, {ability="wisdom", amount, turns=1}={}) {
   return {
     _id: getEffectId("Mending"),
     name: "Mending",
-    icon: "icons/magic/life/cross-beam-green.webp",
+    img: "icons/magic/life/cross-beam-green.webp",
     duration: {turns},
     origin: actor.uuid,
     system: {
@@ -256,7 +256,7 @@ export function inspired(actor, target) {
   return {
     _id: getEffectId("Inspired"),
     name: "Inspired",
-    icon: "icons/magic/light/explosion-star-glow-silhouette.webp",
+    img: "icons/magic/light/explosion-star-glow-silhouette.webp",
     duration: {turns: 1},
     origin: actor.uuid,
     system: {
@@ -281,7 +281,7 @@ export function dominated(actor, {ability="wisdom", amount, turns=3, damageType=
   return {
     _id: getEffectId("Dominated"),
     name: "Dominated",
-    icon: "icons/magic/control/hypnosis-mesmerism-watch.webp",
+    img: "icons/magic/control/hypnosis-mesmerism-watch.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["dominated"],
@@ -307,7 +307,7 @@ export function poisoned(actor, {ability="toughness", amount, turns=6}={}) {
   return {
     _id: getEffectId("Poisoned"),
     name: "Poisoned",
-    icon: "icons/magic/unholy/orb-smoking-green.webp",
+    img: "icons/magic/unholy/orb-smoking-green.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["poisoned"],
@@ -333,7 +333,7 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
   return {
     _id: getEffectId("Shocked"),
     name: "Shocked",
-    icon: "icons/magic/lightning/bolt-strike-forked-blue.webp",
+    img: "icons/magic/lightning/bolt-strike-forked-blue.webp",
     duration: {turns},
     origin: actor.uuid,
     statuses: ["shocked"],
@@ -356,7 +356,7 @@ export function staggered(actor, target) {
   return {
     _id: getEffectId("Staggered"),
     name: "Staggered",
-    icon: "icons/skills/melee/strike-hammer-destructive-orange.webp",
+    img: "icons/skills/melee/strike-hammer-destructive-orange.webp",
     duration: {turns: 1},
     origin: actor.uuid,
     statuses: ["staggered"]

--- a/module/const/statuses.mjs
+++ b/module/const/statuses.mjs
@@ -1,81 +1,81 @@
 const nonGroupTypes = {actorTypes: ["hero", "adversary"]};
 
 
-export const statusEffects = [
-  {
+export const statusEffects = {
+  weakened: {
     id: "weakened",
     name: "ACTIVE_EFFECT.STATUSES.Weakened",
     img: "systems/crucible/icons/statuses/weakened.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.weakened00000000"
   },
-  {
+  dead: {
     id: "dead",
     name: "ACTIVE_EFFECT.STATUSES.Dead",
     img: "icons/svg/skull.svg",
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.dead000000000000"
   },
-  {
+  broken: {
     id: "broken",
     name: "ACTIVE_EFFECT.STATUSES.Broken",
     img: "systems/crucible/icons/statuses/broken.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.broken0000000000"
   },
-  {
+  insane: {
     id: "insane",
     name: "ACTIVE_EFFECT.STATUSES.Insane",
     img: "systems/crucible/icons/statuses/insane.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.insane0000000000"
   },
-  {
+  staggered: {
     id: "staggered",
     name: "ACTIVE_EFFECT.STATUSES.Staggered",
     img: "systems/crucible/icons/statuses/staggered.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.staggered0000000"
   },
-  {
+  stunned: {
     id: "stunned",
     name: "ACTIVE_EFFECT.STATUSES.Stunned",
     img: "icons/svg/daze.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.stunned000000000"
   },
-  {
+  prone: {
     id: "prone",
     name: "ACTIVE_EFFECT.STATUSES.Prone",
     img: "icons/svg/falling.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.prone00000000000"
   },
-  {
+  restrained: {
     id: "restrained",
     name: "ACTIVE_EFFECT.STATUSES.Restrained",
     img: "icons/svg/net.svg",
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.restrained000000"
   },
-  {
+  slowed: {
     id: "slowed",
     name: "ACTIVE_EFFECT.STATUSES.Slowed",
     img: "systems/crucible/icons/statuses/slowed.svg",
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.slowed0000000000"
   },
-  {
+  hastened: {
     id: "hastened",
     name: "ACTIVE_EFFECT.STATUSES.Hastened",
     img: "systems/crucible/icons/statuses/hastened.svg",
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.hastened00000000"
   },
-  {
+  disoriented: {
     id: "disoriented",
     name: "ACTIVE_EFFECT.STATUSES.Disoriented",
     img: "systems/crucible/icons/statuses/disoriented.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.disoriented00000"
   },
-  {
+  exhausted: {
     id: "exhausted",
     name: "ACTIVE_EFFECT.STATUSES.Exhausted",
     img: "systems/crucible/icons/statuses/exhausted.svg",
@@ -83,119 +83,119 @@ export const statusEffects = [
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.exhausted0000000"
   },
 
-  {
+  blinded: {
     id: "blinded",
     name: "ACTIVE_EFFECT.STATUSES.Blind",
     img: "icons/svg/blind.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.blinded000000000"
   },
-  {
+  burrowing: {
     id: "burrowing",
     name: "ACTIVE_EFFECT.STATUSES.Burrowing",
     img: "icons/svg/burrow.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.burrowing0000000"
   },
-  {
+  deafened: {
     id: "deafened",
     name: "ACTIVE_EFFECT.STATUSES.Deaf",
     img: "icons/svg/deaf.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.deafened00000000"
   },
-  {
+  silenced: {
     id: "silenced",
     name: "ACTIVE_EFFECT.STATUSES.Mute",
     img: "icons/svg/silenced.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.silenced00000000"
   },
-  {
+  enraged: {
     id: "enraged",
     name: "ACTIVE_EFFECT.STATUSES.Enraged",
     img: "systems/crucible/icons/statuses/enraged.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.enraged000000000"
   },
-  {
+  frightened: {
     id: "frightened",
     name: "ACTIVE_EFFECT.STATUSES.Fear",
     img: "icons/svg/terror.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.frightened000000"
   },
-  {
+  invisible: {
     id: "invisible",
     name: "ACTIVE_EFFECT.STATUSES.Invisible",
     img: "icons/svg/invisible.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.invisible0000000"
   },
-  {
+  invulnerable: {
     id: "invulnerable",
     name: "ACTIVE_EFFECT.STATUSES.Invulnerable",
     img: "systems/crucible/icons/statuses/invulnerable.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.invulnerable0000"
   },
-  {
+  resolute: {
     id: "resolute",
     name: "ACTIVE_EFFECT.STATUSES.Resolute",
     img: "systems/crucible/icons/statuses/resolute.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.resolute00000000"
   },
-  {
+  guarded: {
     id: "guarded",
     name: "ACTIVE_EFFECT.STATUSES.Guarded",
     img: "systems/crucible/icons/statuses/guarded.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.guarded000000000"
   },
-  {
+  exposed: {
     id: "exposed",
     name: "ACTIVE_EFFECT.STATUSES.Exposed",
     img: "systems/crucible/icons/statuses/exposed.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.exposed000000000"
   },
-  {
+  flanked: {
     id: "flanked",
     name: "ACTIVE_EFFECT.STATUSES.Flanked",
     img: "systems/crucible/icons/statuses/flanked.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.flanked000000000"
   },
-  {
+  diseased: {
     id: "diseased",
     name: "ACTIVE_EFFECT.STATUSES.Diseased",
     img: "icons/svg/acid.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.diseased00000000"
   },
-  {
+  paralyzed: {
     id: "paralyzed",
     name: "ACTIVE_EFFECT.STATUSES.Paralyzed",
     img: "icons/svg/paralysis.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.paralyzed0000000"
   },
-  {
+  asleep: {
     id: "asleep",
     name: "ACTIVE_EFFECT.STATUSES.Asleep",
     img: "icons/svg/sleep.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.asleep0000000000"
   },
-  {
+  incapacitated: {
     id: "incapacitated",
     name: "ACTIVE_EFFECT.STATUSES.Incapacitated",
     img: "icons/svg/unconscious.svg",
     hud: nonGroupTypes,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.incapacitated000"
   },
-  {
+  unaware: {
     id: "unaware",
     name: "ACTIVE_EFFECT.STATUSES.Unaware",
     img: "systems/crucible/icons/statuses/unaware.svg",
@@ -203,95 +203,95 @@ export const statusEffects = [
   },
 
   // Damage Over Time
-  {
+  bleeding: {
     id: "bleeding",
     name: "ACTIVE_EFFECT.STATUSES.Bleeding",
     img: "icons/skills/wounds/blood-spurt-spray-red.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.bleeding00000000"
   },
-  {
+  burning: {
     id: "burning",
     name: "ACTIVE_EFFECT.STATUSES.Burning",
     img: "icons/magic/fire/projectile-smoke-swirl-red.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.burning000000000"
   },
-  {
+  freezing: {
     id: "freezing",
     name: "ACTIVE_EFFECT.STATUSES.Freezing",
     img: "icons/magic/water/orb-ice-web.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.freezing00000000"
   },
-  {
+  confused: {
     id: "confused",
     name: "ACTIVE_EFFECT.STATUSES.Confused",
     img: "icons/magic/air/air-burst-spiral-pink.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.confused00000000"
   },
-  {
+  corroding: {
     id: "corroding",
     name: "ACTIVE_EFFECT.STATUSES.Corroding",
     img: "icons/magic/earth/orb-stone-smoke-teal.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.corroding0000000"
   },
-  {
+  decaying: {
     id: "decaying",
     name: "ACTIVE_EFFECT.STATUSES.Decaying",
     img: "icons/magic/unholy/strike-beam-blood-red-purple.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.decaying00000000"
   },
-  {
+  dominated: {
     id: "dominated",
     name: "ACTIVE_EFFECT.STATUSES.Dominated",
     img: "icons/magic/control/hypnosis-mesmerism-watch.webp",
     hud: false,
     page: "" // TODO
   },
-  {
+  entropy: {
     id: "entropy",
     name: "ACTIVE_EFFECT.STATUSES.Entropy",
     img: "icons/magic/unholy/orb-swirling-teal.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.entropy000000000"
   },
-  {
+  irradiated: {
     id: "irradiated",
     name: "ACTIVE_EFFECT.STATUSES.Irradiated",
     img: "icons/magic/light/beams-rays-orange-purple-large.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.irradiated000000"
   },
-  {
+  mending: {
     id: "mending",
     name: "ACTIVE_EFFECT.STATUSES.Mending",
     img: "icons/magic/life/cross-beam-green.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.mending000000000"
   },
-  {
+  inspired: {
     id: "inspired",
     name: "ACTIVE_EFFECT.STATUSES.Inspired",
     img: "icons/magic/light/explosion-star-glow-silhouette.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.inspired00000000"
   },
-  {
+  poisoned: {
     id: "poisoned",
     name: "ACTIVE_EFFECT.STATUSES.Poisoned",
     img: "icons/magic/unholy/orb-smoking-green.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.poisoned00000000"
   },
-  {
+  shocked: {
     id: "shocked",
     name: "ACTIVE_EFFECT.STATUSES.Shocked",
     img: "icons/magic/lightning/bolt-strike-forked-blue.webp",
     hud: false,
     page: "Compendium.crucible.rules.JournalEntry.crucibleConditio.JournalEntryPage.shocked000000000"
   }
-];
+};

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -193,7 +193,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
    * @protected
    */
   _onRoll(_event, _button, _dialog) {
-    this.action.usage.rollMode = this.rollMode;
+    this.action.usage.messageMode = this.messageMode;
     if ( "special" in this.roll.data.boons ) this.action.usage.boons.special = this.roll.data.boons.special;
     if ( "special" in this.roll.data.banes ) this.action.usage.banes.special = this.roll.data.banes.special;
     return this.action;
@@ -397,7 +397,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
 
     // Identify the mouse cursor position
     let cursor = event.getLocalPosition(canvas.templates);
-    const ray = new Ray(origin, {x: cursor.x, y: cursor.y});
+    const ray = new foundry.canvas.geometry.Ray(origin, {x: cursor.x, y: cursor.y});
     if ( Number.isNumeric(config.distance) ) {
       const maxDistance = (config.distance * s);
       if ( ray.distance > maxDistance ) cursor = ray.project((config.distance * s) / ray.distance);

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -5,11 +5,11 @@ const {DialogV2} = foundry.applications.api;
  * @extends {DialogV2}
  */
 export default class StandardCheckDialog extends DialogV2 {
-  constructor({request=false, roll, rollMode, ...options}={}) {
+  constructor({request=false, roll, messageMode, ...options}={}) {
     super(options);
     this.request = request && game.user.isGM;
     this.roll = roll;
-    this.rollMode = rollMode;
+    this.messageMode = messageMode;
     if ( this.roll.actor ) this.#requestActors.add(this.roll.actor);
   }
 
@@ -25,7 +25,7 @@ export default class StandardCheckDialog extends DialogV2 {
       requestClear: StandardCheckDialog.#onRequestClear,
       requestParty: StandardCheckDialog.#onRequestParty,
       requestRemove: StandardCheckDialog.#onRequestRemove,
-      rollMode: StandardCheckDialog.#onChangeRollMode,
+      messageMode: StandardCheckDialog.#onChangeMessageMode,
       requestSubmit: StandardCheckDialog.#requestSubmit
     },
     position: {
@@ -59,10 +59,10 @@ export default class StandardCheckDialog extends DialogV2 {
   roll;
 
   /**
-   * The selected roll mode for this particular roll.
+   * The selected message mode for this particular roll.
    * @type {string}
    */
-  rollMode;
+  messageMode;
 
   /** @override */
   get title() {
@@ -101,7 +101,7 @@ export default class StandardCheckDialog extends DialogV2 {
   /** @override */
   async _prepareContext(options) {
     const data = this.roll.data;
-    const rollMode = this.rollMode || game.settings.get("core", "rollMode");
+    const messageMode = this.messageMode || game.settings.get("core", "messageMode");
     return Object.assign({}, data, {
       buttons: this.#prepareButtons(),
       dice: this.roll.dice.map(d => `d${d.faces}`),
@@ -109,8 +109,8 @@ export default class StandardCheckDialog extends DialogV2 {
       difficulties: Object.entries(SYSTEM.DICE.checkDifficulties).map(d => ({dc: d[0], label: `${game.i18n.localize(d[1])} (DC ${d[0]})`})),
       isGM: game.user.isGM,
       request: this.#prepareRequest(),
-      rollModes: Object.entries(CONFIG.Dice.rollModes).map(([action, { label, icon }]) => {
-        return {icon, label, action, active: action === rollMode};
+      messageModes: Object.entries(CONFIG.ChatMessage.modes).map(([action, { label, icon }]) => {
+        return {icon, label, action, active: action === messageMode};
       }),
       showDetails: data.totalBoons + data.totalBanes > 0,
       canIncreaseBoons: data.totalBoons < SYSTEM.DICE.MAX_BOONS,
@@ -206,7 +206,7 @@ export default class StandardCheckDialog extends DialogV2 {
    * @protected
    */
   _onRoll(_event, _button, _dialog) {
-    this.roll.data.rollMode = this.rollMode;
+    this.roll.data.messageMode = this.messageMode;
     return this.roll;
   }
 
@@ -292,7 +292,7 @@ export default class StandardCheckDialog extends DialogV2 {
    * @private
    */
   _updatePool(form, updates={}) {
-    const fd = new FormDataExtended(form);
+    const fd = new foundry.applications.ux.FormDataExtended(form);
     updates = foundry.utils.mergeObject(fd.object, updates);
     this.roll.initialize(updates);
   }
@@ -326,14 +326,24 @@ export default class StandardCheckDialog extends DialogV2 {
 
   /* -------------------------------------------- */
 
-  static async #onRequestClear(event) {
+  /**
+   * Handle clicks to clear requested actors
+   * @param {Event} _event
+   * @this StandardCheckDialog
+   */
+  static async #onRequestClear(_event) {
     this.#requestActors.clear();
     await this.render({window: {title: this.title}});
   }
 
   /* -------------------------------------------- */
 
-  static async #onRequestParty(event) {
+  /**
+   * Handle clicks to add party to requested actors
+   * @param {Event} _event
+   * @this StandardCheckDialog
+   */
+  static async #onRequestParty(_event) {
     if ( !crucible.party ) return;
     for ( const member of crucible.party.system.members ) {
       if ( member.actor ) this.#requestActors.add(member.actor);
@@ -343,6 +353,12 @@ export default class StandardCheckDialog extends DialogV2 {
 
   /* -------------------------------------------- */
 
+  /**
+   * Handle clicks to remove a requested actor
+   * @param {Event} _event
+   * @param {HTMLElement} target
+   * @this StandardCheckDialog
+   */
   static async #onRequestRemove(_event, target) {
     const actorId = target.closest(".line-item").dataset.actorId;
     const actor = game.actors.get(actorId);
@@ -398,15 +414,15 @@ export default class StandardCheckDialog extends DialogV2 {
   /* -------------------------------------------- */
 
   /**
-   * Handle clicks on a roll mode selection button.
+   * Handle clicks on a message mode selection button.
    * @param {Event} _event
    * @param {HTMLElement} target
    * @this {StandardCheckDialog}
    */
-  static async #onChangeRollMode(_event, target) {
-    this.rollMode = target.dataset.rollMode;
+  static async #onChangeMessageMode(_event, target) {
+    this.messageMode = target.dataset.messageMode;
     for ( const button of target.parentElement.children ) {
-      button.setAttribute("aria-pressed", button.dataset.rollMode === this.rollMode);
+      button.setAttribute("aria-pressed", button.dataset.messageMode === this.messageMode);
     }
   }
 

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -16,7 +16,7 @@ import StandardCheckDialog from "./standard-check-dialog.mjs";
  * @property {number} [ability=0]             The ability score which modifies the roll, up to a maximum of 12
  * @property {number} [skill=0]               The skill bonus which modifies the roll, up to a maximum of 12
  * @property {number} [enchantment=0]         An enchantment bonus which modifies the roll, up to a maximum of 6
- * @property {string} [rollMode]              The rollMode which should be used if this check is displayed in chat
+ * @property {string} [messageMode]           The messageMode which should be used if this check is displayed in chat
  */
 
 /**
@@ -62,7 +62,7 @@ export default class StandardCheck extends Roll {
     type: "general",
     criticalSuccessThreshold: undefined,
     criticalFailureThreshold: undefined,
-    rollMode: undefined
+    messageMode: undefined
   };
 
   /* -------------------------------------------- */
@@ -298,19 +298,19 @@ export default class StandardCheck extends Roll {
 
   /**
    * Present a Dialog instance for this pool
-   * @param {object} [options]           Options for the dialog
-   * @param {string} [options.title]     The title of the roll request
-   * @param {string} [options.flavor]    Any flavor text attached to the roll
-   * @param {boolean} [options.request]  Display the request tray
-   * @param {string} [options.rollMode]  The requested roll mode
-   * @returns {Promise<{roll:StandardCheck, rollMode: string}|null>}
+   * @param {object} [options]              Options for the dialog
+   * @param {string} [options.title]        The title of the roll request
+   * @param {string} [options.flavor]       Any flavor text attached to the roll
+   * @param {boolean} [options.request]     Display the request tray
+   * @param {string} [options.messageMode]  The requested message mode
+   * @returns {Promise<{roll:StandardCheck, messageMode: string}|null>}
    */
-  async dialog({title, flavor, request, rollMode}={}) {
+  async dialog({title, flavor, request, messageMode}={}) {
     return this.constructor.dialogClass.prompt({
       window: {title},
       flavor,
       request,
-      rollMode,
+      messageMode,
       roll: this
     });
   }
@@ -342,7 +342,7 @@ export default class StandardCheck extends Roll {
 
   /** @inheritdoc */
   async toMessage(messageData, options={}) {
-    options.rollMode = options.rollMode || this.data.rollMode;
+    options.messageMode = options.messageMode || this.data.messageMode;
     messageData.content ||= "";
     this.#addDiceSoNiceEffects();
     return super.toMessage(messageData, options);

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -48,7 +48,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
     };
     // Status tooltip tags
     tags.statuses = this.statuses.reduce((obj, conditionId) => {
-      const cfg = CONFIG.statusEffects.find(c => c.id === conditionId);
+      const cfg = CONFIG.statusEffects[conditionId];
       if (cfg) obj[conditionId] = game.i18n.localize(cfg.name);
       return obj;
     }, {});

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -74,7 +74,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @inheritDoc */
   async _preCreate(data, options, user) {
     await super._preCreate(data, options, user);
-    if ( !("type" in data) ) this.updateSource({type: "combat", "==system": {}});
+    if ( !("type" in data) ) this.updateSource({type: "combat", system: _replace({})});
   }
 
   /* -------------------------------------------- */
@@ -153,7 +153,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
       const impetus = {
         _id: impetusId,
         name: "Impetus",
-        icon: "icons/magic/movement/trail-streak-zigzag-yellow.webp",
+        img: "icons/magic/movement/trail-streak-zigzag-yellow.webp",
         statuses: ["hastened"],
         duration: {
           combat: this.id,

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -551,7 +551,7 @@ async function onClickHazard(event) {
  * @param {RegExpMatchArray} matchArray
  */
 function enrichCondition([match, conditionId]) {
-  const cfg = CONFIG.statusEffects.find(c => c.id === conditionId);
+  const cfg = CONFIG.statusEffects[conditionId];
   if ( !cfg ) return new Text(match);
   const tag = document.createElement("enriched-content");
   tag.innerHTML = game.i18n.localize(cfg.name);

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -185,10 +185,10 @@ HOOKS.clarifyIntent = {
     }
     const effect = outcome.effects[0];
     if ( !effect ) return;
-    effect.changes ||= [];
-    effect.changes.push(
-      {key: "system.rollBonuses.boons.clarifyIntent.number", mode: 5, value: 1},
-      {key: "system.rollBonuses.boons.clarifyIntent.label", mode: 5, value: this.name}
+    effect.system.changes ||= [];
+    effect.system.changes.push(
+      {key: "system.rollBonuses.boons.clarifyIntent.number", type: "override", value: 1},
+      {key: "system.rollBonuses.boons.clarifyIntent.label", type: "override", value: this.name}
     );
   }
 };
@@ -400,10 +400,10 @@ HOOKS.healingTonic = {
 HOOKS.inspireHeroism = {
   preActivate() {
     const effect = this.effects[0];
-    effect.changes ||= [];
-    effect.changes.push(
-      {key: "system.rollBonuses.boons.inspireHeroism.number", mode: 5, value: 1},
-      {key: "system.rollBonuses.boons.inspireHeroism.label", mode: 5, value: this.name}
+    effect.system.changes ||= [];
+    effect.system.changes.push(
+      {key: "system.rollBonuses.boons.inspireHeroism.number", type: "override", value: 1},
+      {key: "system.rollBonuses.boons.inspireHeroism.label", type: "override", value: this.name}
     );
   }
 };
@@ -437,10 +437,10 @@ HOOKS.laughingMatter = {
   postActivate(outcome) {
     if ( outcome.target === this.actor ) return;
     const effect = outcome.effects[0];
-    effect.changes ||= [];
-    effect.changes.push(
-      {key: "system.rollBonuses.banes.laughingMatter.number", mode: 5, value: 1},
-      {key: "system.rollBonuses.banes.laughingMatter.label", mode: 5, value: this.name}
+    effect.system.changes ||= [];
+    effect.system.changes.push(
+      {key: "system.rollBonuses.banes.laughingMatter.number", type: "override", value: 1},
+      {key: "system.rollBonuses.banes.laughingMatter.label", type: "override", value: this.name}
     );
   }
 };
@@ -453,9 +453,9 @@ HOOKS.lastStand = {
     outcome.resources.health += (this.actor.abilities.toughness.value * 2);
     const effect = outcome.effects[0];
     if ( !effect ) return;
-    effect.changes ||= [];
-    effect.changes.push(
-      {key: "system.defenses.wounds.bonus", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: 2}
+    effect.system.changes ||= [];
+    effect.system.changes.push(
+      {key: "system.defenses.wounds.bonus", type: "add", value: 2}
     );
   }
 };
@@ -468,7 +468,7 @@ HOOKS.lifebloom = {
     const lifebloomEffect = {
       _id: "lifebloom0000000",
       name: this.name,
-      icon: this.img,
+      img: this.img,
       origin: this.actor.uuid,
       duration: {turns: 6},
       system: {
@@ -706,19 +706,19 @@ HOOKS.readScroll = {
     const {runes, gestures, inflections} = this.item.system.scroll;
     const changes = [];
     for ( const rune of runes ) {
-      changes.push({key: "system.grimoire.runeIds", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: rune});
-      changes.push({key: `system.training.${rune}`, mode: CONST.ACTIVE_EFFECT_MODES.UPGRADE, value: 1});
+      changes.push({key: "system.grimoire.runeIds", type: "add", value: rune});
+      changes.push({key: `system.training.${rune}`, type: "upgrade", value: 1});
     }
     for ( const gesture of gestures ) {
-      changes.push({key: "system.grimoire.gestureIds", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: gesture});
+      changes.push({key: "system.grimoire.gestureIds", type: "add", value: gesture});
     }
     for ( const inflection of inflections ) {
-      changes.push({key: "system.grimoire.inflectionIds", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: inflection});
+      changes.push({key: "system.grimoire.inflectionIds", type: "add", value: inflection});
     }
     Object.assign(outcome.effects[0], {
       origin: this.item.uuid,
       duration: {seconds: 600},
-      changes
+      system: {changes}
     });
   }
 };

--- a/module/hooks/spellcraft.mjs
+++ b/module/hooks/spellcraft.mjs
@@ -52,14 +52,16 @@ HOOKS.aspect = {
       outcome.effects.push({
         _id: SYSTEM.EFFECTS.getEffectId(`curse${this.damage.type}`),
         name: this.name,
-        icon: this.rune.img,
+        img: this.rune.img,
         duration: {rounds: 6},
         origin: this.actor.uuid,
-        changes: [{
-          key: `system.resistances.${this.damage.type}.bonus`,
-          value: -2,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD
-        }]
+        system: {
+          changes: [{
+            key: `system.resistances.${this.damage.type}.bonus`,
+            value: -2,
+            type: "add"
+          }]
+        }
       });
       return;
     }
@@ -69,21 +71,23 @@ HOOKS.aspect = {
     outcome.effects.push({
       _id: SYSTEM.EFFECTS.getEffectId(`aspect${this.damage.type}`),
       name: this.name,
-      icon: this.gesture.img,
+      img: this.gesture.img,
       duration: {rounds: 6},
       origin: this.actor.uuid,
-      changes: [
-        {
-          key: `system.resistances.${this.damage.type}.bonus`,
-          value: 2,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD
-        },
-        {
-          key: `system.rollBonuses.damage.${this.damage.type}`,
-          value: 2,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD
-        }
-      ]
+      system: {
+        changes: [
+          {
+            key: `system.resistances.${this.damage.type}.bonus`,
+            value: 2,
+            type: "add"
+          },
+          {
+            key: `system.rollBonuses.damage.${this.damage.type}`,
+            value: 2,
+            type: "add"
+          }
+        ]
+      }
     });
   }
 };
@@ -98,7 +102,7 @@ HOOKS.aura = {
     if ( !outcome.self ) return;
     outcome.effects.push({
       _id: SYSTEM.EFFECTS.getEffectId(this.gesture.id),
-      icon: this.img,
+      img: this.img,
       name: this.name,
       system: {}
     });
@@ -115,7 +119,7 @@ HOOKS.conjure = {
     if ( !outcome.self ) return;
     outcome.effects.push({
       _id: outcome.summons[0].effectId,
-      icon: this.img,
+      img: this.img,
       name: this.name,
       duration: {rounds: 12},
       system: {}
@@ -133,7 +137,7 @@ HOOKS.create = {
     if ( !outcome.self ) return;
     outcome.effects.push({
       _id: outcome.summons[0].effectId,
-      icon: this.img,
+      img: this.img,
       name: this.name,
       duration: {rounds: 6},
       system: {}
@@ -168,7 +172,7 @@ HOOKS.sense = {
     if ( !outcome.self ) return;
     outcome.effects.push({
       _id: SYSTEM.EFFECTS.getEffectId(this.gesture.id),
-      icon: this.img,
+      img: this.img,
       name: this.name,
       system: {}
     });
@@ -215,16 +219,18 @@ HOOKS.ward = {
     outcome.effects.push({
       _id: SYSTEM.EFFECTS.getEffectId("ward"),
       name: this.name,
-      icon: this.gesture.img,
+      img: this.gesture.img,
       duration: {rounds: 1},
       origin: this.actor.uuid,
-      changes: [
-        {
-          key: `system.resistances.${this.damage.type}.bonus`,
-          value: resistance,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD
-        }
-      ]
+      system: {
+        changes: [
+          {
+            key: `system.resistances.${this.damage.type}.bonus`,
+            value: resistance,
+            type: "add"
+          }
+        ]
+      }
     });
   }
 };

--- a/module/interaction.mjs
+++ b/module/interaction.mjs
@@ -176,7 +176,7 @@ async function displayLanguageCheck(event) {
  */
 async function displayCondition(event) {
   const element = event.target;
-  const cfg = CONFIG.statusEffects.find(c => c.id === element.dataset.condition);
+  const cfg = CONFIG.statusEffects[element.dataset.condition];
   if ( !cfg ) return;
   event.stopImmediatePropagation();
   element.dataset.tooltipHtml = ""; // Placeholder to prevent double-activation

--- a/module/models/actor-group.mjs
+++ b/module/models/actor-group.mjs
@@ -299,7 +299,7 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
     "${identifier}" on group "${this.parent.name}"`);
     const number = milestones[identifier].number;
     delete milestones[identifier];
-    actorUpdates.push({_id: this.parent.id, system: {advancement: {"==milestones": milestones}}}); // ForcedDeletion
+    actorUpdates.push({_id: this.parent.id, system: {advancement: {milestones: _replace(milestones)}}}); // ForcedDeletion
 
     // Prepare ChatMessage
     const plurals = new Intl.PluralRules(game.i18n.lang);
@@ -365,9 +365,7 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
     content.append(
       identifier.toFormGroup({}, {name: "identifier", placeholder: identifierPlaceholder}),
       number.toFormGroup({classes: ["slim"]}, {name: "number", value: options.number || 1, placeholder: "1"}),
-
-      // TODO: Can remove this manual localization in v14
-      reason.toFormGroup({stacked: true}, {name: "reason", placeholder: game.i18n.localize("ACTOR.GROUP.FIELDS.advancement.milestones.element.reason.placeholder")}),
+      reason.toFormGroup({stacked: true}, {name: "reason"}),
       recipients.toFormGroup({stacked: true}, {name: "recipients", type: "checkboxes", value: Object.keys(heroes),
         sort: true})
     );

--- a/module/models/effect-base.mjs
+++ b/module/models/effect-base.mjs
@@ -1,7 +1,7 @@
 /**
  * Active Effect subtype containing crucible-specific system schema.
  */
-export default class CrucibleBaseActiveEffect extends foundry.abstract.TypeDataModel {
+export default class CrucibleBaseActiveEffect extends foundry.data.ActiveEffectTypeDataModel {
 
   /* -------------------------------------------- */
   /*                  Data Schema                 */
@@ -10,7 +10,7 @@ export default class CrucibleBaseActiveEffect extends foundry.abstract.TypeDataM
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;
-    const schema = {};
+    const schema = super.defineSchema();
 
     // Damage Over Time
     schema.dot = new fields.ArrayField(new fields.SchemaField({
@@ -26,10 +26,9 @@ export default class CrucibleBaseActiveEffect extends foundry.abstract.TypeDataM
       cost: new fields.NumberField({required: true, integer: true, nullable: false})
     }, {nullable: true, initial: null});
 
-    // Scene Regions (currently, Templates)
-    // TODO: Once in v14, type: "Region"
+    // Scene Regions
     // TODO: Actually track these
-    schema.regions = new fields.SetField(new fields.DocumentUUIDField({nullable: false}), {initial: []});
+    schema.regions = new fields.SetField(new fields.DocumentUUIDField({nullable: false, type: "Region"}), {initial: []});
 
     // Summons
     schema.summons = new fields.SetField(new fields.DocumentUUIDField({type: "Token", nullable: false}), {initial: []});

--- a/module/models/effect-flanked.mjs
+++ b/module/models/effect-flanked.mjs
@@ -1,7 +1,7 @@
 /**
  * Active Effect subtype specific to "flanked" effect.
  */
-export default class CrucibleFlankedActiveEffect extends foundry.abstract.TypeDataModel {
+export default class CrucibleFlankedActiveEffect extends foundry.data.ActiveEffectTypeDataModel {
 
   /* -------------------------------------------- */
   /*                  Data Schema                 */
@@ -11,6 +11,7 @@ export default class CrucibleFlankedActiveEffect extends foundry.abstract.TypeDa
   static defineSchema() {
     const fields = foundry.data.fields;
     return {
+      ...super.defineSchema(),
       allies: new fields.NumberField({required: true, integer: true, nullable: false}),
       enemies: new fields.NumberField({required: true, integer: true, nullable: false}),
       flanked: new fields.NumberField({required: true, integer: true, nullable: false})

--- a/module/models/item-ancestry.mjs
+++ b/module/models/item-ancestry.mjs
@@ -121,7 +121,7 @@ export default class CrucibleAncestryItem extends foundry.abstract.TypeDataModel
       },
       talents
     };
-    return this.parent.clone({type: "taxonomy", "==system": system}, {keepId: true, save: false});
+    return this.parent.clone({type: "taxonomy", system: _replace(system)}, {keepId: true, save: false});
   }
 
   /* -------------------------------------------- */

--- a/module/models/item-consumable.mjs
+++ b/module/models/item-consumable.mjs
@@ -237,7 +237,7 @@ class CrucibleScrollConfigDialog extends DialogV2 {
   /** @inheritDoc */
   async _onSubmit(target, event) {
     const form = this.element.querySelector("form");
-    const nameInput = form.elements.name
+    const nameInput = form.elements.name;
     nameInput.value ||= nameInput.placeholder;
     return super._onSubmit(target, event);
   }
@@ -253,7 +253,7 @@ class CrucibleScrollConfigDialog extends DialogV2 {
     const form = event.target.form;
     const nameInput = form.elements.name;
     if ( event.target === nameInput ) return;
-    const formData = foundry.utils.expandObject(new FormDataExtended(form).object);
+    const formData = foundry.utils.expandObject(new foundry.applications.ux.FormDataExtended(form).object);
     nameInput.placeholder = CrucibleConsumableItem.getScrollName(formData.system.scroll);
   }
 }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "crucible",
   "title": "Crucible",
   "description": "Crucible is an innovative and modern tabletop role-playing game system built exclusively for Foundry Virtual Tabletop as a digital platform. From the ground up, Crucible is designed to leverage the unique capabilities of Foundry VTT to provide gamemasters with a powerful toolset and effortless layers of automation, allowing gamemasters and players to focus on what matters most: telling a compelling story.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "manifest": "#{MANIFEST}#",
   "download": "#{DOWNLOAD}#",
   "url": "https://foundryvtt.com/packages/crucible",

--- a/templates/dice/action-use-dialog.hbs
+++ b/templates/dice/action-use-dialog.hbs
@@ -20,9 +20,9 @@
 
     <footer class="form-footer">
         <div class="split-button">
-            {{#each rollModes as |mode|}}
-            <button type="button" class="ui-control icon {{mode.icon}}" data-action="rollMode"
-                    data-roll-mode="{{mode.action}}" aria-pressed="{{mode.active}}"
+            {{#each messageModes as |mode|}}
+            <button type="button" class="ui-control icon {{mode.icon}}" data-action="messageMode"
+                    data-message-mode="{{mode.action}}" aria-pressed="{{mode.active}}"
                     data-tooltip aria-label="{{localize mode.label}}"></button>
             {{/each}}
         </div>

--- a/templates/dice/spell-cast-dialog.hbs
+++ b/templates/dice/spell-cast-dialog.hbs
@@ -59,9 +59,9 @@
 
     <footer class="form-footer">
         <div class="split-button">
-            {{#each rollModes as |mode|}}
-            <button type="button" class="ui-control icon {{mode.icon}}" data-action="rollMode"
-                    data-roll-mode="{{mode.action}}" aria-pressed="{{mode.active}}"
+            {{#each messageModes as |mode|}}
+            <button type="button" class="ui-control icon {{mode.icon}}" data-action="messageMode"
+                    data-message-mode="{{mode.action}}" aria-pressed="{{mode.active}}"
                     data-tooltip aria-label="{{localize mode.label}}"></button>
             {{/each}}
         </div>

--- a/templates/dice/standard-check-dialog.hbs
+++ b/templates/dice/standard-check-dialog.hbs
@@ -51,9 +51,9 @@
 
 <footer class="form-footer">
     <div class="split-button">
-        {{#each rollModes as |mode|}}
-        <button type="button" class="ui-control icon {{mode.icon}}" data-action="rollMode"
-                data-roll-mode="{{mode.action}}" aria-pressed="{{mode.active}}"
+        {{#each messageModes as |mode|}}
+        <button type="button" class="ui-control icon {{mode.icon}}" data-action="messageMode"
+                data-message-mode="{{mode.action}}" aria-pressed="{{mode.active}}"
                 data-tooltip aria-label="{{localize mode.label}}"></button>
         {{/each}}
     </div>


### PR DESCRIPTION
These changes are all solely to avoid errors, deprecation warnings, and unexpected behavior - none of them aim to actually _make use_ of the new features afforded by v14.

- All "this can be removed in V14" stuff has been removed except for the phased AE stuff
- `statusEffects` has been adjusted to be an object, everywhere referencing it has as well
- All instances of `==` or `-=` updates have switched to `_replace` and `_del`, respectively
- `CrucibleActor#applyActiveEffects` now takes and passes the `phase` parameter (we're still not doing anything with it yet)
- Effect subtypes now extend `ActiveEffectTypeDataModel` and their schemae extend it as well
- All instances of `rollMode` now use `messageMode` **(should we get rid of `ic` as an option in the roll dialog?)**
- All context menu additions now use `label`/`visible`/`onClick` rather than `name`/`condition`/`callback`, respectively
- Effect `changes` are now all nested under `system`, and all `mode`s are changed to `type`s (didn't touch pack data for this)
- Replaced deprecated (now no longer shimmed) use of `icon` with `img`
- Removed an extra template draw call (obviously all the region stuff will need redoing, but this at least allows templates to work roughly as they should)
- Addressed old no-longer-global deprecations (`FormDataExtended`, `PreciseText`, `Ray`) and removed them from eslint globals to avoid accidental future use

Note: I mentioned in the v14-feedback channel, I'm _pretty_ sure it's a core bug, but:
I _think_ in `ArrayField#_updateDiff`,
```js
let isDiff = result.length !== (current?.length || 0);
```
should be
```js
let isDiff = result.length !== current?.length;
```
As otherwise, trying to update something which is `undefined` in `_source` to be `[]` won't go through.

In the case of Crucible, this comes up when adding an archetype with no spells/equipment to an actor. Without the above suggested change, you'll see an error there if you test that.