### PR TITLE
hide request rolls for players on standard check dialog

### DIFF
--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -131,7 +131,7 @@ export default class StandardCheckDialog extends DialogV2 {
       {type: "button", action: "requestClear", cssClass: "icon fa-solid fa-ban", tooltip: _loc("DICE.REQUESTS.ClearRequest")},
       {type: "button", action: "requestParty", cssClass: "icon fa-solid fa-users", tooltip: _loc("DICE.REQUESTS.AddParty")}
     );
-    else buttons.push({type: "button", action: "requestToggle", cssClass: "icon fa-solid fa-chevrons-right", tooltip: _loc("DICE.REQUESTS.RequestRolls")});
+    else if ( game.user.isGM )buttons.push({type: "button", action: "requestToggle", cssClass: "icon fa-solid fa-chevrons-right", tooltip: _loc("DICE.REQUESTS.RequestRolls")});
     return buttons;
   }
 


### PR DESCRIPTION
Currently players can also see the roll request button in the standard dialog.
They probably shouldnt and also the button does currently nothing for players

<img width="400" height="500" alt="grafik" src="https://github.com/user-attachments/assets/752d315c-2931-46e3-b402-70e0d5d144ab" />

Fixes #724 