### PR TITLE
Ensure we allow for 0-`turnNumber`-having combatants

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -38,7 +38,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
     const effectUpdate = {};
     const combat = this.start.combat;
     const combatant = combat.getCombatantsByActor(this.parent)[0];
-    if ( combatant?.turnNumber ) {
+    if ( combatant && (combatant.turnNumber !== null) ) {
       effectUpdate.start = {combatant: combatant.id};
       const {units, value, expiry} = this.duration;
       if ( (units === "rounds") && ["turnStart", "turnEnd"].includes(expiry) ) {


### PR DESCRIPTION
We were accidentally catching the first combatant in turn order and not replacing their effects' `start.combatant` or adjusting duration appropriately.