### PR TITLE
Fixed implementation of Strong Grip to better align with the description

### DIFF
--- a/_source/talent/Strong_Grip_stronggrip000000.yml
+++ b/_source/talent/Strong_Grip_stronggrip000000.yml
@@ -6,8 +6,8 @@ system:
   node: str0a
   description: >-
     Your grasp of your weaponry is firm and unyielding. You can perform Actions
-    which require a free hand while wielding a two-handed weapon. Attempts to
-    Disarm you are made with +2 Banes.
+    which require a free hand while wielding a two-handed melee weapon. Attempts
+    to Disarm you are made with +2 Banes.
   actions: []
   requirements: {}
 effects: []

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -676,7 +676,15 @@ HOOKS.strikefirst00000 = {
 
 HOOKS.stronggrip000000 = {
   prepareAction(_item, action) {
-    if ( this.equipment.weapons.twoHanded ) action.usage.availableHands += 1;
+    const isTwoHanded = this.equipment.weapons.twoHanded;
+    const isMelee = !this.equipment.weapons.ranged;
+    if ( isTwoHanded && isMelee ) action.usage.availableHands += 1;
+  },
+  defendAttack(item, action, _origin, rollData) {
+    const isDisarm = action.tags.has("disarm");
+    const isTwoHanded = this.equipment.weapons.twoHanded;
+    const isMelee = !this.equipment.weapons.ranged;
+    if ( isDisarm && isTwoHanded && isMelee ) rollData.banes.strongGrip = {label: item.name, number: 2};
   }
 };
 


### PR DESCRIPTION
Part of #659.

Using `!ranged` to detect melee is weird but lots of things are marked melee. Should I check the weapon category instead or was there something else I've missed somewhere already?