### PR TITLE
i18n restructure v2

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,21 +1,23 @@
 {
-  "ABILITIES.Dexterity": "Dexterity",
-  "ABILITIES.DexterityAbbr": "Dex",
-  "ABILITIES.GROUPS": {
-    "Power": "Power",
-    "Resilience": "Resilience",
-    "Speed": "Speed"
+  "ABILITIES": {
+    "GROUPS": {
+      "Power": "Power",
+      "Resilience": "Resilience",
+      "Speed": "Speed"
+    },
+    "Dexterity": "Dexterity",
+    "DexterityAbbr": "Dex",
+    "Intellect": "Intellect",
+    "IntellectAbbr": "Int",
+    "Presence": "Presence",
+    "PresenceAbbr": "Pre",
+    "Strength": "Strength",
+    "StrengthAbbr": "Str",
+    "Toughness": "Toughness",
+    "ToughnessAbbr": "Tou",
+    "Wisdom": "Wisdom",
+    "WisdomAbbr": "Wis"
   },
-  "ABILITIES.Intellect": "Intellect",
-  "ABILITIES.IntellectAbbr": "Int",
-  "ABILITIES.Presence": "Presence",
-  "ABILITIES.PresenceAbbr": "Pre",
-  "ABILITIES.Strength": "Strength",
-  "ABILITIES.StrengthAbbr": "Str",
-  "ABILITIES.Toughness": "Toughness",
-  "ABILITIES.ToughnessAbbr": "Tou",
-  "ABILITIES.Wisdom": "Wisdom",
-  "ABILITIES.WisdomAbbr": "Wis",
   "ACCESSORY": {
     "CATEGORIES": {
       "Clothing": "Clothing",
@@ -25,6 +27,12 @@
     }
   },
   "ACTION": {
+    "ACTIONS": {
+      "AddFavorite": "Add Favorite",
+      "Delete": "Delete Action: {name}",
+      "DeleteConfirm": "Are you sure you wish to delete the <strong>{name}</strong> action from the <strong>{parent}</strong> {type}?",
+      "RemoveFavorite": "Remove Favorite"
+    },
     "DEFAULT_ACTIONS": {
       "Cast": {
         "Description": "Weave arcana to create a work of spellcraft.",
@@ -75,6 +83,10 @@
       "Custom": "Custom",
       "Failure": "Failure",
       "Success": "Success"
+    },
+    "EFFECTS": {
+      "Add": "Add Effect",
+      "Delete": "Remove Effect"
     },
     "FIELDS": {
       "actionHooks": {
@@ -213,6 +225,140 @@
       "Target": "Target",
       "Usage": "Usage"
     },
+    "TAG": {
+      "Accurate": "Accurate",
+      "AccurateTooltip": "This action is particularly accurate. You gain 2 additional Boons when performing the action.",
+      "AfterStrike": "After Strike",
+      "AfterStrikeTooltip": "This action may only be performed immediately after a basic Strike attack which did not critically miss.",
+      "Auditory": "Auditory",
+      "AuditoryTooltip": "This action requires its targets to be able to hear to be affected.",
+      "Brute": "Brute",
+      "BruteTooltip": "This action involves the application of brute force and requires a weapon which scales using Strength.",
+      "Composed": "Composed Spell",
+      "ComposedTooltip": "This action is a composed spell.",
+      "Consume": "Consume",
+      "ConsumeTooltip": "This action involves and requires consumption of a specific consumable item",
+      "CostAction": "{action}A",
+      "CostFocus": "{focus}F",
+      "CostHand.one": "{hands} Hand",
+      "CostHand.other": "{hands} Hands",
+      "CostHealth": "{health}HP",
+      "CostHeroism": "{heroism}H",
+      "CostTooltip": "The Action Point or Focus Point cost of using this action.",
+      "CostWeapon": "W",
+      "CostWeaponAction": "W{action}A",
+      "Deadly": "Deadly",
+      "DeadlyTooltip": "This action has the potential to deal a tremendous amount of damage, increasing the damage multiplier for any damage dealt by x1.",
+      "Difficult": "Difficult",
+      "DifficultTooltip": "This action is complicated or challenging to perform. You incur 2 additional banes when attempting the action.",
+      "Disarm": "Disarm",
+      "DisarmTooltip": "This action, if successful, causes the target's weapon to be dropped.",
+      "DualWield": "Dual Wield",
+      "DualWieldTooltip": "This action requires wielding two separate weapons or being entirely unarmed to perform.",
+      "Empowered": "Empowered",
+      "EmpoweredTooltip": "This action is powerful and deals additional damage, gaining a +2 damage bonus if successful.",
+      "Finesse": "Finesse",
+      "FinesseTooltip": "This action requires a certain amount of finesse to perform. You must be wielding a weapon which scales using Dexterity.",
+      "Flanking": "Flanking",
+      "FlankingTooltip": "This action may only be performed against a flanked or unaware target.",
+      "Generic": "Generic",
+      "GenericTooltip": "Actions which perform a generic attack without using a specific spell or weapon.",
+      "Harmless": "Harmless",
+      "HarmlessTooltip": "This action does not impose a directly harmful effect, its damage multiplier is zero.",
+      "Healing": "Healing",
+      "HealingTooltip": "This action provides restoration by testing an ally's Wounds threshold.",
+      "IconicSpell": "Iconic Spell",
+      "IconicSpellTooltip": "This action is an Iconic Spell learned through mastery of its components.",
+      "MainHand": "Main-Hand",
+      "MainHandTooltip": "This action utilizes your main-hand weapon to make an attack.",
+      "Maintained": "Maintained",
+      "MaintainedTooltip": "This action can be maintained, incurring its focus cost at the start of your turns.",
+      "Mechanical": "Mechanical",
+      "MechanicalTooltip": "This action requires use of a mechanical weapon.",
+      "Melee": "Melee",
+      "MeleeTooltip": "This action requires wielding a melee weapon or being unarmed to perform.",
+      "Movement": "Movement",
+      "MovementBlink": "Blink",
+      "MovementBlinkTooltip": "This action requires the actor to teleport as part of its movement.",
+      "MovementBurrow": "Burrow",
+      "MovementBurrowTooltip": "This action requires the actor to burrow as part of its movement.",
+      "MovementClimb": "Climb",
+      "MovementClimbTooltip": "This action requires the actor to climb as part of its movement.",
+      "MovementCrawl": "Crawl",
+      "MovementCrawlTooltip": "This action requires the actor to crawl as part of its movement.",
+      "MovementFly": "Fly",
+      "MovementFlyTooltip": "This action requires the actor to fly as part of its movement.",
+      "MovementJump": "Jump",
+      "MovementJumpTooltip": "This action requires the actor to jump as part of its movement.",
+      "MovementStep": "Step",
+      "MovementStepTooltip": "This action requires the actor to use a careful step as part of its movement.",
+      "MovementSwim": "Swim",
+      "MovementSwimTooltip": "This action requires the actor to swim as part of its movement.",
+      "MovementTooltip": "This action allows you to move as part of its activation, including a reduced action point cost for a free movement action per round.",
+      "MovementWalk": "Walk",
+      "MovementWalkTooltip": "This action requires the actor to walk as part of its movement.",
+      "Natural": "Natural Attack",
+      "NaturalTooltip": "This action involves performing a natural weapon attack.",
+      "NonCombat": "Non-Combat",
+      "NonCombatTooltip": "Actions which can only be performed outside of a Combat encounter.",
+      "OffHand": "Off-Hand",
+      "OffHandTooltip": "This action utilizes your off-hand weapon to make an attack.",
+      "OneHand": "One-Handed",
+      "OneHandTooltip": "This action requires wielding a one-handed weapon.",
+      "Projectile": "Projectile",
+      "ProjectileTooltip": "This action requires use of a projectile weapon.",
+      "Rallying": "Rallying",
+      "RallyingTooltip": "This action provides restoration by testing an ally's Madness threshold.",
+      "Ranged": "Ranged",
+      "RangedTooltip": "This action requires wielding a ranged weapon to perform.",
+      "Reaction": "Reaction",
+      "ReactionTooltip": "This action can only be performed during some other creature's turn when its activation condition is met.",
+      "Reload": "Reload",
+      "ReloadTooltip": "This action reloads a ranged weapon which requires reloading.",
+      "Severe": "Severe",
+      "SevereTooltip": "If the target of this action has Wounds and Madness resources, this action damages those resources directly regardless of their Health or Morale.",
+      "Shield": "Shield",
+      "ShieldTooltip": "This action requires wielding a shield to perform.",
+      "Skill": "Skill",
+      "SkillTooltip": "This action involves a targeted or opposed Skill check.",
+      "Spell": "Spell",
+      "SpellTooltip": "This action involves spellcraft.",
+      "Summon": "Summon",
+      "SummonTooltip": "This action summons, calls, or otherwise creates a combatant which joins the encounter.",
+      "TargetTooltip": "The target type, distance, and number which applies to this action.",
+      "Thrown": "Thrown",
+      "ThrownTooltip": "This action involves performing a thrown weapon attack.",
+      "TwoHanded": "Two-Handed",
+      "TwoHandedTooltip": "This action requires wielding a two-handed weapon to perform.",
+      "Unarmed": "Unarmed",
+      "UnarmedTooltip": "This action requires you to be fully unarmed in order to perform.",
+      "Unarmored": "Unarmored",
+      "UnarmoredTooltip": "This action requires you to be unarmored in order to perform.",
+      "Vocal": "Vocal",
+      "VocalTooltip": "This action requires its user to speak or otherwise vocalize sound.",
+      "Weakened": "Weakened",
+      "WeakenedTooltip": "This action is weaker than normal attacks and has a -2 damage bonus."
+    },
+    "TAG_CATEGORIES": {
+      "Attack": "Attack",
+      "Context": "Context",
+      "Damage": "Damage",
+      "Defenses": "Defenses",
+      "Modifiers": "Modifiers",
+      "Movement": "Movement",
+      "Requirements": "Requirements",
+      "Resources": "Resources",
+      "Scaling": "Scaling",
+      "Skills": "Skills",
+      "Special": "Special",
+      "Spellcraft": "Spellcraft"
+    },
+    "TAGS": {
+      "Action": "Action Tags",
+      "Activation": "Activation Tags",
+      "Context": "Context Tags",
+      "TargetLimit": "Limit {limit}"
+    },
     "TARGET_SCOPES": {
       "All": "All",
       "Allies": "Allies",
@@ -232,201 +378,61 @@
       "Single": "Single",
       "Summon": "Summon",
       "Wall": "Wall"
-    }
+    },
+    "WARNINGS": {
+      "CannotAffordCost": "{name} has insufficient {resource} to use {action}!",
+      "CannotAffordHands.one": "{name} must have {hands} free hand to use {action}!",
+      "CannotAffordHands.other": "{name} must have {hands} free hands to use {action}!",
+      "CannotAffordMove": "{name} has insufficient action to move this distance which requires {cost}A!",
+      "CannotSpendAction": "{name} cannot spend Action because they are Incapacitated!",
+      "CannotSpendFocus": "{name} cannot spend Focus because they are currently {status}!",
+      "CannotTargetSelf": "You cannot target yourself with this Action!",
+      "CannotUse": "{name} does not satisfy the prerequisites to use {action}: {reason}",
+      "DirectMovementOnly": "This action requires a direct movement path with no intermediate waypoints.",
+      "IncorrectTargets": "You may only designate up to {number} {type} targets for {action}!",
+      "InvalidTarget": "You must designate at least one {type} target for {action}!",
+      "MaximumRange": "A selected target is further than the maximum range of {max} feet.",
+      "MinimumRange": "A selected target is closer than the minimum range of {min} feet.",
+      "MisconfiguredSummon": "The action {action} does not have a properly configured Summon target.",
+      "MovementTooFar": "The planned movement path exceeds the maximum range allowed by this action.",
+      "MovementTooShort": "The planned movement path does not meet the minimum range required by this action.",
+      "NoAbility": "{actor} has no {ability} score, and therefore cannot use {action}.",
+      "RequireTemplate": "You must place a Measured Template to indicate the area of effect of {action}.",
+      "Silenced": "You cannot use this action while Silenced.",
+      "UnimplementedTarget": "Automation for target type {type} for action {name} is not yet supported, you must manually target affected tokens.",
+      "WrongMovementToken": "You must move the token performing this action."
+    },
+    "Action": "Action",
+    "AffectsScope": "Affects {scope}",
+    "AllResult": "{existing} (All)",
+    "Condition": "Condition",
+    "Confirmed": "Confirmed",
+    "DelayHint": "Choose an initiative value between 1 and {maximum} when you wish to act.",
+    "DelayLabel": "Delayed Initiative",
+    "DelayTitle": "Delay Turn",
+    "DurationRounds": "{value}R",
+    "DurationSeconds": "{value}S",
+    "DurationUntilEnded": "Until Ended",
+    "EffectSpecific": "Effect: {effect}",
+    "NoTargets": "No Targets",
+    "Overview": "Action Overview",
+    "PlanMovement": "Plan Movement",
+    "PlannedMovement": "Movement Planned",
+    "PlannedRegion": "Region Placed",
+    "PlanRegion": "Place Region",
+    "RemoveActor": "Remove Actor",
+    "RequestActorsHint": "Drag individual Actors or groups here to request they participate in this roll.",
+    "RequestedActors": "Requested Actors",
+    "RequestRollsSuffix": "{label}: Request Rolls",
+    "RequiresMovement": "You must plan a movement path before this action can be used.",
+    "RequiresRegion": "You must place a Region before this action can be used.",
+    "SkillCheck": "{skill} Skill Check",
+    "StandardCheck": "Standard Check",
+    "Targets": "Targets",
+    "TemplateTargets": "Template Targets",
+    "Unconfirmed": "Unconfirmed",
+    "UseAction": "Use Action"
   },
-  "ACTION.Action": "Action",
-  "ACTION.ACTIONS": {
-    "AddFavorite": "Add Favorite",
-    "Delete": "Delete Action: {name}",
-    "DeleteConfirm": "Are you sure you wish to delete the <strong>{name}</strong> action from the <strong>{parent}</strong> {type}?",
-    "RemoveFavorite": "Remove Favorite"
-  },
-  "ACTION.AffectsScope": "Affects {scope}",
-  "ACTION.AllResult": "{existing} (All)",
-  "ACTION.Condition": "Condition",
-  "ACTION.Confirmed": "Confirmed",
-  "ACTION.DelayHint": "Choose an initiative value between 1 and {maximum} when you wish to act.",
-  "ACTION.DelayLabel": "Delayed Initiative",
-  "ACTION.DelayTitle": "Delay Turn",
-  "ACTION.DurationRounds": "{value}R",
-  "ACTION.DurationSeconds": "{value}S",
-  "ACTION.DurationUntilEnded": "Until Ended",
-  "ACTION.EFFECTS": {
-    "Add": "Add Effect",
-    "Delete": "Remove Effect"
-  },
-  "ACTION.EffectSpecific": "Effect: {effect}",
-  "ACTION.NoTargets": "No Targets",
-  "ACTION.Overview": "Action Overview",
-  "ACTION.PlanMovement": "Plan Movement",
-  "ACTION.PlannedMovement": "Movement Planned",
-  "ACTION.PlannedRegion": "Region Placed",
-  "ACTION.PlanRegion": "Place Region",
-  "ACTION.RemoveActor": "Remove Actor",
-  "ACTION.RequestActorsHint": "Drag individual Actors or groups here to request they participate in this roll.",
-  "ACTION.RequestedActors": "Requested Actors",
-  "ACTION.RequestRollsSuffix": "{label}: Request Rolls",
-  "ACTION.RequiresMovement": "You must plan a movement path before this action can be used.",
-  "ACTION.RequiresRegion": "You must place a Region before this action can be used.",
-  "ACTION.SkillCheck": "{skill} Skill Check",
-  "ACTION.StandardCheck": "Standard Check",
-  "ACTION.TAG_CATEGORIES": {
-    "Attack": "Attack",
-    "Context": "Context",
-    "Damage": "Damage",
-    "Defenses": "Defenses",
-    "Modifiers": "Modifiers",
-    "Movement": "Movement",
-    "Requirements": "Requirements",
-    "Resources": "Resources",
-    "Scaling": "Scaling",
-    "Skills": "Skills",
-    "Special": "Special",
-    "Spellcraft": "Spellcraft"
-  },
-  "ACTION.TagAccurate": "Accurate",
-  "ACTION.TagAccurateTooltip": "This action is particularly accurate. You gain 2 additional Boons when performing the action.",
-  "ACTION.TagAfterStrike": "After Strike",
-  "ACTION.TagAfterStrikeTooltip": "This action may only be performed immediately after a basic Strike attack which did not critically miss.",
-  "ACTION.TagAuditory": "Auditory",
-  "ACTION.TagAuditoryTooltip": "This action requires its targets to be able to hear to be affected.",
-  "ACTION.TagBrute": "Brute",
-  "ACTION.TagBruteTooltip": "This action involves the application of brute force and requires a weapon which scales using Strength.",
-  "ACTION.TagComposed": "Composed Spell",
-  "ACTION.TagComposedTooltip": "This action is a composed spell.",
-  "ACTION.TagConsume": "Consume",
-  "ACTION.TagConsumeTooltip": "This action involves and requires consumption of a specific consumable item",
-  "ACTION.TagCostAction": "{action}A",
-  "ACTION.TagCostFocus": "{focus}F",
-  "ACTION.TagCostHand.one": "{hands} Hand",
-  "ACTION.TagCostHand.other": "{hands} Hands",
-  "ACTION.TagCostHealth": "{health}HP",
-  "ACTION.TagCostHeroism": "{heroism}H",
-  "ACTION.TagCostTooltip": "The Action Point or Focus Point cost of using this action.",
-  "ACTION.TagCostWeapon": "W",
-  "ACTION.TagCostWeaponAction": "W{action}A",
-  "ACTION.TagDeadly": "Deadly",
-  "ACTION.TagDeadlyTooltip": "This action has the potential to deal a tremendous amount of damage, increasing the damage multiplier for any damage dealt by x1.",
-  "ACTION.TagDifficult": "Difficult",
-  "ACTION.TagDifficultTooltip": "This action is complicated or challenging to perform. You incur 2 additional banes when attempting the action.",
-  "ACTION.TagDisarm": "Disarm",
-  "ACTION.TagDisarmTooltip": "This action, if successful, causes the target's weapon to be dropped.",
-  "ACTION.TagDualWield": "Dual Wield",
-  "ACTION.TagDualWieldTooltip": "This action requires wielding two separate weapons or being entirely unarmed to perform.",
-  "ACTION.TagEmpowered": "Empowered",
-  "ACTION.TagEmpoweredTooltip": "This action is powerful and deals additional damage, gaining a +2 damage bonus if successful.",
-  "ACTION.TagFinesse": "Finesse",
-  "ACTION.TagFinesseTooltip": "This action requires a certain amount of finesse to perform. You must be wielding a weapon which scales using Dexterity.",
-  "ACTION.TagFlanking": "Flanking",
-  "ACTION.TagFlankingTooltip": "This action may only be performed against a flanked or unaware target.",
-  "ACTION.TagGeneric": "Generic",
-  "ACTION.TagGenericTooltip": "Actions which perform a generic attack without using a specific spell or weapon.",
-  "ACTION.TagHarmless": "Harmless",
-  "ACTION.TagHarmlessTooltip": "This action does not impose a directly harmful effect, its damage multiplier is zero.",
-  "ACTION.TagHealing": "Healing",
-  "ACTION.TagHealingTooltip": "This action provides restoration by testing an ally's Wounds threshold.",
-  "ACTION.TagIconicSpell": "Iconic Spell",
-  "ACTION.TagIconicSpellTooltip": "This action is an Iconic Spell learned through mastery of its components.",
-  "ACTION.TagMainHand": "Main-Hand",
-  "ACTION.TagMainHandTooltip": "This action utilizes your main-hand weapon to make an attack.",
-  "ACTION.TagMaintained": "Maintained",
-  "ACTION.TagMaintainedTooltip": "This action can be maintained, incurring its focus cost at the start of your turns.",
-  "ACTION.TagMechanical": "Mechanical",
-  "ACTION.TagMechanicalTooltip": "This action requires use of a mechanical weapon.",
-  "ACTION.TagMelee": "Melee",
-  "ACTION.TagMeleeTooltip": "This action requires wielding a melee weapon or being unarmed to perform.",
-  "ACTION.TagMovement": "Movement",
-  "ACTION.TagMovementBlink": "Blink",
-  "ACTION.TagMovementBlinkTooltip": "This action requires the actor to teleport as part of its movement.",
-  "ACTION.TagMovementBurrow": "Burrow",
-  "ACTION.TagMovementBurrowTooltip": "This action requires the actor to burrow as part of its movement.",
-  "ACTION.TagMovementClimb": "Climb",
-  "ACTION.TagMovementClimbTooltip": "This action requires the actor to climb as part of its movement.",
-  "ACTION.TagMovementCrawl": "Crawl",
-  "ACTION.TagMovementCrawlTooltip": "This action requires the actor to crawl as part of its movement.",
-  "ACTION.TagMovementFly": "Fly",
-  "ACTION.TagMovementFlyTooltip": "This action requires the actor to fly as part of its movement.",
-  "ACTION.TagMovementJump": "Jump",
-  "ACTION.TagMovementJumpTooltip": "This action requires the actor to jump as part of its movement.",
-  "ACTION.TagMovementStep": "Step",
-  "ACTION.TagMovementStepTooltip": "This action requires the actor to use a careful step as part of its movement.",
-  "ACTION.TagMovementSwim": "Swim",
-  "ACTION.TagMovementSwimTooltip": "This action requires the actor to swim as part of its movement.",
-  "ACTION.TagMovementTooltip": "This action allows you to move as part of its activation, including a reduced action point cost for a free movement action per round.",
-  "ACTION.TagMovementWalk": "Walk",
-  "ACTION.TagMovementWalkTooltip": "This action requires the actor to walk as part of its movement.",
-  "ACTION.TagNatural": "Natural Attack",
-  "ACTION.TagNaturalTooltip": "This action involves performing a natural weapon attack.",
-  "ACTION.TagNonCombat": "Non-Combat",
-  "ACTION.TagNonCombatTooltip": "Actions which can only be performed outside of a Combat encounter.",
-  "ACTION.TagOffHand": "Off-Hand",
-  "ACTION.TagOffHandTooltip": "This action utilizes your off-hand weapon to make an attack.",
-  "ACTION.TagOneHand": "One-Handed",
-  "ACTION.TagOneHandTooltip": "This action requires wielding a one-handed weapon.",
-  "ACTION.TagProjectile": "Projectile",
-  "ACTION.TagProjectileTooltip": "This action requires use of a projectile weapon.",
-  "ACTION.TagRallying": "Rallying",
-  "ACTION.TagRallyingTooltip": "This action provides restoration by testing an ally's Madness threshold.",
-  "ACTION.TagRanged": "Ranged",
-  "ACTION.TagRangedTooltip": "This action requires wielding a ranged weapon to perform.",
-  "ACTION.TagReaction": "Reaction",
-  "ACTION.TagReactionTooltip": "This action can only be performed during some other creature's turn when its activation condition is met.",
-  "ACTION.TagReload": "Reload",
-  "ACTION.TagReloadTooltip": "This action reloads a ranged weapon which requires reloading.",
-  "ACTION.TAGS": {
-    "Action": "Action Tags",
-    "Activation": "Activation Tags",
-    "Context": "Context Tags",
-    "TargetLimit": "Limit {limit}"
-  },
-  "ACTION.TagSevere": "Severe",
-  "ACTION.TagSevereTooltip": "If the target of this action has Wounds and Madness resources, this action damages those resources directly regardless of their Health or Morale.",
-  "ACTION.TagShield": "Shield",
-  "ACTION.TagShieldTooltip": "This action requires wielding a shield to perform.",
-  "ACTION.TagSkill": "Skill",
-  "ACTION.TagSkillTooltip": "This action involves a targeted or opposed Skill check.",
-  "ACTION.TagSpell": "Spell",
-  "ACTION.TagSpellTooltip": "This action involves spellcraft.",
-  "ACTION.TagSummon": "Summon",
-  "ACTION.TagSummonTooltip": "This action summons, calls, or otherwise creates a combatant which joins the encounter.",
-  "ACTION.TagTargetTooltip": "The target type, distance, and number which applies to this action.",
-  "ACTION.TagThrown": "Thrown",
-  "ACTION.TagThrownTooltip": "This action involves performing a thrown weapon attack.",
-  "ACTION.TagTwoHanded": "Two-Handed",
-  "ACTION.TagTwoHandedTooltip": "This action requires wielding a two-handed weapon to perform.",
-  "ACTION.TagUnarmed": "Unarmed",
-  "ACTION.TagUnarmedTooltip": "This action requires you to be fully unarmed in order to perform.",
-  "ACTION.TagUnarmored": "Unarmored",
-  "ACTION.TagUnarmoredTooltip": "This action requires you to be unarmored in order to perform.",
-  "ACTION.TagVocal": "Vocal",
-  "ACTION.TagVocalTooltip": "This action requires its user to speak or otherwise vocalize sound.",
-  "ACTION.TagWeakened": "Weakened",
-  "ACTION.TagWeakenedTooltip": "This action is weaker than normal attacks and has a -2 damage bonus.",
-  "ACTION.Targets": "Targets",
-  "ACTION.TemplateTargets": "Template Targets",
-  "ACTION.Unconfirmed": "Unconfirmed",
-  "ACTION.UseAction": "Use Action",
-  "ACTION.WarningCannotAffordCost": "{name} has insufficient {resource} to use {action}!",
-  "ACTION.WarningCannotAffordHands.one": "{name} must have {hands} free hand to use {action}!",
-  "ACTION.WarningCannotAffordHands.other": "{name} must have {hands} free hands to use {action}!",
-  "ACTION.WarningCannotAffordMove": "{name} has insufficient action to move this distance which requires {cost}A!",
-  "ACTION.WarningCannotSpendAction": "{name} cannot spend Action because they are Incapacitated!",
-  "ACTION.WarningCannotSpendFocus": "{name} cannot spend Focus because they are currently {status}!",
-  "ACTION.WarningCannotTargetSelf": "You cannot target yourself with this Action!",
-  "ACTION.WarningCannotUse": "{name} does not satisfy the prerequisites to use {action}: {reason}",
-  "ACTION.WarningDirectMovementOnly": "This action requires a direct movement path with no intermediate waypoints.",
-  "ACTION.WarningIncorrectTargets": "You may only designate up to {number} {type} targets for {action}!",
-  "ACTION.WarningInvalidTarget": "You must designate at least one {type} target for {action}!",
-  "ACTION.WarningMaximumRange": "A selected target is further than the maximum range of {max} feet.",
-  "ACTION.WarningMinimumRange": "A selected target is closer than the minimum range of {min} feet.",
-  "ACTION.WarningMisconfiguredSummon": "The action {action} does not have a properly configured Summon target.",
-  "ACTION.WarningMovementTooFar": "The planned movement path exceeds the maximum range allowed by this action.",
-  "ACTION.WarningMovementTooShort": "The planned movement path does not meet the minimum range required by this action.",
-  "ACTION.WarningNoAbility": "{actor} has no {ability} score, and therefore cannot use {action}.",
-  "ACTION.WarningRequireTemplate": "You must place a Measured Template to indicate the area of effect of {action}.",
-  "ACTION.WarningSilenced": "You cannot use this action while Silenced.",
-  "ACTION.WarningUnimplementedTarget": "Automation for target type {type} for action {name} is not yet supported, you must manually target affected tokens.",
-  "ACTION.WarningWrongMovementToken": "You must move the token performing this action.",
   "ACTIVE_EFFECT": {
     "ACTIONS": {
       "Create": "Create Effect",
@@ -597,6 +603,51 @@
         "label": "Resistances"
       }
     },
+    "GROUP": {
+      "ACTIONS": {
+        "RemoveMember": "Remove Member"
+      },
+      "FIELDS": {
+        "advancement": {
+          "label": "Advancement",
+          "milestones": {
+            "element": {
+              "number.label": "Award Number",
+              "reason.label": "Award Reason",
+              "reason.placeholder": "An optional award reason."
+            },
+            "hint": "A record of milestones that have been earned by this group.",
+            "label": "Milestones Earned"
+          }
+        },
+        "details": {
+          "biography": {
+            "private.label": "Private Biography",
+            "public.label": "Public Biography"
+          }
+        },
+        "members": {
+          "actor.label": "Actor ID",
+          "label": "Group Members",
+          "one": "Member",
+          "other": "Members",
+          "quantity.label": "Actor Quantity"
+        },
+        "movement": {
+          "air.label": "Air Speed",
+          "label": "Movement Speed",
+          "land.label": "Land Speed",
+          "pace.label": "Travel Pace",
+          "water.label": "Water Speed"
+        }
+      },
+      "LABELS": {
+        "cyclePace": "Cycle Pace",
+        "medianLevel": "Median Level",
+        "recover": "Recover",
+        "rest": "Rest"
+      }
+    },
     "LABELS": {
       "Capacity": "Carrying Capacity",
       "Currency": "Currency",
@@ -651,9 +702,6 @@
       }
     },
     "SHEET": {
-      "Abilities": "Abilities",
-      "AbilityPoints": "Ability Points",
-      "Defenses": "Defenses",
       "HEADERS": {
         "ActionsAttack": "Attack Actions",
         "ActionsConsumable": "Consumable Actions",
@@ -667,6 +715,9 @@
         "EffectsSuppressed": "Suppressed Effects",
         "EffectsTemporary": "Temporary Effects"
       },
+      "Abilities": "Abilities",
+      "AbilityPoints": "Ability Points",
+      "Defenses": "Defenses",
       "PointsAvailable": "Available",
       "PointsSpent": "Spent",
       "Resources": "Resources"
@@ -689,67 +740,24 @@
       "OverspentTalent": "Too many Talents have been taken",
       "UnderspentAbility": "Spend Ability Points",
       "UnderspentTalent": "Spend Talent Points"
-    }
-  },
-  "ACTOR.Details": "Details",
-  "ACTOR.GROUP": {
-    "ACTIONS": {
-      "RemoveMember": "Remove Member"
     },
-    "FIELDS": {
-      "advancement": {
-        "label": "Advancement",
-        "milestones": {
-          "element": {
-            "number.label": "Award Number",
-            "reason.label": "Award Reason",
-            "reason.placeholder": "An optional award reason."
-          },
-          "hint": "A record of milestones that have been earned by this group.",
-          "label": "Milestones Earned"
-        }
-      },
-      "details": {
-        "biography": {
-          "private.label": "Private Biography",
-          "public.label": "Public Biography"
-        }
-      },
-      "members": {
-        "actor.label": "Actor ID",
-        "label": "Group Members",
-        "one": "Member",
-        "other": "Members",
-        "quantity.label": "Actor Quantity"
-      },
-      "movement": {
-        "air.label": "Air Speed",
-        "label": "Movement Speed",
-        "land.label": "Land Speed",
-        "pace.label": "Travel Pace",
-        "water.label": "Water Speed"
-      }
-    },
-    "LABELS": {
-      "cyclePace": "Cycle Pace",
-      "medianLevel": "Median Level",
-      "recover": "Recover",
-      "rest": "Rest"
-    }
+    "Details": "Details",
+    "KnowledgeSpecific": "Knowledge: {knowledge}",
+    "LanguageSpecific": "Language: {language}",
+    "LevelSpecific": "Level {level}",
+    "ProgressionRequirements": "Progression Requirements",
+    "ResistanceSpecific": "Resistance: {resistance}",
+    "SizeSpecific": "Size {size}",
+    "StrideSpecific": "Stride {stride}",
+    "VulnerabilitySpecific": "Vulnerability: {vulnerability}"
   },
-  "ACTOR.KnowledgeSpecific": "Knowledge: {knowledge}",
-  "ACTOR.LanguageSpecific": "Language: {language}",
-  "ACTOR.LevelSpecific": "Level {level}",
-  "ACTOR.ProgressionRequirements": "Progression Requirements",
-  "ACTOR.ResistanceSpecific": "Resistance: {resistance}",
-  "ACTOR.SizeSpecific": "Size {size}",
-  "ACTOR.StrideSpecific": "Stride {stride}",
-  "ACTOR.VulnerabilitySpecific": "Vulnerability: {vulnerability}",
-  "ADVANCEMENT.ExpectedLevel": "Expected Level",
-  "ADVANCEMENT.Level": "Level",
-  "ADVANCEMENT.MilestoneAward": "Award Milestones",
-  "ADVANCEMENT.MilestoneTooltip": "{progress} of {required} milestones until next level",
-  "ADVANCEMENT.Progress": "Milestone Progress",
+  "ADVANCEMENT": {
+    "ExpectedLevel": "Expected Level",
+    "Level": "Level",
+    "MilestoneAward": "Award Milestones",
+    "MilestoneTooltip": "{progress} of {required} milestones until next level",
+    "Progress": "Milestone Progress"
+  },
   "ADVERSARY": {
     "THREAT_RANKS": {
       "Boss": "Boss",
@@ -902,19 +910,24 @@
       "Unarmored": "Unarmored"
     }
   },
-  "ATTACK.RESULT_TYPES.Armor": "Armor",
-  "ATTACK.RESULT_TYPES.Block": "Block",
-  "ATTACK.RESULT_TYPES.Dodge": "Dodge",
-  "ATTACK.RESULT_TYPES.Glance": "Glance",
-  "ATTACK.RESULT_TYPES.Hit": "Hit",
-  "ATTACK.RESULT_TYPES.Miss": "Miss",
-  "ATTACK.RESULT_TYPES.Parry": "Parry",
-  "ATTACK.RESULT_TYPES.Resist": "Resist",
-  "ATTRIBUTES.Abilities": "Ability Scores",
-  "ATTRIBUTES.Pools": "Resource Pools",
-  "ATTRIBUTES.Resistances": "Damage Resistances",
+  "ATTACK": {
+    "RESULT_TYPES": {
+      "Armor": "Armor",
+      "Block": "Block",
+      "Dodge": "Dodge",
+      "Glance": "Glance",
+      "Hit": "Hit",
+      "Miss": "Miss",
+      "Parry": "Parry",
+      "Resist": "Resist"
+    }
+  },
+  "ATTRIBUTES": {
+    "Abilities": "Ability Scores",
+    "Pools": "Resource Pools",
+    "Resistances": "Damage Resistances"
+  },
   "AWARD": {
-    "Each": "each",
     "LABELS": {
       "Award": "Award",
       "Revoke": "Revoke"
@@ -932,18 +945,16 @@
       "Revoke": "Revoke Milestones"
     },
     "SUMMARIES": {
-      "Cost": "{award} cost paid by:",
-      "CostSplit": "{award} cost split between:",
-      "Reward": "{award} granted to:",
-      "RewardSplit": "{award} split between:",
       "TABLE": {
         "Formula": "Formula",
         "Label": "Currency",
         "Total": "Total"
-      }
+      },
+      "Cost": "{award} cost paid by:",
+      "CostSplit": "{award} cost split between:",
+      "Reward": "{award} granted to:",
+      "RewardSplit": "{award} split between:"
     },
-    "TitleCost": "Choose Contributor(s)",
-    "TitleReward": "Choose Recipient(s)",
     "TOOLTIPS": {
       "Currency": "Award Currency",
       "Milestone": "Award Milestone(s)"
@@ -952,7 +963,10 @@
       "CannotAfford": "The following actors cannot afford the cost of this enricher: {actors}",
       "InvalidTerms": "Unable to parse {terms} as valid award terms.",
       "RequiresGM": "You must be a Gamemaster to use Award enrichers."
-    }
+    },
+    "Each": "each",
+    "TitleCost": "Choose Contributor(s)",
+    "TitleReward": "Choose Recipient(s)"
   },
   "BACKGROUND": {
     "ERRORS": {
@@ -1043,7 +1057,11 @@
       }
     }
   },
-  "COMBAT.WarningCannotChangeRound": "Only a Gamemaster user may change the Combat round.",
+  "COMBAT": {
+    "WARNINGS": {
+      "CannotChangeRound": "Only a Gamemaster user may change the Combat round."
+    }
+  },
   "CONSUMABLE": {
     "CATEGORIES": {
       "Ammunition": "Ammunition",
@@ -1075,28 +1093,19 @@
       "ConfigureTitle": "Configure Spell Scroll: {name}",
       "NoComponents": "This spell scroll is blank and cannot be read.",
       "ScrollName": "Scroll of {scroll}"
-    }
-  },
-  "CONSUMABLE.USES": {
-    "Of": "of",
-    "TagMax": {
-      "one": "{value} Use",
-      "other": "{value} Uses"
     },
-    "TagPartial": {
-      "one": "{value}/{max} Use",
-      "other": "{value}/{max} Uses"
+    "USES": {
+      "Of": "of",
+      "TagMax.one": "{value} Use",
+      "TagMax.other": "{value} Uses",
+      "TagPartial.one": "{value}/{max} Use",
+      "TagPartial.other": "{value}/{max} Uses"
     }
   },
   "CONTROLS": {
     "VisualizeFlanking": "Visualize Flanking"
   },
   "CRUCIBLE": {
-    "Base": "Base",
-    "Bonus": "Bonus",
-    "Rules": "Crucible Rules",
-    "Scaled": "Scaled",
-    "Scaling": "Scaling",
     "SHEETS": {
       "Adversary": "Crucible Adversary Sheet",
       "Ancestry": "Crucible Ancestry Sheet",
@@ -1114,7 +1123,12 @@
       "Taxonomy": "Crucible Taxonomy Sheet",
       "Tool": "Crucible Tool Sheet",
       "Weapon": "Crucible Weapon Sheet"
-    }
+    },
+    "Base": "Base",
+    "Bonus": "Bonus",
+    "Rules": "Crucible Rules",
+    "Scaled": "Scaled",
+    "Scaling": "Scaling"
   },
   "CURRENCY_DENOMINATIONS": {
     "CP": {
@@ -1134,88 +1148,94 @@
       "label": "Silver Pieces"
     }
   },
-  "DAMAGE.Acid": "Acid",
-  "DAMAGE.Bludgeoning": "Bludgeoning",
-  "DAMAGE.Cold": "Cold",
-  "DAMAGE.Corruption": "Corruption",
-  "DAMAGE.Damage": "Damage",
-  "DAMAGE.Electricity": "Electricity",
-  "DAMAGE.Elemental": "Elemental",
-  "DAMAGE.Fire": "Fire",
-  "DAMAGE.Physical": "Physical",
-  "DAMAGE.Piercing": "Piercing",
-  "DAMAGE.Poison": "Poison",
-  "DAMAGE.Psychic": "Psychic",
-  "DAMAGE.Radiant": "Radiant",
-  "DAMAGE.Restoration": "Restoration",
-  "DAMAGE.Slashing": "Slashing",
-  "DAMAGE.Spiritual": "Spiritual",
-  "DAMAGE.Void": "Void",
-  "DEFENSES.Armor": "Armor",
-  "DEFENSES.Block": "Block",
-  "DEFENSES.Dodge": "Dodge",
-  "DEFENSES.Fortitude": "Fortitude",
-  "DEFENSES.Madness": "Madness",
-  "DEFENSES.Parry": "Parry",
-  "DEFENSES.Physical": "Physical",
-  "DEFENSES.Reflex": "Reflex",
-  "DEFENSES.TOOLTIPS": {
-    "Fortitude": "{base} + ((Strength + Wisdom) / 4)",
-    "Madness": "{base} + (Madness / 10)",
-    "Reflex": "{base} + ((Dexterity + Intellect) / 4)",
-    "Willpower": "{base} + ((Toughness + Presence) / 4)",
-    "Wounds": "{base} + (Wounds / 10)"
+  "DAMAGE": {
+    "Acid": "Acid",
+    "Bludgeoning": "Bludgeoning",
+    "Cold": "Cold",
+    "Corruption": "Corruption",
+    "Damage": "Damage",
+    "Electricity": "Electricity",
+    "Elemental": "Elemental",
+    "Fire": "Fire",
+    "Physical": "Physical",
+    "Piercing": "Piercing",
+    "Poison": "Poison",
+    "Psychic": "Psychic",
+    "Radiant": "Radiant",
+    "Restoration": "Restoration",
+    "Slashing": "Slashing",
+    "Spiritual": "Spiritual",
+    "Void": "Void"
   },
-  "DEFENSES.Willpower": "Willpower",
-  "DEFENSES.Wounds": "Wounds",
-  "DICE.Ability": "Ability",
-  "DICE.AbilityBonus": "Ability Bonus",
-  "DICE.Banes.one": "Bane",
-  "DICE.Banes.other": "Banes",
-  "DICE.Boons.one": "Boon",
-  "DICE.Boons.other": "Boons",
-  "DICE.CircumstanceBonus": "Circumstance Bonus",
-  "DICE.Confirm": "Confirm",
-  "DICE.Damage": "Damage",
-  "DICE.DamageBase": "Base {type}",
-  "DICE.DamageBonus": "Action Bonus",
-  "DICE.DamageOverflow": "Overflow Amount",
-  "DICE.DamageResistance": "Damage Resistance",
-  "DICE.DamageTotal": "Damage Total",
-  "DICE.DamageVulnerability": "Damage Vulnerability",
-  "DICE.DC": "DC",
-  "DICE.DCSpecific": "DC {dc}",
-  "DICE.DiceTotal": "Dice Total",
-  "DICE.DIFFICULTIES": {
-    "Challenging": "Challenging",
-    "Custom": "Custom Difficulty",
-    "Difficult": "Difficult",
-    "Easy": "Easy",
-    "Formidable": "Formidable",
-    "Impossible": "Impossible",
-    "Moderate": "Moderate",
-    "Trivial": "Trivial"
+  "DEFENSES": {
+    "TOOLTIPS": {
+      "Fortitude": "{base} + ((Strength + Wisdom) / 4)",
+      "Madness": "{base} + (Madness / 10)",
+      "Reflex": "{base} + ((Dexterity + Intellect) / 4)",
+      "Willpower": "{base} + ((Toughness + Presence) / 4)",
+      "Wounds": "{base} + (Wounds / 10)"
+    },
+    "Armor": "Armor",
+    "Block": "Block",
+    "Dodge": "Dodge",
+    "Fortitude": "Fortitude",
+    "Madness": "Madness",
+    "Parry": "Parry",
+    "Physical": "Physical",
+    "Reflex": "Reflex",
+    "Willpower": "Willpower",
+    "Wounds": "Wounds"
   },
-  "DICE.Enchantment": "Enchantment",
-  "DICE.EnchantmentBonus": "Enchantment Bonus",
-  "DICE.Healing": "Healing",
-  "DICE.REQUESTS": {
-    "AddParty": "Add Party",
-    "AnyActor": "Any Actor",
-    "AnyActorHint": "Choose any world Actors.",
-    "ChooseTarget": "Choose Target",
-    "ClearRequest": "Clear Request",
-    "Request": "Request",
-    "RequestRolls": "Request Rolls",
-    "SpecificActors": "Specific Actors",
-    "SpecificActorsHint": "Choose specific relevant actors."
+  "DICE": {
+    "DIFFICULTIES": {
+      "Challenging": "Challenging",
+      "Custom": "Custom Difficulty",
+      "Difficult": "Difficult",
+      "Easy": "Easy",
+      "Formidable": "Formidable",
+      "Impossible": "Impossible",
+      "Moderate": "Moderate",
+      "Trivial": "Trivial"
+    },
+    "REQUESTS": {
+      "AddParty": "Add Party",
+      "AnyActor": "Any Actor",
+      "AnyActorHint": "Choose any world Actors.",
+      "ChooseTarget": "Choose Target",
+      "ClearRequest": "Clear Request",
+      "Request": "Request",
+      "RequestRolls": "Request Rolls",
+      "SpecificActors": "Specific Actors",
+      "SpecificActorsHint": "Choose specific relevant actors."
+    },
+    "Ability": "Ability",
+    "AbilityBonus": "Ability Bonus",
+    "Banes.one": "Bane",
+    "Banes.other": "Banes",
+    "Boons.one": "Boon",
+    "Boons.other": "Boons",
+    "CircumstanceBonus": "Circumstance Bonus",
+    "Confirm": "Confirm",
+    "Damage": "Damage",
+    "DamageBase": "Base {type}",
+    "DamageBonus": "Action Bonus",
+    "DamageOverflow": "Overflow Amount",
+    "DamageResistance": "Damage Resistance",
+    "DamageTotal": "Damage Total",
+    "DamageVulnerability": "Damage Vulnerability",
+    "DC": "DC",
+    "DCSpecific": "DC {dc}",
+    "DiceTotal": "Dice Total",
+    "Enchantment": "Enchantment",
+    "EnchantmentBonus": "Enchantment Bonus",
+    "Healing": "Healing",
+    "Reverse": "Reverse",
+    "Roll": "Roll",
+    "RollTotal": "Roll Total",
+    "SetDifficulty": "Set Difficulty",
+    "Skill": "Skill",
+    "SkillBonus": "Skill Bonus"
   },
-  "DICE.Reverse": "Reverse",
-  "DICE.Roll": "Roll",
-  "DICE.RollTotal": "Roll Total",
-  "DICE.SetDifficulty": "Set Difficulty",
-  "DICE.Skill": "Skill",
-  "DICE.SkillBonus": "Skill Bonus",
   "FLANKED_EFFECT": {
     "FIELDS": {
       "allies": {
@@ -1335,19 +1355,21 @@
     },
     "WARNINGS": {
       "NotTalent": "The dropped document must be a Talent."
-    }
+    },
+    "EnchantmentLegendary": "Legendary",
+    "EnchantmentMajor": "Major",
+    "EnchantmentMinor": "Minor",
+    "EnchantmentMundane": "Mundane",
+    "QualityFine": "Fine",
+    "QualityMasterwork": "Masterwork",
+    "QualityShoddy": "Shoddy",
+    "QualityStandard": "Standard",
+    "QualitySuperior": "Superior"
   },
-  "ITEM.EnchantmentLegendary": "Legendary",
-  "ITEM.EnchantmentMajor": "Major",
-  "ITEM.EnchantmentMinor": "Minor",
-  "ITEM.EnchantmentMundane": "Mundane",
-  "ITEM.QualityFine": "Fine",
-  "ITEM.QualityMasterwork": "Masterwork",
-  "ITEM.QualityShoddy": "Shoddy",
-  "ITEM.QualityStandard": "Standard",
-  "ITEM.QualitySuperior": "Superior",
-  "KEYBINDINGS.ConfirmAction": "Confirm Action",
-  "KEYBINDINGS.ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken.",
+  "KEYBINDINGS": {
+    "ConfirmAction": "Confirm Action",
+    "ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken."
+  },
   "KNOWLEDGE": {
     "Alchemy": "Alchemy",
     "Ancients": "Ancients",
@@ -1397,12 +1419,6 @@
     }
   },
   "RESOURCES": {
-    "Action": "Action",
-    "Focus": "Focus",
-    "Health": "Health",
-    "Heroism": "Heroism",
-    "Madness": "Madness",
-    "Morale": "Morale",
     "TOOLTIPS": {
       "Action": "6 + Action Bonus",
       "Focus": "(Wisdom + Presence + Intellect) / 2",
@@ -1412,9 +1428,17 @@
       "Morale": "(6 &times; Level) + (4 &times; Presence) + (2 &times; Wisdom)",
       "Wounds": "Health &times; 1.5"
     },
+    "Action": "Action",
+    "Focus": "Focus",
+    "Health": "Health",
+    "Heroism": "Heroism",
+    "Madness": "Madness",
+    "Morale": "Morale",
     "Wounds": "Wounds"
   },
-  "RULER.CannotAffordMove": "You cannot afford to move {distance} spaces which costs {action} Action points.",
+  "RULER": {
+    "CannotAffordMove": "You cannot afford to move {distance} spaces which costs {action} Action points."
+  },
   "SCHEMATIC": {
     "CATEGORIES": {
       "Alchemy": "Alchemy Formula",
@@ -1492,11 +1516,6 @@
     }
   },
   "SETTINGS": {
-    "AutoConfirmAll": "Auto-Confirm All Actions",
-    "AutoConfirmHint": "Enable auto-confirmation of actions in combat which do not deal damage or cause active effects. This can speed things up but is not recommended during play-testing.",
-    "AutoConfirmName": "Action Auto-Confirmation",
-    "AutoConfirmNone": "No Auto-Confirmation",
-    "AutoConfirmSelf": "Self-Target Actions Only",
     "COMPENDIUM_SOURCES": {
       "ancestry": {
         "hint": "Which packs will be used as sources of ancestries during character creation.",
@@ -1522,12 +1541,15 @@
         "label": "Talent Sources"
       }
     },
+    "AutoConfirmAll": "Auto-Confirm All Actions",
+    "AutoConfirmHint": "Enable auto-confirmation of actions in combat which do not deal damage or cause active effects. This can speed things up but is not recommended during play-testing.",
+    "AutoConfirmName": "Action Auto-Confirmation",
+    "AutoConfirmNone": "No Auto-Confirmation",
+    "AutoConfirmSelf": "Self-Target Actions Only",
     "CruciblePartyHint": "Configure which which Group Actor is the primary group of protagonists.",
     "CruciblePartyLabel": "Primary Adventuring Party"
   },
   "SKILL": {
-    "AcquiredRanks": "Acquired Ranks",
-    "CantAfford": "You cannot afford to increase this skill. The next rank costs {cost} points and you have {points} skill points available.",
     "CATEGORY": {
       "CRAFTING": {
         "hint": "Artisanal skills reflecting your character's ability to create items or equipment.",
@@ -1546,9 +1568,6 @@
         "label": "Social"
       }
     },
-    "CategoryHeader": "{category} Skills",
-    "ChoosePath": "You must choose a specialization path before advancing this Skill further.",
-    "Id": "Skill ID",
     "LABELS": {
       "alchemy": "Alchemy",
       "arcana": "Arcana",
@@ -1571,13 +1590,6 @@
       "tailoring": "Tailoring",
       "wilderness": "Wilderness"
     },
-    "Overview": "Skill Overview",
-    "PageSheet": "Crucible Skill",
-    "PassiveSpecific": "Passive: {passive}",
-    "PathId": "Path ID",
-    "PathName": "Path Name",
-    "PathOverview": "Path Overview",
-    "Ranks": "Skill Ranks",
     "RANKS": {
       "ADEPT": {
         "hint": "You are a subject matter expert and fluent in all base competencies and applications of this skill.",
@@ -1608,6 +1620,18 @@
         "label": "Untrained"
       }
     },
+    "AcquiredRanks": "Acquired Ranks",
+    "CantAfford": "You cannot afford to increase this skill. The next rank costs {cost} points and you have {points} skill points available.",
+    "CategoryHeader": "{category} Skills",
+    "ChoosePath": "You must choose a specialization path before advancing this Skill further.",
+    "Id": "Skill ID",
+    "Overview": "Skill Overview",
+    "PageSheet": "Crucible Skill",
+    "PassiveSpecific": "Passive: {passive}",
+    "PathId": "Path ID",
+    "PathName": "Path Name",
+    "PathOverview": "Path Overview",
+    "Ranks": "Skill Ranks",
     "RollFlavor": "{name} rolls a {skill} check",
     "RollTitle": "[{name}] {skill} Skill Check",
     "SheetTitle": "[{actor}] {skill} Skill",
@@ -1638,6 +1662,13 @@
       "RuneSpecific": "Rune: {rune}"
     },
     "COUNTERSPELL": {
+      "WARNINGS": {
+        "BadTarget": "You can only Counterspell the caster of the last action, and that action must be a spell.",
+        "InvalidTerms": "Unable to parse {terms} as valid Counterspell terms.",
+        "MissingComponents": "A Counterspell enricher must have at least 1 rune and 1 gesture.",
+        "NoTalent": "{actor} does not have the Counterspell talent.",
+        "NoUser": "No non-GM users present to handle Counterspelling for actor {actor}"
+      },
       "Detailed": "Counterspell ({details})",
       "Name": "Counterspell",
       "OpposingRune": "Counterspell: Opposing Rune",
@@ -1645,16 +1676,8 @@
       "Tags": "Counterspell Tags",
       "TargetGesture": "Target Gesture: {gesture}",
       "TargetRune": "Target Rune: {rune}",
-      "UseForActor": "Use Counterspell for: {actor}",
-      "WARNINGS": {
-        "BadTarget": "You can only Counterspell the caster of the last action, and that action must be a spell.",
-        "InvalidTerms": "Unable to parse {terms} as valid Counterspell terms.",
-        "MissingComponents": "A Counterspell enricher must have at least 1 rune and 1 gesture.",
-        "NoTalent": "{actor} does not have the Counterspell talent.",
-        "NoUser": "No non-GM users present to handle Counterspelling for actor {actor}"
-      }
+      "UseForActor": "Use Counterspell for: {actor}"
     },
-    "DamageType": "Damage Type",
     "FIELDS": {
       "actions": {
         "hint": "Associate Actions which are available to characters which know this Iconic Spell.",
@@ -1695,8 +1718,6 @@
       "Touch": "Touch",
       "Ward": "Ward"
     },
-    "Iconic": "Iconic Spell",
-    "IconicPl": "Iconic Spells",
     "INFLECTIONS": {
       "Compose": "Compose",
       "ComposeAdj": "Composed",
@@ -1719,8 +1740,6 @@
       "Reshape": "Reshape",
       "ReshapeAdj": "Shaped"
     },
-    "NameFormatAdj": "{rune} {gesture}",
-    "NameFormatNoun": "{gesture} of {rune}",
     "NAMES": {
       "CurseConductivity": "Curse of Conductivity",
       "CurseCowardice": "Curse of Cowardice",
@@ -1772,7 +1791,12 @@
       "CannotUseNotComposed": "You cannot cast a Spell which has not yet been fully composed.",
       "CannotUseSilenced": "Cannot use Inflections while Silenced.",
       "NotConfigured": "This Iconic Spell is not yet fully configured. It requires all three spellcraft components to be defined."
-    }
+    },
+    "DamageType": "Damage Type",
+    "Iconic": "Iconic Spell",
+    "IconicPl": "Iconic Spells",
+    "NameFormatAdj": "{rune} {gesture}",
+    "NameFormatNoun": "{gesture} of {rune}"
   },
   "TALENT": {
     "ACTIONS": {
@@ -1837,14 +1861,10 @@
       "Register": "Register Hook Function"
     },
     "LABELS": {
-      "Points": {
-        "one": "Point",
-        "other": "Points"
-      },
-      "Talents": {
-        "one": "Talent",
-        "other": "Talents"
-      }
+      "Points.one": "Point",
+      "Points.other": "Points",
+      "Talents.one": "Talent",
+      "Talents.other": "Talents"
     },
     "NODES": {
       "Attack": "Attack",
@@ -1861,9 +1881,6 @@
       "Training": "Training",
       "Utility": "Utility"
     },
-    "NodeSpecific": "{nodeType} Node",
-    "PointsAvailable": "Points Available",
-    "Prerequisites": "Prerequisites",
     "RANKS": {
       "Expert": "Expert",
       "Master": "Master",
@@ -1886,9 +1903,12 @@
       "Locked": "You do not satisfy the requirements to acquire \"{name}\" which requires {requires} {requirement}.",
       "RequiresRuneGesture": "You must know a spellcraft Rune in order to utilize a Gesture.",
       "RequiresRuneInflection": "You must know a spellcraft Rune in order to utilize an Inflection."
-    }
+    },
+    "GrantsSpells": "<strong>Iconic Spells:</strong>: {name} grants {spells} Iconic Spell slots.",
+    "NodeSpecific": "{nodeType} Node",
+    "PointsAvailable": "Points Available",
+    "Prerequisites": "Prerequisites"
   },
-  "TALENT.GrantsSpells": "<strong>Iconic Spells:</strong>: {name} grants {spells} Iconic Spell slots.",
   "TAXONOMY": {
     "CATEGORIES": {
       "Beast": "Beast",
@@ -1974,7 +1994,9 @@
           "description": "Move while Prone a distance up to half your Stride attribute per Action.",
           "label": "Crawl"
         },
-        "fast.label": "Hurried",
+        "fast": {
+          "label": "Hurried"
+        },
         "fly": {
           "description": "Move through the air a distance up to your Fly attribute per Action. Only creatures with a Fly speed can use this movement mode.",
           "label": "Fly"
@@ -1983,8 +2005,12 @@
           "description": "Leap to traverse a distance up to half your Stride attribute per Action.",
           "label": "Jump"
         },
-        "normal.label": "Normal",
-        "slow.label": "Cautious",
+        "normal": {
+          "label": "Normal"
+        },
+        "slow": {
+          "label": "Cautious"
+        },
         "step": {
           "description": "Move cautiously a distance up to half your Stride attribute per Action. This movement does not provoke disengagement.",
           "label": "Step"
@@ -2047,28 +2073,32 @@
       "skill": "Crucible Skill"
     }
   },
-  "WALKTHROUGH.AbilityPoints": "Spend available Ability Points by increasing your Ability scores.",
-  "WALKTHROUGH.AddAncestry": "Choose an Ancestry from the Compendium or Items sidebar and add it via drag-and-drop.",
-  "WALKTHROUGH.AddBackground": "Choose a Background from the Compendium or Items sidebar and add it via drag-and-drop.",
-  "WALKTHROUGH.ConfigureArchetype": "Configure an Archetype for this adversary.",
-  "WALKTHROUGH.ConfigureTaxonomy": "Configure a Taxonomy for this adversary.",
-  "WALKTHROUGH.LevelOne": "Set your character to Level 1 and begin your adventure!",
-  "WALKTHROUGH.LevelUp": "You have made enough progress to advance to a new level. Increase your level by one when you are ready!",
-  "WALKTHROUGH.LevelZero": "Complete all character creation steps before advancing your character to Level 1.",
-  "WALKTHROUGH.LevelZeroIncomplete": "You may not advance to Level 1 until you have finished all character creation steps!",
-  "WALKTHROUGH.NextLevel": "Advancement progress towards next level",
-  "WALKTHROUGH.SkillPoints": "Spend available Skill Points by increasing your Skill ranks.",
-  "WALKTHROUGH.TalentPoints": "Spend available Talent Points by opening the Talent Tree.",
-  "WARNING.AbilityCannotDecrease": "You cannot decrease this Ability further.",
-  "WARNING.AbilityCannotIncrease": "You cannot increase this Ability further.",
-  "WARNING.AbilityRequireAncestry": "You must assign an Ancestry before you can purchase Ability increases.",
-  "WARNING.CannotEquipActionCost": "You cannot equip weaponry because you have no Action points available.",
-  "WARNING.CannotEquipInCombat": "Actor {actor} cannot equip or un-equip {item} during a combat encounter.",
-  "WARNING.CannotEquipInvalidCategory": "Actor {actor} cannot use {item} in the {type} equipment slot.",
-  "WARNING.CannotEquipSlotInUse": "Actor {actor} cannot equip {item} because the {type} item slot is already in use.",
-  "WARNING.CannotEquipTaxonomy": "Actor {actor} cannot equip {item} because the \"{taxonomy}\" taxonomy is incapable of using equipment.",
-  "WARNING.NoParty": "You must have a primary party configured for this.",
-  "WARNING.SkillRequireAncestryBackground": "You must assign both Ancestry and Background before you can purchase Skill ranks.",
+  "WALKTHROUGH": {
+    "AbilityPoints": "Spend available Ability Points by increasing your Ability scores.",
+    "AddAncestry": "Choose an Ancestry from the Compendium or Items sidebar and add it via drag-and-drop.",
+    "AddBackground": "Choose a Background from the Compendium or Items sidebar and add it via drag-and-drop.",
+    "ConfigureArchetype": "Configure an Archetype for this adversary.",
+    "ConfigureTaxonomy": "Configure a Taxonomy for this adversary.",
+    "LevelOne": "Set your character to Level 1 and begin your adventure!",
+    "LevelUp": "You have made enough progress to advance to a new level. Increase your level by one when you are ready!",
+    "LevelZero": "Complete all character creation steps before advancing your character to Level 1.",
+    "LevelZeroIncomplete": "You may not advance to Level 1 until you have finished all character creation steps!",
+    "NextLevel": "Advancement progress towards next level",
+    "SkillPoints": "Spend available Skill Points by increasing your Skill ranks.",
+    "TalentPoints": "Spend available Talent Points by opening the Talent Tree."
+  },
+  "WARNING": {
+    "AbilityCannotDecrease": "You cannot decrease this Ability further.",
+    "AbilityCannotIncrease": "You cannot increase this Ability further.",
+    "AbilityRequireAncestry": "You must assign an Ancestry before you can purchase Ability increases.",
+    "CannotEquipActionCost": "You cannot equip weaponry because you have no Action points available.",
+    "CannotEquipInCombat": "Actor {actor} cannot equip or un-equip {item} during a combat encounter.",
+    "CannotEquipInvalidCategory": "Actor {actor} cannot use {item} in the {type} equipment slot.",
+    "CannotEquipSlotInUse": "Actor {actor} cannot equip {item} because the {type} item slot is already in use.",
+    "CannotEquipTaxonomy": "Actor {actor} cannot equip {item} because the \"{taxonomy}\" taxonomy is incapable of using equipment.",
+    "NoParty": "You must have a primary party configured for this.",
+    "SkillRequireAncestryBackground": "You must assign both Ancestry and Background before you can purchase Skill ranks."
+  },
   "WEAPON": {
     "CATEGORIES": {
       "Balanced": "Balanced",

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -233,7 +233,7 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   _addDragWaypoint(point, options) {
     const dialog = crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document);
     if ( dialog?.action.usage.movement.direct !== false ) {
-      ui.notifications.warn(_loc("ACTION.WarningDirectMovementOnly"));
+      ui.notifications.warn(_loc("ACTION.WARNINGS.DirectMovementOnly"));
       return;
     }
     return super._addDragWaypoint(point, options);
@@ -245,7 +245,7 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   _canDragLeftStart(user, event, {notify=true}={}) {
     if ( crucible.api.dice.ActionUseDialog.activeMovementPlan
       && !crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document) ) {
-      if ( notify ) ui.notifications.warn(_loc("ACTION.WarningWrongMovementToken"));
+      if ( notify ) ui.notifications.warn(_loc("ACTION.WARNINGS.WrongMovementToken"));
       return false;
     }
     return super._canDragLeftStart(user, event, {notify});
@@ -358,15 +358,15 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
     const foundPath = context?.foundPath ?? [];
     const cost = foundPath.length > 1 ? this.measureMovementPath(foundPath).cost : 0;
     if ( (movement.direct !== false) && context?.waypoints?.length ) {
-      ui.notifications.warn(_loc("ACTION.WarningDirectMovementOnly"));
+      ui.notifications.warn(_loc("ACTION.WARNINGS.DirectMovementOnly"));
       return true;
     }
     if ( minRange && (cost < minRange) ) {
-      ui.notifications.warn(_loc("ACTION.WarningMovementTooShort"));
+      ui.notifications.warn(_loc("ACTION.WARNINGS.MovementTooShort"));
       return true;
     }
     if ( maxRange && ((cost > maxRange) || context?.unreachableWaypoints?.length) ) {
-      ui.notifications.warn(_loc("ACTION.WarningMovementTooFar"));
+      ui.notifications.warn(_loc("ACTION.WARNINGS.MovementTooFar"));
       return true;
     }
     return false;

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -218,8 +218,8 @@ export const TAGS = {
   // Requires Dual-Wield
   dualwield: {
     tag: "dualwield",
-    label: "ACTION.TagDualWield",
-    tooltip: "ACTION.TagDualWieldTooltip",
+    label: "ACTION.TAG.DualWield",
+    tooltip: "ACTION.TAG.DualWieldTooltip",
     category: "requirements",
     canUse() {
       return this.actor.equipment.weapons.dualWield;
@@ -229,8 +229,8 @@ export const TAGS = {
   // Requires One-Handed weapon
   onehand: {
     tag: "onehand",
-    label: "ACTION.TagOneHand",
-    tooltip: "ACTION.TagOneHandTooltip",
+    label: "ACTION.TAG.OneHand",
+    tooltip: "ACTION.TAG.OneHandTooltip",
     category: "requirements",
     canUse() {
       return !this.actor.equipment.weapons.twoHanded;
@@ -240,8 +240,8 @@ export const TAGS = {
   // Requires Dexterity Weapon
   finesse: {
     tag: "finesse",
-    label: "ACTION.TagFinesse",
-    tooltip: "ACTION.TagFinesseTooltip",
+    label: "ACTION.TAG.Finesse",
+    tooltip: "ACTION.TAG.FinesseTooltip",
     category: "requirements",
     canUse() {
       if ( !this.usage.strikes.every(w => w.config.category.scaling.includes("dexterity")) ) {
@@ -253,8 +253,8 @@ export const TAGS = {
   // Requires Strength Weapon
   brute: {
     tag: "brute",
-    label: "ACTION.TagBrute",
-    tooltip: "ACTION.TagBruteTooltip",
+    label: "ACTION.TAG.Brute",
+    tooltip: "ACTION.TAG.BruteTooltip",
     category: "requirements",
     priority: 5,
     canUse() {
@@ -267,8 +267,8 @@ export const TAGS = {
   // Requires a Projectile Weapon
   projectile: {
     tag: "projectile",
-    label: "ACTION.TagProjectile",
-    tooltip: "ACTION.TagProjectileTooltip",
+    label: "ACTION.TAG.Projectile",
+    tooltip: "ACTION.TAG.ProjectileTooltip",
     category: "requirements",
     propagate: ["ranged"],
     canUse() {
@@ -281,8 +281,8 @@ export const TAGS = {
   // Requires a Mechanical Weapon
   mechanical: {
     tag: "mechanical",
-    label: "ACTION.TagMechanical",
-    tooltip: "ACTION.TagMechanicalTooltip",
+    label: "ACTION.TAG.Mechanical",
+    tooltip: "ACTION.TAG.MechanicalTooltip",
     category: "requirements",
     propagate: ["ranged"],
     canUse() {
@@ -295,8 +295,8 @@ export const TAGS = {
   // Requires Shield
   shield: {
     tag: "shield",
-    label: "ACTION.TagShield",
-    tooltip: "ACTION.TagShieldTooltip",
+    label: "ACTION.TAG.Shield",
+    tooltip: "ACTION.TAG.ShieldTooltip",
     category: "requirements",
     canUse() {
       return this.actor.equipment.weapons.shield;
@@ -306,8 +306,8 @@ export const TAGS = {
   // Requires Unarmed
   unarmed: {
     tag: "unarmed",
-    label: "ACTION.TagUnarmed",
-    tooltip: "ACTION.TagUnarmedTooltip",
+    label: "ACTION.TAG.Unarmed",
+    tooltip: "ACTION.TAG.UnarmedTooltip",
     category: "requirements",
     propagate: ["melee"],
     canUse() {
@@ -318,8 +318,8 @@ export const TAGS = {
   // Requires Unarmored
   unarmored: {
     tag: "unarmored",
-    label: "ACTION.TagUnarmored",
-    tooltip: "ACTION.TagUnarmoredTooltip",
+    label: "ACTION.TAG.Unarmored",
+    tooltip: "ACTION.TAG.UnarmoredTooltip",
     category: "requirements",
     canUse() {
       return this.actor.equipment.unarmored;
@@ -329,8 +329,8 @@ export const TAGS = {
   // After a Basic Strike
   afterStrike: {
     tag: "afterStrike",
-    label: "ACTION.TagAfterStrike",
-    tooltip: "ACTION.TagActorStrikeTooltip",
+    label: "ACTION.TAG.AfterStrike",
+    tooltip: "ACTION.TAG.ActorStrikeTooltip",
     category: "requirements",
     canUse() {
       const lastAction = this.actor.lastConfirmedAction;
@@ -349,19 +349,19 @@ export const TAGS = {
   // Requires the ability to speak
   vocal: {
     tag: "vocal",
-    label: "ACTION.TagVocal",
-    tooltip: "ACTION.TagVocalTooltip",
+    label: "ACTION.TAG.Vocal",
+    tooltip: "ACTION.TAG.VocalTooltip",
     category: "requirements",
     canUse() {
-      if ( this.actor.statuses.has("silenced") ) throw new Error(game.i18n.localize("ACTION.WarningSilenced"));
+      if ( this.actor.statuses.has("silenced") ) throw new Error(game.i18n.localize("ACTION.WARNINGS.Silenced"));
     }
   },
 
   // Requires the ability to hear
   auditory: {
     tag: "auditory",
-    label: "ACTION.TagAuditory",
-    tooltip: "ACTION.TagAuditoryTooltip",
+    label: "ACTION.TAG.Auditory",
+    tooltip: "ACTION.TAG.AuditoryTooltip",
     category: "requirements",
     preActivate(targets) {
       // Remove targets which are deafened
@@ -379,13 +379,13 @@ export const TAGS = {
   // Requires Reaction
   reaction: {
     tag: "reaction",
-    label: "ACTION.TagReaction",
-    tooltip: "ACTION.TagReactionTooltip",
+    label: "ACTION.TAG.Reaction",
+    tooltip: "ACTION.TAG.ReactionTooltip",
     category: "context",
     canUse() {
       if ( !this.actor.inCombat ) return false;
       if ( this.actor.statuses.has("unaware") ) throw new Error("You may not use a reaction while Unaware!");
-      if ( !this.actor.abilities.dexterity.value ) throw new Error(_loc("ACTION.WarningNoAbility", {
+      if ( !this.actor.abilities.dexterity.value ) throw new Error(_loc("ACTION.WARNINGS.NoAbility", {
         actor: this.actor.name,
         ability: SYSTEM.ABILITIES.dexterity.label,
         action: this.name
@@ -406,8 +406,8 @@ export const TAGS = {
   // Non-Combat Actions
   noncombat: {
     tag: "noncombat",
-    label: "ACTION.TagNonCombat",
-    tooltip: "ACTION.TagNonCombatTooltip",
+    label: "ACTION.TAG.NonCombat",
+    tooltip: "ACTION.TAG.NonCombatTooltip",
     category: "context",
     canUse() {
       if ( this.actor.inCombat ) throw new Error(`You may not use ${this.name} during Combat.`);
@@ -417,8 +417,8 @@ export const TAGS = {
   // Requires a Flanked Opponent
   flanking: {
     tag: "flanking",
-    label: "ACTION.TagFlanking",
-    tooltip: "ACTION.TagFlankingTooltip",
+    label: "ACTION.TAG.Flanking",
+    tooltip: "ACTION.TAG.FlankingTooltip",
     category: "context",
     acquireTargets(targets) {
       for ( const target of targets ) {
@@ -430,8 +430,8 @@ export const TAGS = {
   // Consumables
   consume: {
     tag: "consume",
-    label: "ACTION.TagConsume",
-    tooltip: "ACTION.TagConsumeTooltip",
+    label: "ACTION.TAG.Consume",
+    tooltip: "ACTION.TAG.ConsumeTooltip",
     category: "special",
     initialize() {
       if ( this.item?.type === "consumable" ) this.usage.consumable = this.item;
@@ -454,8 +454,8 @@ export const TAGS = {
 
   spell: {
     tag: "spell",
-    label: "ACTION.TagSpell",
-    tooltip: "ACTION.TagSpellTooltip",
+    label: "ACTION.TAG.Spell",
+    tooltip: "ACTION.TAG.SpellTooltip",
     category: "spellcraft",
     priority: 1,
     initialize() {
@@ -478,8 +478,8 @@ export const TAGS = {
   // Composed Spells
   composed: {
     tag: "composed",
-    label: "ACTION.TagComposed",
-    tooltip: "ACTION.TagComposedTooltip",
+    label: "ACTION.TAG.Composed",
+    tooltip: "ACTION.TAG.ComposedTooltip",
     category: "spellcraft",
     priority: 2,
     initialize() {
@@ -496,20 +496,20 @@ export const TAGS = {
   // Iconic Spell
   iconicSpell: {
     tag: "iconicSpell",
-    label: "ACTION.TagIconicSpell",
-    tooltip: "ACTION.TagSpellTooltip",
+    label: "ACTION.TAG.IconicSpell",
+    tooltip: "ACTION.TAG.SpellTooltip",
     category: "spellcraft",
     priority: 2
   },
 
   summon: {
     tag: "summon",
-    label: "ACTION.TagSummon",
-    tooltip: "ACTION.TagSummonTooltip",
+    label: "ACTION.TAG.Summon",
+    tooltip: "ACTION.TAG.SummonTooltip",
     category: "special",
     canUse() {
       if ( !this.usage.summons?.length || this.usage.summons.some(s => !s.actorUuid) ) {
-        throw new Error(_loc("ACTION.WarningMisconfiguredSummon", { action: this.name }));
+        throw new Error(_loc("ACTION.WARNINGS.MisconfiguredSummon", { action: this.name }));
       }
     },
     async postActivate(outcome) {
@@ -679,8 +679,8 @@ export const TAGS = {
   // Requires a Melee Weapon
   melee: {
     tag: "melee",
-    label: "ACTION.TagMelee",
-    tooltip: "ACTION.TagMeleeTooltip",
+    label: "ACTION.TAG.Melee",
+    tooltip: "ACTION.TAG.MeleeTooltip",
     category: "attack",
     propagate: ["strike"],
     priority: 1,
@@ -694,8 +694,8 @@ export const TAGS = {
   // Requires a Ranged Weapon
   ranged: {
     tag: "ranged",
-    label: "ACTION.TagRanged",
-    tooltip: "ACTION.TagRangedTooltip",
+    label: "ACTION.TAG.Ranged",
+    tooltip: "ACTION.TAG.RangedTooltip",
     category: "attack",
     propagate: ["strike"],
     priority: 1,
@@ -716,8 +716,8 @@ export const TAGS = {
 
   mainhand: {
     tag: "mainhand",
-    label: "ACTION.TagMainHand",
-    tooltip: "ACTION.TagMainHandTooltip",
+    label: "ACTION.TAG.MainHand",
+    tooltip: "ACTION.TAG.MainHandTooltip",
     category: "attack",
     propagate: ["strike"],
     priority: 9,
@@ -730,8 +730,8 @@ export const TAGS = {
 
   twohand: {
     tag: "twohand",
-    label: "ACTION.TagTwoHanded",
-    tooltip: "ACTION.TagTwoHandedTooltip",
+    label: "ACTION.TAG.TwoHanded",
+    tooltip: "ACTION.TAG.TwoHandedTooltip",
     category: "attack",
     propagate: ["strike"],
     priority: 9,
@@ -749,8 +749,8 @@ export const TAGS = {
 
   offhand: {
     tag: "offhand",
-    label: "ACTION.TagOffHand",
-    tooltip: "ACTION.TagOffHandTooltip",
+    label: "ACTION.TAG.OffHand",
+    tooltip: "ACTION.TAG.OffHandTooltip",
     category: "attack",
     propagate: ["strike"],
     priority: 9,
@@ -768,8 +768,8 @@ export const TAGS = {
 
   thrown: {
     tag: "thrown",
-    label: "ACTION.TagThrown",
-    tooltip: "ACTION.TagThrownTooltip",
+    label: "ACTION.TAG.Thrown",
+    tooltip: "ACTION.TAG.ThrownTooltip",
     category: "attack",
     propagate: ["melee"],
     canUse() {
@@ -795,8 +795,8 @@ export const TAGS = {
   natural: {
     tag: "natural",
     category: "attack",
-    label: "ACTION.TagNatural",
-    tooltip: "ACTION.TagNaturalTooltip",
+    label: "ACTION.TAG.Natural",
+    tooltip: "ACTION.TAG.NaturalTooltip",
     propagate: ["melee"],
     priority: 9,
     canUse() {
@@ -836,8 +836,8 @@ export const TAGS = {
 
   generic: {
     tag: "generic",
-    label: "ACTION.TagGeneric",
-    tooltip: "ACTION.TagGenericTooltip",
+    label: "ACTION.TAG.Generic",
+    tooltip: "ACTION.TAG.GenericTooltip",
     category: "special",
     priority: 9,
     prepare() {
@@ -886,8 +886,8 @@ export const TAGS = {
 
   reload: {
     tag: "reload",
-    label: "ACTION.TagReload",
-    tooltip: "ACTION.TagReloadTooltip",
+    label: "ACTION.TAG.Reload",
+    tooltip: "ACTION.TAG.ReloadTooltip",
     category: "special",
     canUse() {
       const {mainhand: m, offhand: o, reload} = this.actor.equipment.weapons;
@@ -908,8 +908,8 @@ export const TAGS = {
 
   disarm: {
     tag: "disarm",
-    label: "ACTION.TagDisarm",
-    tooltip: "ACTION.TagDisarmTooltip",
+    label: "ACTION.TAG.Disarm",
+    tooltip: "ACTION.TAG.DisarmTooltip",
     category: "special",
     postActivate(outcome) {
       if ( outcome.target === this.actor ) return;
@@ -929,8 +929,8 @@ export const TAGS = {
 
   deadly: {
     tag: "deadly",
-    label: "ACTION.TagDeadly",
-    tooltip: "ACTION.TagDeadlyTooltip",
+    label: "ACTION.TAG.Deadly",
+    tooltip: "ACTION.TAG.DeadlyTooltip",
     category: "modifiers",
     prepare() {
       this.usage.bonuses.multiplier += 1;
@@ -939,18 +939,18 @@ export const TAGS = {
 
   difficult: {
     tag: "difficult",
-    label: "ACTION.TagDifficult",
-    tooltip: "ACTION.TagDifficultTooltip",
+    label: "ACTION.TAG.Difficult",
+    tooltip: "ACTION.TAG.DifficultTooltip",
     category: "modifiers",
     prepare() {
-      this.usage.banes.difficult = {label: "ACTION.TagDifficult", number: 1};
+      this.usage.banes.difficult = {label: "ACTION.TAG.Difficult", number: 1};
     }
   },
 
   empowered: {
     tag: "empowered",
-    label: "ACTION.TagEmpowered",
-    tooltip: "ACTION.TagEmpoweredTooltip",
+    label: "ACTION.TAG.Empowered",
+    tooltip: "ACTION.TAG.EmpoweredTooltip",
     category: "modifiers",
     prepare() {
       this.usage.bonuses.damageBonus += 6;
@@ -958,17 +958,17 @@ export const TAGS = {
   },
   accurate: {
     tag: "accurate",
-    label: "ACTION.TagAccurate",
-    tooltip: "ACTION.TagAccurateTooltip",
+    label: "ACTION.TAG.Accurate",
+    tooltip: "ACTION.TAG.AccurateTooltip",
     category: "modifiers",
     prepare() {
-      this.usage.boons.accurate = {label: "ACTION.TagAccurate", number: 2};
+      this.usage.boons.accurate = {label: "ACTION.TAG.Accurate", number: 2};
     }
   },
   harmless: {
     tag: "harmless",
-    label: "ACTION.TagHarmless",
-    tooltip: "ACTION.TagHarmlessTooltip",
+    label: "ACTION.TAG.Harmless",
+    tooltip: "ACTION.TAG.HarmlessTooltip",
     category: "modifiers",
     async postActivate(outcome) {
       for ( const roll of outcome.rolls ) {
@@ -981,8 +981,8 @@ export const TAGS = {
   },
   weakened: {
     tag: "weakened",
-    label: "ACTION.TagWeakened",
-    tooltip: "ACTION.TagWeakenedTooltip",
+    label: "ACTION.TAG.Weakened",
+    tooltip: "ACTION.TAG.WeakenedTooltip",
     category: "modifiers",
     prepare() {
       this.usage.bonuses.damageBonus -= 6;
@@ -991,8 +991,8 @@ export const TAGS = {
 
   severe: {
     tag: "severe",
-    label: "ACTION.TagSevere",
-    tooltip: "ACTION.TagSevereTooltip",
+    label: "ACTION.TAG.Severe",
+    tooltip: "ACTION.TAG.SevereTooltip",
     category: "modifiers",
     async postActivate(outcome) {
       const targetResources = outcome.target?.system?.resources;
@@ -1050,8 +1050,8 @@ export const TAGS = {
 
   healing: {
     tag: "healing",
-    label: "ACTION.TagHealing",
-    tooltip: "ACTION.TagHealingTooltip",
+    label: "ACTION.TAG.Healing",
+    tooltip: "ACTION.TAG.HealingTooltip",
     category: "damage",
     prepare() {
       this.usage.hasDice = true;
@@ -1063,8 +1063,8 @@ export const TAGS = {
 
   rallying: {
     tag: "rallying",
-    label: "ACTION.TagRallying",
-    tooltip: "ACTION.TagRallyingTooltip",
+    label: "ACTION.TAG.Rallying",
+    tooltip: "ACTION.TAG.RallyingTooltip",
     category: "damage",
     prepare() {
       this.usage.hasDice = true;
@@ -1080,8 +1080,8 @@ export const TAGS = {
 
   maintained: {
     tag: "maintained",
-    label: "ACTION.TagMaintained",
-    tooltip: "ACTION.TagMaintainedTooltip",
+    label: "ACTION.TAG.Maintained",
+    tooltip: "ACTION.TAG.MaintainedTooltip",
     category: "resources",
     async postActivate(outcome) {
       if ( !outcome.self ) return;
@@ -1097,8 +1097,8 @@ export const TAGS = {
 
   movement: {
     tag: "movement",
-    label: "ACTION.TagMovement",
-    tooltip: "ACTION.TagMovementTooltip",
+    label: "ACTION.TAG.Movement",
+    tooltip: "ACTION.TAG.MovementTooltip",
     category: "movement",
     canUse() {
       if ( this.actor.statuses.has("restrained") ) throw new Error("You may not move while Restrained!");
@@ -1166,8 +1166,8 @@ export const TAGS = {
 for ( const id of Object.keys(MOVEMENT_ACTIONS) ) {
   TAGS[id] = {
     tag: id,
-    label: `ACTION.TagMovement${id[0].toUpperCase()}${id.slice(1)}`,
-    tooltip: `ACTION.TagMovement${id[0].toUpperCase()}${id.slice(1)}Tooltip`,
+    label: `ACTION.TAG.Movement${id[0].toUpperCase()}${id.slice(1)}`,
+    tooltip: `ACTION.TAG.Movement${id[0].toUpperCase()}${id.slice(1)}Tooltip`,
     category: "movement",
     propagate: ["movement"],
     prepare() {
@@ -1228,7 +1228,7 @@ for ( const resource of ["health", "morale"] ) {
 // All Skill Attacks
 TAGS.skill = {
   tag: "skill",
-  label: "ACTION.TagSkill",
+  label: "ACTION.TAG.Skill",
   category: "skills"
 };
 

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -24,7 +24,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @inheritDoc */
   async previousRound() {
     if ( !game.user.isGM ) {
-      ui.notifications.warn("COMBAT.WarningCannotChangeRound", {localize: true});
+      ui.notifications.warn("COMBAT.WARNINGS.CannotChangeRound", {localize: true});
       return this;
     }
     return super.previousRound();
@@ -35,7 +35,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @inheritDoc */
   async nextRound() {
     if ( !game.user.isGM ) {
-      ui.notifications.warn("COMBAT.WarningCannotChangeRound", {localize: true});
+      ui.notifications.warn("COMBAT.WARNINGS.CannotChangeRound", {localize: true});
       return this;
     }
     return super.nextRound();

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -72,7 +72,7 @@ export default class CrucibleToken extends foundry.documents.TokenDocument {
     const {cost} = this.actor.getMovementActionCost(movement.passed.cost + movement.pending.cost);
     const isUnconstrained = game.user.isGM && ui.controls.controls.tokens.tools.unconstrainedMovement.active;
     if ( (cost > this.actor.resources.action.value) && !isUnconstrained ) {
-      ui.notifications.warn(_loc("ACTION.WarningCannotAffordMove", {name: this.actor.name, cost,
+      ui.notifications.warn(_loc("ACTION.WARNINGS.CannotAffordMove", {name: this.actor.name, cost,
         action: this.actor.actions.move.name}));
       return false;
     }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -877,7 +877,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
           targets = canvas.ready ? this.#acquireSingleTargets(strict) : [];
           break;
         default:
-          ui.notifications.warn(_loc("ACTION.WarningUnimplementedTarget", {type: this.target.type, name: this.name}));
+          ui.notifications.warn(_loc("ACTION.WARNINGS.UnimplementedTarget", {type: this.target.type, name: this.name}));
           targets = Array.from(game.user.targets).map(CrucibleAction.#getTargetFromToken);
           break;
       }
@@ -1040,7 +1040,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Too few targets
     if ( tokens.size < 1 ) {
-      if ( strict ) throw new Error(_loc("ACTION.WarningInvalidTarget", {
+      if ( strict ) throw new Error(_loc("ACTION.WARNINGS.InvalidTarget", {
         number: this.target.number,
         type: this.target.type,
         action: this.name
@@ -1050,7 +1050,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Too many targets
     if ( tokens.size > this.target.number ) {
-      errorAll = _loc("ACTION.WarningIncorrectTargets", {
+      errorAll = _loc("ACTION.WARNINGS.IncorrectTargets", {
         number: this.target.number,
         type: this.target.type,
         action: this.name
@@ -1065,15 +1065,15 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       targets.push(t);
       if ( !this.token ) continue;
       if ( (token === this.token) && !this.damage?.restoration ) {
-        t.error = _loc("ACTION.WarningCannotTargetSelf");
+        t.error = _loc("ACTION.WARNINGS.CannotTargetSelf");
         continue;
       }
       const range = crucible.api.canvas.grid.getLinearRangeCost(this.token.object, token);
       if ( this.range.minimum && (range < this.range.minimum) ) {
-        t.error ||= _loc("ACTION.WarningMinimumRange", {min: this.range.minimum});
+        t.error ||= _loc("ACTION.WARNINGS.MinimumRange", {min: this.range.minimum});
       }
       if ( this.range.maximum && (range > this.range.maximum) ) {
-        t.error ||= _loc("ACTION.WarningMaximumRange", {max: this.range.maximum});
+        t.error ||= _loc("ACTION.WARNINGS.MaximumRange", {max: this.range.maximum});
       }
     }
     return targets;
@@ -1477,7 +1477,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Cannot spend action
     if ( this.cost.action && this.actor.isIncapacitated ) {
-      throw new Error(_loc("ACTION.WarningCannotSpendAction", {
+      throw new Error(_loc("ACTION.WARNINGS.CannotSpendAction", {
         name: this.actor.name
       }));
     }
@@ -1488,7 +1488,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       const allowEnragedFocus = this.actor.talentIds.has("iramancer0000000") || this.tags.has("strike");
       if ( statuses.has("broken") ) focusBlock = "broken";
       else if ( statuses.has("enraged") && !allowEnragedFocus ) focusBlock = "enraged";
-      if ( focusBlock ) throw new Error(_loc("ACTION.WarningCannotSpendFocus", {
+      if ( focusBlock ) throw new Error(_loc("ACTION.WARNINGS.CannotSpendFocus", {
         name: this.actor.name,
         status: _loc(`ACTIVE_EFFECT.STATUSES.${focusBlock.titleCase()}`)
       }));
@@ -1496,7 +1496,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Cannot afford action cost
     if ( this.cost.action > r.action.value ) {
-      throw new Error(_loc("ACTION.WarningCannotAffordCost", {
+      throw new Error(_loc("ACTION.WARNINGS.CannotAffordCost", {
         name: this.actor.name,
         resource: SYSTEM.RESOURCES.action.label,
         action: this.name
@@ -1505,7 +1505,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Cannot afford focus cost
     if ( this.cost.focus > r.focus.value ) {
-      throw new Error(_loc("ACTION.WarningCannotAffordCost", {
+      throw new Error(_loc("ACTION.WARNINGS.CannotAffordCost", {
         name: this.actor.name,
         resource: SYSTEM.RESOURCES.focus.label,
         action: this.name
@@ -1514,7 +1514,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Cannot afford heroism cost
     if ( this.cost.heroism > r.heroism.value ) {
-      throw new Error(_loc("ACTION.WarningCannotAffordCost", {
+      throw new Error(_loc("ACTION.WARNINGS.CannotAffordCost", {
         name: this.actor.name,
         resource: SYSTEM.RESOURCES.heroism.label,
         action: this.name
@@ -1524,7 +1524,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     // Cannot afford hands cost
     if ( this.cost.hands > this.usage.availableHands ) {
       const plurals = new Intl.PluralRules(game.i18n.lang);
-      const error = this.tags.has("spell") ? "SPELL.WARNINGS.CannotAffordHands" : "ACTION.WarningCannotAffordHands";
+      const error = this.tags.has("spell") ? "SPELL.WARNINGS.CannotAffordHands" : "ACTION.WARNINGS.CannotAffordHands";
       throw new Error(_loc(`${error}.${plurals.select(this.cost.hands)}`, {
         name: this.actor.name,
         hands: this.cost.hands,
@@ -1534,7 +1534,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Cannot use physical scaling
     if ( !this.actor.abilities.strength.value && this.scaling.length && this.scaling.every(s => ["strength", "toughness", "dexterity"].includes(s)) ) {
-      throw new Error(_loc("ACTION.WarningNoAbility", {
+      throw new Error(_loc("ACTION.WARNINGS.NoAbility", {
         actor: this.actor.name,
         ability: SYSTEM.ABILITIES.strength.label,
         action: this.name
@@ -1543,7 +1543,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
     // Cannot use mental scaling
     if ( !this.actor.abilities.wisdom.value && this.scaling.length && this.scaling.every(s => ["wisdom", "presence", "intellect"].includes(s)) ) {
-      throw new Error(_loc("ACTION.WarningNoAbility", {
+      throw new Error(_loc("ACTION.WARNINGS.NoAbility", {
         actor: this.actor.name,
         ability: SYSTEM.ABILITIES.wisdom.label,
         action: this.name
@@ -1563,7 +1563,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         errorOptions = {cause: err};
       }
       if ( errorReason ) {
-        throw new Error(_loc("ACTION.WarningCannotUse", {
+        throw new Error(_loc("ACTION.WARNINGS.CannotUse", {
           name: this.actor.name,
           action: this.name,
           reason: errorReason
@@ -1875,10 +1875,10 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const cost = this._trueCost || this.cost;
     const ap = cost.action ?? 0;
     if ( this.cost.weapon && !this.usage.strikes?.length ) { // Strike sequence not yet determined
-      if ( ap === 0 ) tags.activation.ap = _loc("ACTION.TagCostWeapon");
-      else tags.activation.ap = _loc("ACTION.TagCostWeaponAction", {action: ap.signedString()});
+      if ( ap === 0 ) tags.activation.ap = _loc("ACTION.TAG.CostWeapon");
+      else tags.activation.ap = _loc("ACTION.TAG.CostWeaponAction", {action: ap.signedString()});
     }
-    else tags.activation.ap = _loc("ACTION.TagCostAction", {action: ap});
+    else tags.activation.ap = _loc("ACTION.TAG.CostAction", {action: ap});
     if ( ap ) {
       const unmet = ap > this.actor?.resources.action.value;
       const label = tags.activation.ap;
@@ -1886,24 +1886,24 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     }
     if ( Number.isFinite(cost.focus) && (cost.focus !== 0) ) {
       const unmet = cost.focus > this.actor?.resources.focus.value;
-      const label = _loc("ACTION.TagCostFocus", {focus: cost.focus});
+      const label = _loc("ACTION.TAG.CostFocus", {focus: cost.focus});
       tags.activation.fp = {label, unmet};
     }
     if ( Number.isFinite(cost.heroism) && cost.heroism ) {
       const unmet = cost.heroism > this.actor?.resources.heroism.value;
-      const label = _loc("ACTION.TagCostHeroism", {heroism: cost.heroism});
+      const label = _loc("ACTION.TAG.CostHeroism", {heroism: cost.heroism});
       tags.activation.hp = {label, unmet};
     }
     if ( Number.isFinite(cost.health) && (cost.health !== 0) ) {
       const unmet = cost.health > this.actor?.resources.health.value; // Blood Magic, for example
-      const label = _loc("ACTION.TagCostHealth", {health: cost.health});
+      const label = _loc("ACTION.TAG.CostHealth", {health: cost.health});
       tags.activation.health = {label, unmet};
     }
     if ( !(tags.activation.ap || tags.activation.fp || tags.activation.hp || tags.activation.health) ) tags.activation.ap = "Free";
     if ( cost.hands ) {
       const unmet = cost.hands > this.usage.availableHands;
       const plurals = new Intl.PluralRules(game.i18n.lang);
-      const label = _loc(`ACTION.TagCostHand.${plurals.select(cost.hands)}`, {hands: cost.hands});
+      const label = _loc(`ACTION.TAG.CostHand.${plurals.select(cost.hands)}`, {hands: cost.hands});
       tags.activation.hands = {label, unmet};
     }
     return tags;

--- a/module/models/spell-action.mjs
+++ b/module/models/spell-action.mjs
@@ -401,7 +401,7 @@ export default class CrucibleSpellAction extends CrucibleAction {
 
     delete tags.action.spell;
     tags.action.scaling = Array.from(this.scaling).map(a => SYSTEM.ABILITIES[a].label).join("/");
-    if ( this.damage.healing ) tags.action.healing = _loc("ACTION.TagHealing");
+    if ( this.damage.healing ) tags.action.healing = _loc("ACTION.TAG.Healing");
     else tags.action.defense = SYSTEM.DEFENSES[this.usage.defenseType].label;
     tags.action.resource = SYSTEM.RESOURCES[this.rune.resource].label;
 


### PR DESCRIPTION
## Actual i18n key changes:
- `ACTION.TagSomething` and `ACTION.TagSomethingTooltip` have moved to `ACTION.TAG.Something` and `ACTION.TAG.SomethingTooltip`
- `ACTION.WarningSomething` has moved to `ACTION.WARNINGS.Something`
- `COMBAT.WarningSomething` has moved to `COMBAT.WARNINGS.Something`

## Things which maybe could/should be moved (but haven't):
- `ADVANCEMENT` could go under `ACTOR.ADVANCEMENT`
- `ADVERSARY` could go under `ACTOR.ADVERSARY`
- `ITEM.EnchchantmentX` and `ITEM.QualityX` could be moved to `ITEM.ENCHANTMENT.RANKS.X` and `ITEM.QUALITY.RANKS.X` or something, if in the future we may add additional enchant/quality-specific i18n. Otherwise this is fine, there's only 9 total
- `WALKTHROUGH` could go under `ACTOR.WALKTHROUGH`
- Everything in `WARNING` could be split out into their appropriate `<NAMESPACE>.WARNINGS`

## Style-only decisions which could go either way:
- Nested `one` and `other` stuff have been un-nested, if they're gonna be the _only_ sub-keys.
- Un-nested movement action stuff (`fast/normal/slow.label`) have been nested, in case `description` is added in the future & to make skimming/parsing easier. I actually think we can kill these? We use `TRAVEL_PACES` for the localization, which also includes Hidden and Reckless

Have **not** done a search for unused i18n keys