### PR TITLE
[#702] Rework weapon choice framework to fix a number of bugs/bothers

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -689,7 +689,7 @@ export const TAGS = {
     prepare() {
       this.usage.actorStatus.rangedAttack = true;
       if ( !this.usage.weapon ) {
-        const valid = this.getValidWeaponChoices(true);
+        const valid = this.getValidWeaponChoices({strict: true});
         valid.sort((a, b) => a.item.system.actionCost - b.item.system.actionCost);
         this.usage.weapon = valid[0]?.item;
       }
@@ -850,9 +850,9 @@ export const TAGS = {
       if ( r >= AttackRoll.RESULT_TYPES.GLANCE ) {
         roll.data.damage = {
           overflow: roll.overflow,
-          multiplier: bonuses.multiplier,
+          multiplier: bonuses.multiplier ?? 1,
           base: bonuses.base ?? 0,
-          bonus: bonuses.damageBonus,
+          bonus: bonuses.damageBonus ?? 0,
           resistance: target.getResistance(resource, damageType),
           type: damageType,
           resource: resource,

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -847,18 +847,19 @@ export const TAGS = {
 
       // Compute the final result against defenses
       const r = roll.data.result = target.testDefense(defenseType, roll);
-      if ( r < AttackRoll.RESULT_TYPES.GLANCE ) return roll;
-      roll.data.damage = {
-        overflow: roll.overflow,
-        multiplier: 1,
-        base: 0,
-        bonus: 0,
-        resistance: target.getResistance(resource, damageType),
-        type: damageType,
-        resource: resource,
-        restoration: false
-      };
-      roll.data.damage.total = CrucibleAction.computeDamage(roll.data.damage);
+      if ( r >= AttackRoll.RESULT_TYPES.GLANCE ) {
+        roll.data.damage = {
+          overflow: roll.overflow,
+          multiplier: 1,
+          base: 0,
+          bonus: 0,
+          resistance: target.getResistance(resource, damageType),
+          type: damageType,
+          resource: resource,
+          restoration: false
+        };
+        roll.data.damage.total = CrucibleAction.computeDamage(roll.data.damage);
+      }
       outcome.rolls.push(roll);
     }
   },

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -579,6 +579,11 @@ export const TAGS = {
       this.usage.strikes = []; // Reset strike sequence
     },
     prepare() {
+      if ( !this.usage.weapon ) {
+        const valid = this.getValidWeaponChoices();
+        valid.sort((a, b) => a.item.system.actionCost - b.item.system.actionCost);
+        this.usage.weapon = valid[0]?.item;
+      }
       const {strikes, weapon} = this.usage;
 
       // Default weapon-based strikes
@@ -639,6 +644,14 @@ export const TAGS = {
         roll.data.strike = i; // TODO handle this better?
         outcome.rolls.push(roll);
       }
+    },
+    preActivate(_targets) {
+      for ( const w of this.usage.strikes ) {
+        if ( w.config.category.reload ) {
+          this.usage.actorUpdates.items ||= [];
+          this.usage.actorUpdates.items.push({_id: w.id, "system.loaded": false});
+        }
+      }
     }
   },
 
@@ -653,21 +666,6 @@ export const TAGS = {
     canUse() {
       if ( !this.actor.equipment.weapons.melee ) {
         throw new Error("You must have melee weapons equipped to use this action.");
-      }
-    },
-    prepare() {
-      if ( !this.usage.weapon ) {
-        const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
-        if ( mh && !mh.system.config.category.ranged ) this.usage.weapon = mh;
-        else if ( oh && !oh.system.config.category.ranged ) this.usage.weapon = oh;
-        else {
-          for ( const n of natural ) {
-            if ( !n.system.config.category.ranged ) {
-              this.usage.weapon = n;
-              break;
-            }
-          }
-        }
       }
     }
   },
@@ -684,32 +682,16 @@ export const TAGS = {
       if ( !this.actor.equipment.weapons.ranged ) {
         throw new Error("This action requires a ranged weapon equipped.");
       }
-      if ( this.usage.strikes.some(w => w.config.category.reload && !w.system.loaded && !this.tags.has("reload")) ) {
+      if ( this.usage.strikes.some(w => w.system.needsReload && !this.tags.has("reload")) ) {
         throw new Error("Your weapon requires reloading in order to use this action.");
       }
     },
     prepare() {
       this.usage.actorStatus.rangedAttack = true;
       if ( !this.usage.weapon ) {
-        const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
-        if ( mh && mh.system.config.category.ranged ) this.usage.weapon = mh;
-        else if ( oh && oh.system.config.category.ranged ) this.usage.weapon = oh;
-        else {
-          for ( const n of natural ) {
-            if ( n.system.config.category.ranged ) {
-              this.usage.weapon = n;
-              break;
-            }
-          }
-        }
-      }
-    },
-    preActivate(_targets) {
-      for ( const w of this.usage.strikes ) {
-        if ( w.config.category.reload ) {
-          this.usage.actorUpdates.items ||= [];
-          this.usage.actorUpdates.items.push({_id: w.id, "system.loaded": false});
-        }
+        const valid = this.getValidWeaponChoices(true);
+        valid.sort((a, b) => a.item.system.actionCost - b.item.system.actionCost);
+        this.usage.weapon = valid[0]?.item;
       }
     }
   },
@@ -774,7 +756,7 @@ export const TAGS = {
     propagate: ["melee"],
     canUse() {
       for ( const w of this.usage.strikes ) {
-        if ( !w.system.canThrow() ) throw new Error("You cannot throw this weapon.");
+        if ( !w.system.canThrow ) throw new Error("You cannot throw this weapon.");
       }
     },
     prepare() {
@@ -784,7 +766,7 @@ export const TAGS = {
     preActivate(_targets) {
       if ( !this.usage.strikes?.length ) return;
       for ( const weapon of this.usage.strikes ) {
-        if ( !weapon.system.canThrow() ) throw new Error("You cannot throw this weapon.");
+        if ( !weapon.system.canThrow ) throw new Error("You cannot throw this weapon.");
         this.usage.actorUpdates.items ||= [];
         this.usage.actorUpdates.items.push({_id: weapon.id, system: {dropped: true, equipped: false}});
         if ( !weapon.system.properties.has("thrown") ) this.usage.banes[this.id] = {label: this.name, number: 2};
@@ -890,18 +872,15 @@ export const TAGS = {
     category: "special",
     canUse() {
       const {mainhand: m, offhand: o, reload} = this.actor.equipment.weapons;
-      if ( !reload || (m.system.loaded && (!o || o.system.loaded)) ) {
+      if ( !reload || (!m.system.needsReload && !o?.system.needsReload) ) {
         throw new Error("Your weapons do not require reloading");
       }
     },
-    prepare() {
-      const {mainhand: m, offhand: o} = this.actor.equipment.weapons;
+    preActivate() {
       this.usage.actorUpdates.items ||= [];
-      if (m.config.category.reload && !m.system.loaded) {
-        this.usage.actorUpdates.items.push({_id: m.id, "system.loaded": true});
-      }
-      else if (o?.config.category.reload && !o.system.loaded) {
-        this.usage.actorUpdates.items.push({_id: o.id, "system.loaded": true});
+      this.usage.weapon ??= this.getValidWeaponChoices()[0]?.item;
+      if ( this.usage.weapon ) {
+        this.usage.actorUpdates.items.push({_id: this.usage.weapon.id, "system.loaded": true});
       }
     }
   },

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -850,9 +850,9 @@ export const TAGS = {
       if ( r >= AttackRoll.RESULT_TYPES.GLANCE ) {
         roll.data.damage = {
           overflow: roll.overflow,
-          multiplier: 1,
-          base: 0,
-          bonus: 0,
+          multiplier: bonuses.multiplier,
+          base: bonuses.base ?? 0,
+          bonus: bonuses.damageBonus,
           resistance: target.getResistance(resource, damageType),
           type: damageType,
           resource: resource,

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -110,9 +110,10 @@ export default class ActionUseDialog extends StandardCheckDialog {
    */
   #prepareWeaponChoice() {
     if ( !this.action.allowWeaponChoice ) return null;
-    const validChoices = this.action.getValidWeaponChoices(true);
-    if ( validChoices.length <= 1 ) return null;
-    const choices = validChoices.reduce((acc, {id, label}) => ({...acc, [id]: label}), {});
+    const baseActionCost = this.action.cost.action - (this.action.usage.weapon?.system.actionCost ?? 0);
+    const maxCost = this.actor.resources.action.value - baseActionCost;
+    const choices = this.action.getValidWeaponChoices({strict: true, maxCost});
+    if ( choices.length <= 1 ) return null;
     const weapon = new foundry.data.fields.StringField({blank: true, required: true, choices,
       label: "Weapon", hint: "You may choose which weapon to use for this Action."});
     weapon.name = "weapon";

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -110,19 +110,9 @@ export default class ActionUseDialog extends StandardCheckDialog {
    */
   #prepareWeaponChoice() {
     if ( !this.action.allowWeaponChoice ) return null;
-    const {mainhand: mh, offhand: oh, natural} = this.action.actor.equipment.weapons;
-    const choices = {};
-    if ( mh ) {
-      const mainhandId = mh.id || "mainhandUnarmed";
-      choices[mainhandId] = `${mh.name} (${SYSTEM.WEAPON.SLOTS.labels.MAINHAND})`;
-    }
-    if ( oh ) {
-      const offhandId = oh.id || "offhandUnarmed";
-      choices[offhandId] = `${oh.name} (${SYSTEM.WEAPON.SLOTS.labels.OFFHAND})`;
-    }
-    for ( const n of natural ) {
-      choices[n.id] = `${n.name} (${SYSTEM.WEAPON.PROPERTIES.natural.label})`;
-    }
+    const validChoices = this.action.getValidWeaponChoices(true);
+    if ( validChoices.length <= 1 ) return null;
+    const choices = validChoices.reduce((acc, {id, label}) => ({...acc, [id]: label}), {});
     const weapon = new foundry.data.fields.StringField({blank: true, required: true, choices,
       label: "Weapon", hint: "You may choose which weapon to use for this Action."});
     weapon.name = "weapon";
@@ -178,6 +168,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
       else weapon = this.action.actor.items.get(c);
       this.action.usage.weapon = weapon;
       this.action.reset();
+      this.roll = crucible.api.dice.StandardCheck.fromAction(this.action);
       this.render();
     }
   }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1365,7 +1365,7 @@ export default class CrucibleActor extends Actor {
       // Categorize damage
       const damage = {};
       for ( let {amount, damageType, resource, restoration} of dot ) {
-        if ( !restoration ) amount = -Math.clamp(amount - this.resistances[damageType].total, 0, 2 * amount);
+        if ( !restoration ) amount = -Math.clamp(amount - this.getResistance(resource, damageType), 0, 2 * amount);
         damage[resource] ??= 0;
         damage[resource] += amount;
       }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1339,7 +1339,7 @@ export default class CrucibleActor extends Actor {
     // Reload any equipped weapons
     const {mainhand, offhand} = this.equipment.weapons;
     for ( const weapon of [mainhand, offhand] ) {
-      if ( weapon?.config.category.reload && !weapon.system.loaded ) {
+      if ( weapon?.system.needsReload ) {
         itemUpdates.push({
           _id: weapon.id,
           "system.loaded": true

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -766,7 +766,7 @@ export default class CrucibleActor extends Actor {
       roll.data.damage = {
         overflow: roll.overflow,
         multiplier: bonuses.multiplier,
-        base: bonuses.skill + (bonuses.base ?? 0),
+        base: bonuses.base ?? 0,
         bonus: bonuses.damageBonus,
         resistance: target.getResistance(resource, damageType, restoration),
         type: damageType,

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1125,7 +1125,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         const fn = SYSTEM.EFFECTS[status];
         if ( typeof fn !== "function" ) continue;
         const statusEffect = fn(this.actor, {ability: this.scaling});
-        if ( statusEffect.system?.dot ) effect.system.dot ||= statusEffect.system.dot;
+        if ( statusEffect.system?.dot && !effect.system.dot?.length ) effect.system.dot = statusEffect.system.dot;
         if ( statusEffect.statuses ) {
           for ( const s of statusEffect.statuses ) statuses.add(s);
         }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1253,6 +1253,39 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Get all equipped weapons which fulfil the requirements for this action, optionally excluding those which are
+   * valid generally, but are not currently due to a lack of resource or being unloaded
+   * @param {boolean} [strict] If true, will not return items which cannot be used due to some transient condition
+   * @returns {{item: CrucibleWeaponItem, label: string}[]}
+   */
+  getValidWeaponChoices(strict=false) {
+    const choices = [];
+    if ( !["strike", "reload"].some(t => this.tags.has(t)) ) return choices;
+    const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
+    const isValidChoice = weapon => {
+      if ( this.tags.has("ranged") && (!weapon.config.category.ranged || (strict && weapon.system.needsReload)) ) return false;
+      if ( this.tags.has("melee") && weapon.config.category.ranged ) return false;
+      if ( this.tags.has("reload") && !weapon.system.needsReload ) return false;
+      return !strict || (this.cost.action + weapon.system.actionCost <= this.actor.resources.action.value);
+    };
+    const isNatural = this.tags.has("natural");
+    if ( mh && !isNatural && isValidChoice(mh) ) {
+      choices.push({item: mh, id: mh.id || "mainhandUnarmed", label: `${mh.name} (${SYSTEM.WEAPON.SLOTS.labels.MAINHAND})`});
+    }
+    if ( oh && !isNatural && isValidChoice(oh) ) {
+      choices.push({item: oh, id: oh.id || "offhandUnarmed", label: `${oh.name} (${SYSTEM.WEAPON.SLOTS.labels.OFFHAND})`});
+    }
+    if ( !this.tags.has("ranged") ) {
+      for ( const n of natural ) {
+        choices.push({item: n, id: n.id, label: `${n.name} (${SYSTEM.WEAPON.PROPERTIES.natural.label})`});
+      }
+    }
+    return choices;
+  }
+
+  /* -------------------------------------------- */
   /*  Action Lifecycle Methods                    */
   /* -------------------------------------------- */
 
@@ -1683,8 +1716,8 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const original = this.actor.actions[this.id];
     if ( !original ) return false;
     const {cost, tags} = original._source;
-    if ( !cost.weapon ) return false;
-    if ( ["mainhand", "offhand", "twohand", "natural"].some(t => tags.includes(t)) ) return false;
+    if ( !(cost.weapon || tags.includes("reload")) ) return false;
+    if ( ["mainhand", "offhand", "twohand"].some(t => tags.includes(t)) ) return false;
     return this.actor?.equipment.weapons.hasChoice;
   }
 

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1257,19 +1257,20 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
   /**
    * Get all equipped weapons which fulfil the requirements for this action, optionally excluding those which are
    * valid generally, but are not currently due to a lack of resource or being unloaded
-   * @param {boolean} [strict] If true, will not return items which cannot be used due to some transient condition
+   * @param {object} [options]              Additional options
+   * @param {boolean} [options.strict]      Whether to filter out items which can't be used due to a transient condition
+   * @param {number|null} [options.maxCost] If provided, filter out weapons with greater action cost
    * @returns {{item: CrucibleWeaponItem, label: string}[]}
    */
-  getValidWeaponChoices(strict=false) {
+  getValidWeaponChoices({strict=false, maxCost=null}={}) {
     const choices = [];
     if ( !["strike", "reload"].some(t => this.tags.has(t)) ) return choices;
     const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
-    const trueCost = this.cost.action - (this.usage.weapon ? this.usage.weapon.system.actionCost : 0);
     const isValidChoice = weapon => {
       if ( this.tags.has("reload") ) return weapon.system.needsReload;
       let isValid = this.tags.has("ranged") && weapon.config.category.ranged && !(strict && weapon.system.needsReload);
       isValid ||= this.tags.has("melee") && !weapon.config.category.ranged;
-      if ( strict ) isValid &&= trueCost + weapon.system.actionCost <= this.actor.resources.action.value;
+      if ( maxCost !== null ) isValid &&= weapon.system.actionCost <= maxCost;
       return isValid;
     };
     const isNatural = this.tags.has("natural");

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1264,11 +1264,12 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const choices = [];
     if ( !["strike", "reload"].some(t => this.tags.has(t)) ) return choices;
     const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
+    const trueCost = this.cost.action - (this.usage.weapon ? this.usage.weapon.system.actionCost : 0);
     const isValidChoice = weapon => {
       if ( this.tags.has("ranged") && (!weapon.config.category.ranged || (strict && weapon.system.needsReload)) ) return false;
       if ( this.tags.has("melee") && weapon.config.category.ranged ) return false;
-      if ( this.tags.has("reload") && !weapon.system.needsReload ) return false;
-      return !strict || (this.cost.action + weapon.system.actionCost <= this.actor.resources.action.value);
+      if ( this.tags.has("reload") ) return weapon.system.needsReload;
+      return !strict || (trueCost + weapon.system.actionCost <= this.actor.resources.action.value);
     };
     const isNatural = this.tags.has("natural");
     if ( mh && !isNatural && isValidChoice(mh) ) {

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1266,10 +1266,11 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
     const trueCost = this.cost.action - (this.usage.weapon ? this.usage.weapon.system.actionCost : 0);
     const isValidChoice = weapon => {
-      if ( this.tags.has("ranged") && (!weapon.config.category.ranged || (strict && weapon.system.needsReload)) ) return false;
-      if ( this.tags.has("melee") && weapon.config.category.ranged ) return false;
       if ( this.tags.has("reload") ) return weapon.system.needsReload;
-      return !strict || (trueCost + weapon.system.actionCost <= this.actor.resources.action.value);
+      let isValid = this.tags.has("ranged") && weapon.config.category.ranged && !(strict && weapon.system.needsReload);
+      isValid ||= this.tags.has("melee") && !weapon.config.category.ranged;
+      if ( strict ) isValid &&= trueCost + weapon.system.actionCost <= this.actor.resources.action.value;
+      return isValid;
     };
     const isNatural = this.tags.has("natural");
     if ( mh && !isNatural && isValidChoice(mh) ) {

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -849,7 +849,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     rs.heroism.base = p.heroismMax;
 
     // Initialize bonuses for each resource
-    for ( const r of Object.values(rs) ) r.bonus = 0;
+    for ( const r of Object.values(rs) ) r.bonus ??= 0;
   }
 
   /* -------------------------------------------- */
@@ -1059,7 +1059,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
           if ( !w.reload ) continue;
           break;
         case "throwWeapon":
-          if ( !(w.mainhand?.system.canThrow() || w.offhand?.system.canThrow()) ) continue;
+          if ( !(w.mainhand?.system.canThrow || w.offhand?.system.canThrow) ) continue;
           break;
       }
 

--- a/module/models/item-weapon.mjs
+++ b/module/models/item-weapon.mjs
@@ -201,12 +201,22 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
 
   /**
    * Can this weapon be thrown?
-   * @returns {boolean}
+   * @type {boolean}
    */
-  canThrow() {
+  get canThrow() {
     const category = this.config.category;
     if ( (category.id === "unarmed") || category.ranged || this.properties.has("natural") ) return false;
     return true;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does this weapon require reloading before it can be used?
+   * @type {boolean}
+   */
+  get needsReload() {
+    return this.config.category.reload && !this.loaded;
   }
 
   /* -------------------------------------------- */
@@ -275,7 +285,7 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
 
     // Damage and Range
     tags.damage = game.i18n.format("ITEM.PROPERTIES.Damage", {damage: this.damage.weapon});
-    if ( this.config.category.reload && !this.loaded ) tags.damage = game.i18n.localize("WEAPON.TAGS.Reload");
+    if ( this.needsReload ) tags.damage = game.i18n.localize("WEAPON.TAGS.Reload");
     tags.range = game.i18n.format("ITEM.PROPERTIES.Range", {range: this.range});
 
     // Weapon Properties

--- a/module/models/spell-action.mjs
+++ b/module/models/spell-action.mjs
@@ -122,7 +122,7 @@ export default class CrucibleSpellAction extends CrucibleAction {
     this.scaling = [this.rune.scaling, this.gesture.scaling];
     this.training = [this.rune.id];
     this.damage = CrucibleSpellAction.#prepareDamage.call(this);
-    this.usage.defenseType ||= CrucibleSpellAction.#prepareDefense.call(this);
+    this.usage.defenseType = CrucibleSpellAction.#prepareDefense.call(this);
 
     // Composed Spells Only
     if ( this.isComposed ) {

--- a/templates/dice/action-use-dialog.hbs
+++ b/templates/dice/action-use-dialog.hbs
@@ -4,7 +4,7 @@
     </div>
 
     {{#if weaponChoice}}
-    {{formGroup weaponChoice.field value=weaponChoice.value}}
+    {{formGroup weaponChoice.field value=weaponChoice.value valueAttr="id"}}
     {{/if}}
 
     {{#if hasDice}}


### PR DESCRIPTION
Closes #702, Closes #701
Changes:
- When `usage.weapon` is set in `prepare`, it will only be set to a weapon which would cause `_canUse` to throw if there are no valid options
- Moved the setting of `system.loaded` to a `strike` hook instead of `ranged`, as some action (like Offhand Strike) would otherwise not be updating reloadable weapons' loaded status
- When doing a `natural`-tagged action, if multiple natural weapons are equipped, can choose which to attack with
- When using a `reload`-tagged action, if multiple unloaded weapons are equipped, can choose which to reload
- Choosing a different weapon in the action use dialog will now update the display of ability/enchantment/skill
- Also fixed `#prepareBaseResources` so that AEs can target `bonus` again

There's definitely room for further refinement - right now one can select, for instance, a Talisman to perform a ranged strike with, or a hand crossbow to try to Refocus with (the latter will yell, and it's better than before where sometimes you couldn't refocus at all, but still).