### PR TITLE
skill pips for visual pre-filtering of appropriate player proficiency

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -759,7 +759,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
 
       // Skill data
       s.abilityAbbrs = [a1.abbreviation, a2.abbreviation];
-      s.pips = Array.fromRange(4).map((v, i) => i < s.rank ? "trained" : "untrained");
+      s.pips = Array.fromRange(4).map(i => i < s.rank ? "full" : "");
 
       // Specialization status
       const rank = SYSTEM.TALENT.TRAINING_RANK_VALUES[s.rank];

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -1,3 +1,5 @@
+import { SYSTEM } from "../const/system.mjs";
+
 const {DialogV2} = foundry.applications.api;
 
 /**
@@ -139,10 +141,16 @@ export default class StandardCheckDialog extends DialogV2 {
   #prepareRequest() {
     if ( !this.request ) return null;
     const actors = [];
+    const skillId = this.roll.data.type;
+    const skill = SYSTEM.SKILLS[skillId];
+    const resourceColor = skill ? SYSTEM.SKILL.CATEGORIES[skill.category]?.color?.css : null;
     for ( const actor of this.#requestActors ) {
-      actors.push({id: actor.id, name: actor.name, img: actor.img, tags: actor.getTags("short")});
+      const rank = actor.system.skills[skillId]?.rank ?? 0;
+      const pips = Array.fromRange(4).map(i => i < rank ? "full" : "");
+      const rankTooltip = SYSTEM.TALENT.TRAINING_RANK_VALUES[rank]?.label ?? SYSTEM.TALENT.TRAINING_RANKS.untrained.label;
+      actors.push({id: actor.id, name: actor.name, img: actor.img, tags: actor.getTags("short"), pips, rank, rankTooltip});
     }
-    return {actors};
+    return {actors, resourceColor};
   }
 
   /* -------------------------------------------- */

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -441,28 +441,10 @@
               text-align: center;
             }
           }
-          .pips {
+          .crucible-rank-pips {
             flex: 0 0 100px;
             justify-content: center;
             gap: 4px 0;
-            .pip {
-              flex: 0 0 14px;
-              height: 14px;
-              border: 1px solid var(--color-frame);
-              border-radius: 7px;
-              &.double {
-                border-color: var(--resource-color);
-              }
-            }
-            .full::before {
-              display: block;
-              content: "";
-              width: 8px;
-              height: 8px;
-              margin: 2px;
-              background: var(--resource-color);
-              border-radius: 4px;
-            }
           }
         }
         .action {
@@ -942,26 +924,6 @@
       justify-content: center;
       span:first-child {
         color: var(--color-text-emphatic);
-      }
-    }
-
-    // Skill ranks
-    .ranks {
-      justify-content: space-between;
-      .pip {
-        flex: 0 0 14px;
-        height: 14px;
-        border: 1px solid var(--color-frame);
-        border-radius: 7px;
-      }
-      .trained::before {
-        display: block;
-        content: "";
-        width: 8px;
-        height: 8px;
-        margin: 2px;
-        background: var(--skill-color);
-        border-radius: 4px;
       }
     }
 

--- a/styles/theme.less
+++ b/styles/theme.less
@@ -420,6 +420,34 @@
       bottom: -0.5rem;
     }
   }
+
+  .crucible-rank-pips {
+    justify-content: space-between;
+    --pip-size: 14px;
+    --pip-border: 1px;
+    --pip-dot-margin: 2px;
+
+    .pip {
+      flex: 0 0 var(--pip-size);
+      height: var(--pip-size);
+      border: var(--pip-border) solid var(--color-frame);
+      border-radius: calc(var(--pip-size) / 2);
+      &.double {
+        border-color: var(--resource-color);
+      }
+    }
+
+    .full::before {
+      --dot-size: calc(var(--pip-size) - 2 * var(--pip-border) - 2 * var(--pip-dot-margin));
+      display: block;
+      content: "";
+      width: var(--dot-size);
+      height: var(--dot-size);
+      margin: var(--pip-dot-margin);
+      background: var(--resource-color);
+      border-radius: calc(var(--dot-size) / 2);
+    }
+  }
 }
 
 /** ----------------------------------------- *

--- a/templates/dice/standard-check-dialog.hbs
+++ b/templates/dice/standard-check-dialog.hbs
@@ -25,7 +25,7 @@
 {{#if request}}
 <aside class="request-form standard-form">
     <h3 class="divider">{{localize "ACTION.RequestedActors"}}</h3>
-    <div class="requested-actors flexcol droppable scrollable">
+    <div class="requested-actors flexcol droppable scrollable" {{#if request.resourceColor}}style="--resource-color:{{request.resourceColor}}"{{/if}}>
         {{#each request.actors as |actor|}}
         <div class="line-item member" data-actor-id="{{actor.id}}">
             <img class="icon" src="{{actor.img}}">
@@ -35,6 +35,9 @@
                     {{#each actor.tags as |label tag|}}
                     <span class="tag">{{label}}</span>
                     {{/each}}
+                    <div class="crucible-rank-pips flexrow" data-tooltip="{{actor.rankTooltip}}">
+                        {{#each actor.pips}}<span class="pip {{this}}"></span>{{/each}}
+                    </div>
                 </div>
             </div>
             <div class="controls">

--- a/templates/sheets/actor/adversary-attributes.hbs
+++ b/templates/sheets/actor/adversary-attributes.hbs
@@ -20,7 +20,7 @@
                 <h4 class="label" data-tooltip="{{resources.action.tooltip}}">{{resources.action.label}}</h4>
                 <div class="points flexrow">
                     {{formInput fields.resources.fields.action.fields.value value=resources.action.value type="number"}}
-                    <div class="pips flexrow">
+                    <div class="crucible-rank-pips flexrow">
                         {{#each resources.action.pips as |pip i|}}
                         <a class="pip {{pip.cssClass}}" data-action="resourcePip" data-resource="action" data-index="{{i}}"></a>
                         {{/each}}
@@ -33,7 +33,7 @@
                 <h4 class="label" data-tooltip="{{resources.focus.tooltip}}">{{resources.focus.label}}</h4>
                 <div class="points flexrow">
                     {{formInput fields.resources.fields.focus.fields.value value=resources.focus.value type="number"}}
-                    <div class="pips flexrow">
+                    <div class="crucible-rank-pips flexrow">
                         {{#each resources.focus.pips as |pip i|}}
                         <a class="pip {{pip.cssClass}}" data-action="resourcePip" data-resource="focus" data-index="{{i}}"></a>
                         {{/each}}
@@ -47,7 +47,7 @@
                 <h4 class="label" data-tooltip="{{resources.heroism.tooltip}}">{{resources.heroism.label}}</h4>
                 <div class="points flexrow">
                     {{formInput fields.resources.fields.heroism.fields.value value=resources.heroism.value type="number"}}
-                    <div class="pips flexrow">
+                    <div class="crucible-rank-pips flexrow">
                         {{#each resources.heroism.pips as |pip i|}}
                             <a class="pip {{pip.cssClass}}" data-action="resourcePip" data-resource="heroism" data-index="{{i}}"></a>
                         {{/each}}

--- a/templates/sheets/actor/hero-attributes.hbs
+++ b/templates/sheets/actor/hero-attributes.hbs
@@ -26,7 +26,7 @@
                 <h4 class="label" data-tooltip="{{resources.action.tooltip}}">{{resources.action.label}}</h4>
                 <div class="points flexrow">
                     {{formInput fields.resources.fields.action.fields.value value=resources.action.value type="number"}}
-                    <div class="pips flexrow">
+                    <div class="crucible-rank-pips flexrow">
                         {{#each resources.action.pips as |pip i|}}
                         <a class="pip {{pip.cssClass}}" data-action="resourcePip" data-resource="action" data-index="{{i}}"></a>
                         {{/each}}
@@ -39,7 +39,7 @@
                 <h4 class="label" data-tooltip="{{resources.focus.tooltip}}">{{resources.focus.label}}</h4>
                 <div class="points flexrow">
                     {{formInput fields.resources.fields.focus.fields.value value=resources.focus.value type="number"}}
-                    <div class="pips flexrow">
+                    <div class="crucible-rank-pips flexrow">
                         {{#each resources.focus.pips as |pip i|}}
                         <a class="pip {{pip.cssClass}}" data-action="resourcePip" data-resource="focus" data-index="{{i}}"></a>
                         {{/each}}
@@ -52,7 +52,7 @@
                 <h4 class="label" data-tooltip="{{resources.heroism.tooltip}}">{{resources.heroism.label}}</h4>
                 <div class="points flexrow">
                     {{formInput fields.resources.fields.heroism.fields.value value=resources.heroism.value type="number"}}
-                    <div class="pips flexrow">
+                    <div class="crucible-rank-pips flexrow">
                         {{#each resources.heroism.pips as |pip i|}}
                             <a class="pip {{pip.cssClass}}" data-action="resourcePip" data-resource="heroism" data-index="{{i}}"></a>
                         {{/each}}

--- a/templates/sheets/actor/skills.hbs
+++ b/templates/sheets/actor/skills.hbs
@@ -3,7 +3,7 @@
     {{#each skillCategories as |category catId|}}
     <div class="sheet-section item-section flexcol">
         <h3 class="section-header">{{localize "SKILL.CategoryHeader" category=category.label}}</h3>
-        <ol class="items-list" style="--skill-color:{{category.color.css}}">
+        <ol class="items-list" style="--resource-color:{{category.color.css}}">
             {{#each category.skills as |skill skillId|}}
             <li class="skill line-item" data-skill="{{skillId}}">
                 <img class="icon" src="{{skill.icon}}" alt="{{skill.label}}">
@@ -19,7 +19,7 @@
                     <span class="value hex {{skill.hexClass}}" data-tooltip="{{skill.tooltips.value}}">{{numberFormat skill.score sign=true}}</span>
                     <span class="passive" data-tooltip="{{localize "SKILL.PassiveSpecific" passive=skill.tooltips.passive}}">{{skill.passive}}</span>
                 </div>
-                <div class="ranks flexrow">
+                <div class="crucible-rank-pips flexrow">
                     {{#each skill.pips}}<span class="pip {{this}}"></span>{{/each}}
                 </div>
                 <div class="tags training">


### PR DESCRIPTION
Relate to #97

Extracted ranks css to be generally available in other apps too

Reasoning:

Group Checks or Request Rolls should provide the gamemaster with a preview of the proficiency of the players in a certain skill to:
* gate skill checks to those that provide the actual capability to do so (e.g. if a task can not be done unless learned
* have a feeling on the probability of success for the players and maybe adjust the dc

Moreover this indicator can now be reused in other places there it might become important e.g. in journal tooltips on request rolls


Alternatives would be to use the label instead of the pips e.g. "trained untrained" which would not require css change but is little less visible

Pip preparation is currently on the actor sheet and could be extracted to a public helper for that too


<img width="667" height="448" alt="grafik" src="https://github.com/user-attachments/assets/0b62f5fd-3ab2-466e-9320-5bb27081322b" />


