### PR TITLE
[#431] Add embedded behavior for physical items & iconic spells

### DIFF
--- a/module/models/item-physical.mjs
+++ b/module/models/item-physical.mjs
@@ -203,4 +203,23 @@ export default class CruciblePhysicalItem extends foundry.abstract.TypeDataModel
       actions: await item.prepareActionsContext()
     });
   }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async toEmbed(config, _options) {
+    const container = document.createElement("section");
+
+    // Description only
+    if ( config.values.includes("description") ) {
+      container.innerHTML = await CONFIG.ux.TextEditor.enrichHTML(this.description.public);
+      return container;
+    }
+
+    // Embedded Item card
+    container.classList = "crucible item-embed";
+    container.innerHTML = await this.renderCard();
+    if ( config.values.includes("centered") ) container.firstElementChild.classList.add("centered");
+    return container;
+  }
 }

--- a/module/models/item-spell.mjs
+++ b/module/models/item-spell.mjs
@@ -194,4 +194,23 @@ export default class CrucibleSpellItem extends foundry.abstract.TypeDataModel {
       prerequisites: [...runeReqs, ...gestureReqs, ...inflectionReqs]
     });
   }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async toEmbed(config, _options) {
+    const container = document.createElement("section");
+
+    // Description only
+    if ( config.values.includes("description") ) {
+      container.innerHTML = await CONFIG.ux.TextEditor.enrichHTML(this.description);
+      return container;
+    }
+
+    // Embedded Talent card
+    container.classList = "crucible item-embed";
+    container.innerHTML = await this.renderCard();
+    if ( config.values.includes("centered") ) container.firstElementChild.classList.add("centered");
+    return container;
+  }
 }


### PR DESCRIPTION
Closes #431 
Only item types without specific embedded behavior are the background item types, and those don't have tooltip cards currently. The code is the same as in `item-talent.mjs`, except for physical items where description is split into private/public. Probably some room for deduplication there, but not sure it's necessary.