### PR TITLE
Fix missing i18n and localize all user-facing errors/warnings

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -822,7 +822,7 @@ function enableSpellcheckContext() {
 async function syncOwnedItems({force=false, reload=true, talents=true, spells=true}={}) {
   console.groupCollapsed("Crucible | Talent/Spell Data Synchronization");
   const bar = {n: 0, total: game.actors.size, pct: 0};
-  const progress = ui.notifications.info("Synchronizing Talents & Spells", {console: true, progress: true});
+  const progress = ui.notifications.info(_loc("CRUCIBLE.Syncing"), {console: true, progress: true});
   for ( const actor of game.actors ) {
     bar.n++;
     bar.pct = bar.n / bar.total;

--- a/lang/en.json
+++ b/lang/en.json
@@ -380,6 +380,18 @@
       "Wall": "Wall"
     },
     "WARNINGS": {
+      "SPECIFIC": {
+        "BODY_BLOCK": {
+          "AlreadyConfirmed": "The attack against you has already been confirmed and can no longer be blocked.",
+          "InvalidOutcome": "You may only use Body Block after an attack against you is defended by Armor or a Glance.",
+          "MeleeOnly": "You may only use Body Block against an incoming melee attack."
+        },
+        "DELAY": {
+          "AlreadyDelayed": "You may not delay your turn again this combat round.",
+          "WrongTurn": "You may only use the Delay action on your own turn in combat."
+        }
+      },
+      "BadStatus": "You may not perform {action} while {status}.",
       "CannotAffordCost": "{name} has insufficient {resource} to use {action}!",
       "CannotAffordHands.one": "{name} must have {hands} free hand to use {action}!",
       "CannotAffordHands.other": "{name} must have {hands} free hands to use {action}!",
@@ -387,17 +399,39 @@
       "CannotSpendAction": "{name} cannot spend Action because they are Incapacitated!",
       "CannotSpendFocus": "{name} cannot spend Focus because they are currently {status}!",
       "CannotTargetSelf": "You cannot target yourself with this Action!",
+      "CannotThrow": "You cannot throw this weapon.",
       "CannotUse": "{name} does not satisfy the prerequisites to use {action}: {reason}",
       "DirectMovementOnly": "This action requires a direct movement path with no intermediate waypoints.",
       "IncorrectTargets": "You may only designate up to {number} {type} targets for {action}!",
       "InvalidTarget": "You must designate at least one {type} target for {action}!",
+      "LastCriticallyMissed": "You may only perform {action} after a basic Strike which did not critically miss.",
       "MaximumRange": "A selected target is further than the maximum range of {max} feet.",
       "MinimumRange": "A selected target is closer than the minimum range of {min} feet.",
+      "MinimumSize": "You must be at least size {size} to use {action}",
       "MisconfiguredSummon": "The action {action} does not have a properly configured Summon target.",
+      "MissingSummonEffect": "ActiveEffect data must be defined to track the non-permanent summon created by the action \"{action}\"",
       "MovementTooFar": "The planned movement path exceeds the maximum range allowed by this action.",
       "MovementTooShort": "The planned movement path does not meet the minimum range required by this action.",
+      "MustFollowStrike": "You may only perform the {action} action after a basic Strike action",
+      "MustReload": "Your weapon requires reloading in order to use this action.",
+      "MustScaleDex": "Every weapon used in this action must scale using dexterity.",
+      "MustScaleStrength": "Every weapon used in this action must scale using strength.",
       "NoAbility": "{actor} has no {ability} score, and therefore cannot use {action}.",
+      "NoConsumable": "No consumable Item identified for action \"{action}\"",
+      "NoConsumableUses": "Consumable item \"{item}\" has no uses remaining for Action \"{action}\"",
+      "NonCombat": "You may not use {action} during Combat.",
+      "NoReloadRequired": "Your weapons do not require reloading",
+      "NotFlanked": "{action} requires a flanked target. Target \"{target}\" is not flanked.",
+      "ReactionUnaware": "You may not use a reaction while Unaware!",
+      "RequiresMelee": "You must have melee weapons equipped to use this action.",
+      "RequiresNatural": "This action requires use of a natural weapon.",
+      "RequiresOffhand": "This action requires an offhand weapon equipped.",
+      "RequiresRanged": "This action requires a ranged weapon equipped.",
+      "RequiresSlashingMelee": "{action} requires a melee weapon which deals slashing damage.",
+      "RequiresTalisman": "{action} requires use of a Talisman weapon.",
+      "RequiresTwoHanded": "This action requires a two-handed weapon equipped.",
       "RequireTemplate": "You must place a Measured Template to indicate the area of effect of {action}.",
+      "Restrained": "You may not move while Restrained!",
       "Silenced": "You cannot use this action while Silenced.",
       "UnimplementedTarget": "Automation for target type {type} for action {name} is not yet supported, you must manually target affected tokens.",
       "WrongMovementToken": "You must move the token performing this action."
@@ -405,6 +439,8 @@
     "Action": "Action",
     "AffectsScope": "Affects {scope}",
     "AllResult": "{existing} (All)",
+    "ChooseWeaponLabel": "Weapon",
+    "ChooseWeaponHint": "You may choose which weapon to use for this Action.",
     "Condition": "Condition",
     "Confirmed": "Confirmed",
     "DelayHint": "Choose an initiative value between 1 and {maximum} when you wish to act.",
@@ -646,6 +682,10 @@
         "medianLevel": "Median Level",
         "recover": "Recover",
         "rest": "Rest"
+      },
+      "WARNINGS": {
+        "NoAddSelf": "You cannot add your own group!",
+        "NotWorldActor": "You can only add a World Actor"
       }
     },
     "LABELS": {
@@ -733,6 +773,9 @@
       "Talents": "Talents"
     },
     "WARNINGS": {
+      "InsufficientCurrency": "Insufficient currency to deduct {delta} {denom}",
+      "MacroNoToken": "You must have a Token controlled to use this Macro",
+      "NoAction": "Actor \"{actor}\" does not have the action \"{action}\"",
       "NoAncestry": "Choose an Ancestry",
       "NoBackground": "Choose a Background",
       "NoDragTalent": "Talents can only be added to a Hero Actor via the Talent Tree.",
@@ -742,6 +785,7 @@
       "UnderspentTalent": "Spend Talent Points"
     },
     "Details": "Details",
+    "DisarmedStatus": "Disarmed!",
     "KnowledgeSpecific": "Knowledge: {knowledge}",
     "LanguageSpecific": "Language: {language}",
     "LevelSpecific": "Level {level}",
@@ -871,6 +915,8 @@
       "Skills": "Skill Progression"
     },
     "WARNINGS": {
+      "InvalidAbilities": "The sum of ability scaling values must equal 12. Currently {sum}",
+      "InvalidSpells": "There must not be duplicate spells on an archetype.",
       "NotEquipment": "The dropped document must be Equipment.",
       "NotSpell": "The dropped document must be an Iconic Spell."
     }
@@ -961,6 +1007,11 @@
     },
     "WARNINGS": {
       "CannotAfford": "The following actors cannot afford the cost of this enricher: {actors}",
+      "CannotRevokeMilestone": "There is no milestone award with identifier \"{identifier}\" on group \"{group}\"",
+      "DuplicateMilestone": "A milestone with identifier \"{identifier}\" has already been awarded to group \"{group}\"",
+      "InvalidMilestoneNumber": "The number of milestones awarded must be a positive integer",
+      "InvalidMilestoneRecipient": "Actor ID \"{id}\" cannot be awarded a milestone",
+      "InvalidMilestoneRevokee": "Actor ID \"{id}\" cannot have a milestone revoked",
       "InvalidTerms": "Unable to parse {terms} as valid award terms.",
       "RequiresGM": "You must be a Gamemaster to use Award enrichers."
     },
@@ -1058,9 +1109,16 @@
     }
   },
   "COMBAT": {
+    "INITIATIVE": {
+      "Combatant": "Combatant",
+      "Result": "Result",
+      "Round": "Initiative - Round {round}"
+    },
     "WARNINGS": {
       "CannotChangeRound": "Only a Gamemaster user may change the Combat round."
-    }
+    },
+    "HeroismPct": "Heroism {pct}%",
+    "HeroismTooltip": "Progress to next Heroism point"
   },
   "CONSUMABLE": {
     "CATEGORIES": {
@@ -1128,7 +1186,8 @@
     "Bonus": "Bonus",
     "Rules": "Crucible Rules",
     "Scaled": "Scaled",
-    "Scaling": "Scaling"
+    "Scaling": "Scaling",
+    "Syncing": "Synchronizing Talents & Spells"
   },
   "CURRENCY_DENOMINATIONS": {
     "CP": {
@@ -1224,6 +1283,8 @@
     "DamageTotal": "Damage Total",
     "DamageVulnerability": "Damage Vulnerability",
     "DC": "DC",
+    "DCAdditionalPassive": "{dcLabel}, Passive",
+    "DCAdditionalGroup": "{dcLabel}, Group",
     "DCSpecific": "DC {dc}",
     "DiceTotal": "Dice Total",
     "Enchantment": "Enchantment",
@@ -1354,6 +1415,8 @@
       "Talents": "Talents"
     },
     "WARNINGS": {
+      "HookAlreadyExists": "{item} already declares a function for the \"{hook}\" hook.",
+      "InvalidIdentifier": "Invalid Crucible identifier value \"{id}\" which must be alphanumeric without spaces or special characters",
       "NotTalent": "The dropped document must be a Talent."
     },
     "EnchantmentLegendary": "Legendary",
@@ -1664,6 +1727,7 @@
     "COUNTERSPELL": {
       "WARNINGS": {
         "BadTarget": "You can only Counterspell the caster of the last action, and that action must be a spell.",
+        "CannotConfirm": "Cannot {change} a Counterspell if the targeted spell is already {state}",
         "InvalidTerms": "Unable to parse {terms} as valid Counterspell terms.",
         "MissingComponents": "A Counterspell enricher must have at least 1 rune and 1 gesture.",
         "NoTalent": "{actor} does not have the Counterspell talent.",
@@ -1786,11 +1850,17 @@
       "Knowledge": "Required Knowledge"
     },
     "WARNINGS": {
+      "BindArmamentAlreadyBound": "weapon is already bound",
+      "BindArmamentNoMainhand": "no mainhand weapon",
       "CannotAffordHands.one": "The {action} spell requires {hands} free hand to cast.",
       "CannotAffordHands.other": "The {action} spell requires {hands} free hands to cast.",
       "CannotUseNotComposed": "You cannot cast a Spell which has not yet been fully composed.",
       "CannotUseSilenced": "Cannot use Inflections while Silenced.",
-      "NotConfigured": "This Iconic Spell is not yet fully configured. It requires all three spellcraft components to be defined."
+      "IconicAlreadyKnown": "Actor {actor} already knows the {spell} Iconic Spell.",
+      "IconicNoSlots": "Actor {actor} does not have any available Iconic Spell slots.",
+      "IconicNotSatisfied": "Actor {actor} does not satisfy the knowledge requirements to learn the {spell} Iconic Spell.", 
+      "NotConfigured": "This Iconic Spell is not yet fully configured. It requires all three spellcraft components to be defined.",
+      "SorcererNoIconic": "As a {talent}, you cannot cast Iconic Spells."
     },
     "DamageType": "Damage Type",
     "Iconic": "Iconic Spell",
@@ -1976,6 +2046,10 @@
       "Clear": "Clear Taxonomy",
       "Physiology": "Physiology",
       "Stature": "Taxonomy Stature"
+    },
+    "WARNINGS": {
+      "InvalidAbilities": "The sum of initial ability values must equal 12. Currently {sum}",
+      "InvalidResistances": "The sum of resistance scaling values must equal zero. Currently {sum}"
     }
   },
   "TOKEN": {

--- a/module/applications/elements/currency.mjs
+++ b/module/applications/elements/currency.mjs
@@ -136,7 +136,7 @@ export default class HTMLCrucibleCurrencyElement extends foundry.applications.el
       }
       const d = crucible.api.documents.CrucibleActor.convertCurrency({[input.dataset.denomination]: delta});
       if ( (this._value + d) < 0 ) {
-        ui.notifications.warn(`Insufficient currency to deduct ${delta} ${cfg.label}.`);
+        ui.notifications.warn(_loc("ACTOR.WARNINGS.InsufficientCurrency", {delta, denom: cfg.label}));
         input.value = amounts[d];
         return;
       }

--- a/module/applications/sheets/hero-sheet.mjs
+++ b/module/applications/sheets/hero-sheet.mjs
@@ -183,7 +183,7 @@ export default class HeroSheet extends CrucibleBaseActorSheet {
         break;
       case "talent":
         if ( !crucible.developmentMode ) {
-          ui.notifications.error("ACTOR.WARNINGS.NoDragTalent", {localize: true});
+          ui.notifications.error(_loc("ACTOR.WARNINGS.NoDragTalent"));
           return;
         }
     }

--- a/module/applications/sheets/item-actor-details-sheet.mjs
+++ b/module/applications/sheets/item-actor-details-sheet.mjs
@@ -139,11 +139,11 @@ export default class CrucibleActorDetailsItemSheet extends CrucibleBaseItemSheet
     if ( talents.some(({item}) => item === data.uuid) ) return;
     const talent = await fromUuid(data.uuid);
     if ( talent?.type !== "talent" ) {
-      ui.notifications.warn("ITEM.WARNINGS.NotTalent", {localize: true});
+      ui.notifications.warn(_loc("ITEM.WARNINGS.NotTalent"));
       return;
     }
     if ( talent.system.node?.tier && (talent.system.node.tier !== 0 ) ) {
-      return ui.notifications.error("BACKGROUND.ERRORS.TalentTier", {localize: true});
+      return ui.notifications.error(_loc("BACKGROUND.ERRORS.TalentTier"));
     }
     const tier = talent.system.nodes.reduce((minTier, node) => (minTier < node.tier) ? minTier : node.tier, Infinity);
     const updateData = {

--- a/module/applications/sheets/item-archetype-sheet.mjs
+++ b/module/applications/sheets/item-archetype-sheet.mjs
@@ -172,7 +172,7 @@ export default class CrucibleArchetypeItemSheet extends CrucibleBackgroundItemSh
     if ( (data.type !== "Item") || equipment.map(e => e.item).includes(data.uuid) ) return;
     const item = await fromUuid(data.uuid);
     if ( !(item?.system instanceof crucible.api.models.CruciblePhysicalItem) ) {
-      ui.notifications.warn("ARCHETYPE.WARNINGS.NotEquipment", {localize: true});
+      ui.notifications.warn(_loc("ARCHETYPE.WARNINGS.NotEquipment"));
       return;
     }
 
@@ -198,7 +198,7 @@ export default class CrucibleArchetypeItemSheet extends CrucibleBackgroundItemSh
     if ( (data.type !== "Item") || spells.some(s => s.item === data.uuid) ) return;
     const spell = await fromUuid(data.uuid);
     if ( !(spell?.system instanceof crucible.api.models.CrucibleSpellItem) ) {
-      ui.notifications.warn("ARCHETYPE.WARNINGS.NotSpell", {localize: true});
+      ui.notifications.warn(_loc("ARCHETYPE.WARNINGS.NotSpell"));
       return;
     }
 

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -422,7 +422,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
     const submitData = this._getSubmitData(event);
     submitData.system.actorHooks ||= [];
     if ( submitData.system.actorHooks.find(h => h.hook === hook ) ) {
-      ui.notifications.warn(`${this.document.name} already declares a function for the "${hook}" hook.`);
+      ui.notifications.warn(_loc("ITEM.WARNINGS.HookAlreadyExists", {item: this.document.name, hook}));
       return;
     }
     submitData.system.actorHooks.push({hook, fn: "// Hook code here"});

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -245,7 +245,7 @@ export const TAGS = {
     category: "requirements",
     canUse() {
       if ( !this.usage.strikes.every(w => w.config.category.scaling.includes("dexterity")) ) {
-        throw new Error("Every weapon used in this action must scale using dexterity.");
+        throw new Error(_loc("ACTION.WARNINGS.MustScaleDex"));
       }
     }
   },
@@ -259,7 +259,7 @@ export const TAGS = {
     priority: 5,
     canUse() {
       if ( !this.usage.strikes.every(w => w.config.category.scaling.includes("strength")) ) {
-        throw new Error("Every weapon used in this action must scale using strength.");
+        throw new Error(_loc("ACTION.WARNINGS.MustScaleStrength"));
       }
     }
   },
@@ -335,12 +335,12 @@ export const TAGS = {
     canUse() {
       const lastAction = this.actor.lastConfirmedAction;
       if ( lastAction?.id !== "strike" ) {
-        throw new Error(`You may only perform the ${this.name} action after a basic Strike action.`);
+        throw new Error(_loc("ACTION.WARNINGS.MustFollowStrike", {action: this.name}));
       }
       for ( const outcome of lastAction.outcomes.values() ) {
         if ( outcome.target === this.actor ) continue;
         if ( outcome.rolls.some(r => r.isCriticalFailure) ) {
-          throw new Error(`You may only perform ${this.name} after a basic Strike which did not critically miss.`);
+          throw new Error(_loc("ACTION.WARNINGS.LastCriticallyMissed", {action: this.name}));
         }
       }
     }
@@ -384,7 +384,7 @@ export const TAGS = {
     category: "context",
     canUse() {
       if ( !this.actor.inCombat ) return false;
-      if ( this.actor.statuses.has("unaware") ) throw new Error("You may not use a reaction while Unaware!");
+      if ( this.actor.statuses.has("unaware") ) throw new Error(_loc("ACTION.WARNINGS.ReactionUnaware"));
       if ( !this.actor.abilities.dexterity.value ) throw new Error(_loc("ACTION.WARNINGS.NoAbility", {
         actor: this.actor.name,
         ability: SYSTEM.ABILITIES.dexterity.label,
@@ -410,7 +410,7 @@ export const TAGS = {
     tooltip: "ACTION.TAG.NonCombatTooltip",
     category: "context",
     canUse() {
-      if ( this.actor.inCombat ) throw new Error(`You may not use ${this.name} during Combat.`);
+      if ( this.actor.inCombat ) throw new Error(_loc("ACTION.WARNINGS.NonCombat", {action: this.name}));
     }
   },
 
@@ -422,7 +422,7 @@ export const TAGS = {
     category: "context",
     acquireTargets(targets) {
       for ( const target of targets ) {
-        if ( !target.actor.statuses.has("flanked") ) target.error ??= `${this.name} requires a flanked target. Target "${target.actor.name}" is not flanked.`;
+        if ( !target.actor.statuses.has("flanked") ) target.error ??= _loc("ACTION.WARNINGS.NotFlanked", {action: this.name, target: target.actor.name});
       }
     }
   },
@@ -438,9 +438,9 @@ export const TAGS = {
     },
     canUse() {
       const item = this.usage.consumable;
-      if ( !item ) throw new Error(`No consumable Item identified for Action "${this.id}"`);
+      if ( !item ) throw new Error(_loc("ACTION.WARNINGS.NoConsumable", {action: this.id}));
       if ( item.system.isDepleted ) {
-        throw new Error(`Consumable item "${item.name}" has no uses remaining for Action "${this.id}"`);
+        throw new Error(_loc("ACTION.WARNINGS.NoConsumableUses", {item: item.name, action: this.id}));
       }
     },
     async confirm(reverse) {
@@ -519,8 +519,7 @@ export const TAGS = {
         summon.tokenData ||= {};
         summon.tokenData.x ??= position.x;
         summon.tokenData.y ??= position.y;
-        if ( (summon.permanent === false) && !outcome.effects.length ) throw new Error(`ActiveEffect data must be 
-          defined to track the non-permanent summon created by the action "${this.id}"`);
+        if ( (summon.permanent === false) && !outcome.effects.length ) throw new Error(_loc("ACTION.WARNINGS.MissingSummonEffect", {action: this.id}));
       }
     },
     async confirm(reverse) {
@@ -596,7 +595,7 @@ export const TAGS = {
     },
     canUse() {
       if ( this.usage.strikes.some(w => w.system.needsReload && !this.tags.has("reload")) ) {
-        throw new Error("Your weapon requires reloading in order to use this action.");
+        throw new Error(_loc("ACTION.WARNINGS.MustReload"));
       }
     },
     prepare() {
@@ -686,7 +685,7 @@ export const TAGS = {
     priority: 1,
     canUse() {
       if ( !this.actor.equipment.weapons.melee ) {
-        throw new Error("You must have melee weapons equipped to use this action.");
+        throw new Error(_loc("ACTION.WARNINGS.RequiresMelee"));
       }
     }
   },
@@ -701,7 +700,7 @@ export const TAGS = {
     priority: 1,
     canUse() {
       if ( !this.actor.equipment.weapons.ranged ) {
-        throw new Error("This action requires a ranged weapon equipped.");
+        throw new Error(_loc("ACTION.WARNINGS.RequiresRanged"));
       }
     },
     prepare() {
@@ -742,7 +741,7 @@ export const TAGS = {
     },
     canUse() {
       if ( !this.actor.equipment.weapons.twoHanded ) {
-        throw new Error("This action requires a two-handed weapon equipped.");
+        throw new Error(_loc("ACTION.WARNINGS.RequiresTwoHanded"));
       }
     }
   },
@@ -761,7 +760,7 @@ export const TAGS = {
     },
     canUse() {
       if ( !this.actor.equipment.weapons.offhand ) {
-        throw new Error("This action requires an offhand weapon equipped.");
+        throw new Error(_loc("ACTION.WARNINGS.RequiresOffhand"));
       }
     }
   },
@@ -774,7 +773,7 @@ export const TAGS = {
     propagate: ["melee"],
     canUse() {
       for ( const w of this.usage.strikes ) {
-        if ( !w.system.canThrow ) throw new Error("You cannot throw this weapon.");
+        if ( !w.system.canThrow ) throw new Error(_loc("ACTION.WARNINGS.CannotThrow"));
       }
     },
     prepare() {
@@ -784,7 +783,7 @@ export const TAGS = {
     preActivate(_targets) {
       if ( !this.usage.strikes?.length ) return;
       for ( const weapon of this.usage.strikes ) {
-        if ( !weapon.system.canThrow ) throw new Error("You cannot throw this weapon.");
+        if ( !weapon.system.canThrow ) throw new Error(_loc("ACTION.WARNINGS.CannotThrow"));
         this.usage.actorUpdates.items ||= [];
         this.usage.actorUpdates.items.push({_id: weapon.id, system: {dropped: true, equipped: false}});
         if ( !weapon.system.properties.has("thrown") ) this.usage.banes[this.id] = {label: this.name, number: 2};
@@ -801,7 +800,7 @@ export const TAGS = {
     priority: 9,
     canUse() {
       if ( !this.usage.strikes.every(w => w.system.properties.has("natural")) ) {
-        throw new Error("This action requires use of a natural weapon.");
+        throw new Error(_loc("ACTION.WARNINGS.RequiresNatural"));
       }
     },
     prepare() {
@@ -892,7 +891,7 @@ export const TAGS = {
     canUse() {
       const {mainhand: m, offhand: o, reload} = this.actor.equipment.weapons;
       if ( !reload || (!m.system.needsReload && !o?.system.needsReload) ) {
-        throw new Error("Your weapons do not require reloading");
+        throw new Error(_loc("ACTION.WARNINGS.NoReloadRequired"));
       }
     },
     preActivate() {
@@ -918,7 +917,7 @@ export const TAGS = {
         if ( !mainhand?.id ) return;
         outcome.actorUpdates.items ||= [];
         outcome.actorUpdates.items.push({_id: mainhand.id, system: {dropped: true, equipped: false}});
-        outcome.statusText.push({text: "Disarmed!", fontSize: 64});
+        outcome.statusText.push({text: _loc("ACTOR.DisarmedStatus"), fontSize: 64});
       }
     }
   },
@@ -1101,7 +1100,7 @@ export const TAGS = {
     tooltip: "ACTION.TAG.MovementTooltip",
     category: "movement",
     canUse() {
-      if ( this.actor.statuses.has("restrained") ) throw new Error("You may not move while Restrained!");
+      if ( this.actor.statuses.has("restrained") ) throw new Error(_loc("ACTION.WARNINGS.Restrained"));
     },
     prepare() {
       const stride = this.actor.system.movement.stride;

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -142,7 +142,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
     const choices = this.action.getValidWeaponChoices({strict: true, maxCost});
     if ( choices.length <= 1 ) return null;
     const weapon = new foundry.data.fields.StringField({blank: true, required: true, choices,
-      label: "Weapon", hint: "You may choose which weapon to use for this Action."});
+      label: _loc("ACTION.ChooseWeaponLabel"), hint: _loc("ACTION.ChooseWeaponHint")});
     weapon.name = "weapon";
     return {field: weapon, value: this.#weaponChoice};
   }

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -355,7 +355,7 @@ export default class StandardCheckDialog extends DialogV2 {
   static async #onRequestParty(_event) {
     const members = crucible.party?.system.actors;
     if ( !members?.size ) {
-      ui.notifications.warn("WARNING.NoParty", {localize: true});
+      ui.notifications.warn(_loc("WARNING.NoParty"));
       return;
     }
     for ( const m of members ) this.#requestActors.add(m);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -599,10 +599,10 @@ export default class CrucibleActor extends Actor {
    * @returns {Promise<void>}
    */
   static async macroAction(actor, actionId) {
-    if ( !actor ) return ui.notifications.warn("You must have a Token controlled to use this Macro");
+    if ( !actor ) return ui.notifications.warn(_loc("ACTOR.WARNINGS.MacroNoToken"));
     let action = actor.actions[actionId];
     if ( !action && actionId.startsWith("spell.") ) action = CrucibleSpellAction.fromId(actionId, {actor});
-    if ( !action ) return ui.notifications.warn(`Actor "${actor.name}" does not have the action "${actionId}"`);
+    if ( !action ) return ui.notifications.warn(_loc("ACTOR.WARNINGS.NoAction", {actor: actor.name, action: actionId}));
     await action.use();
   }
 
@@ -1403,13 +1403,13 @@ export default class CrucibleActor extends Actor {
   canLearnIconicSpell(spell) {
     const {iconicSpells, iconicSlots} = this.grimoire;
     if ( iconicSpells.length >= iconicSlots ) {
-      throw new Error(`Actor ${this.name} does not have any available Iconic Spell slots.`);
+      throw new Error(_loc("SPELL.WARNINGS.IconicNoSlots", {actor: this.name}));
     }
     if ( this.items.get(spell._id) ) {
-      throw new Error(`Actor ${this.name} already knows the ${spell.name} Iconic Spell.`);
+      throw new Error(_loc("SPELL.WARNINGS.IconicAlreadyKnown", {actor: this.name, spell: spell.name}));
     }
     if ( !spell.system.canKnowSpell(this.system.grimoire) ) {
-      throw new Error(`Actor ${this.name} does not satisfy the knowledge requirements to learn the ${spell.name} Iconic Spell.`);
+      throw new Error(_loc("SPELL.WARNINGS.IconicNotSatisfied", {actor: this.name, spell: spell.name}));
     }
   }
 
@@ -1704,7 +1704,7 @@ export default class CrucibleActor extends Actor {
         !this.points.ability.requireInput,
         !this.points.talent.available
       ];
-      if ( !steps.every(k => k) ) return ui.notifications.warn("WALKTHROUGH.LevelZeroIncomplete", {localize: true});
+      if ( !steps.every(k => k) ) return ui.notifications.warn(_loc("WALKTHROUGH.LevelZeroIncomplete"));
     }
 
     // Commit the update
@@ -1728,7 +1728,7 @@ export default class CrucibleActor extends Actor {
 
     // Can the ability be purchased?
     if ( !this.canPurchaseAbility(ability, delta) ) {
-      return ui.notifications.warn(`WARNING.AbilityCannot${delta > 0 ? "Increase" : "Decrease"}`, {localize: true});
+      return ui.notifications.warn(_loc(`WARNING.AbilityCannot${delta > 0 ? "Increase" : "Decrease"}`));
     }
 
     // Modify the ability

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -125,7 +125,7 @@ export default class CrucibleChatMessage extends ChatMessage {
       else {
         if ( meta ) meta.insertAdjacentHTML("afterbegin", "<i class=\"unconfirmed fa-solid fa-hexagon-xmark\" data-tooltip=\"ACTION.Unconfirmed\"></i>");
         if ( game.user.isGM ) {
-          const confirm = foundry.utils.parseHTML("<button class=\"confirm frame-brown\" type=\"button\"><i class=\"fas fa-hexagon-check\"></i>Confirm</button>");
+          const confirm = foundry.utils.parseHTML(`<button class=\"confirm frame-brown\" type=\"button\"><i class=\"fas fa-hexagon-check\"></i>${_loc("DICE.Confirm")}</button>`);
           html.appendChild(confirm);
           confirm.addEventListener("click", event => {
             const button = event.currentTarget;

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -24,7 +24,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @inheritDoc */
   async previousRound() {
     if ( !game.user.isGM ) {
-      ui.notifications.warn("COMBAT.WARNINGS.CannotChangeRound", {localize: true});
+      ui.notifications.warn(_loc("COMBAT.WARNINGS.CannotChangeRound"));
       return this;
     }
     return super.previousRound();
@@ -35,7 +35,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @inheritDoc */
   async nextRound() {
     if ( !game.user.isGM ) {
-      ui.notifications.warn("COMBAT.WARNINGS.CannotChangeRound", {localize: true});
+      ui.notifications.warn(_loc("COMBAT.WARNINGS.CannotChangeRound"));
       return this;
     }
     return super.nextRound();

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -237,7 +237,7 @@ function renderAward(element) {
  */
 async function onClickAward(event) {
   event.preventDefault();
-  if ( !game.user.isGM ) return ui.notifications.warn("AWARD.WARNINGS.RequiresGM", { localize: true });
+  if ( !game.user.isGM ) return ui.notifications.warn(_loc("AWARD.WARNINGS.RequiresGM"));
 
   const { currency, each: eachString } = foundry.utils.expandObject({...event.currentTarget.dataset});
   const each = eachString === "true";
@@ -465,7 +465,7 @@ function renderMilestone(element) {
  */
 async function onClickMilestone(event) {
   event.preventDefault();
-  if ( !crucible.party ) return ui.notifications.warn("WARNING.NoParty", { localize: true });
+  if ( !crucible.party ) return ui.notifications.warn(_loc("WARNING.NoParty"));
 
   const quantity = event.currentTarget.dataset.quantity;
   await crucible.party.system.awardMilestoneDialog(quantity);
@@ -642,17 +642,17 @@ function createSkillCheckElement(skill, dc, {passive=false, group=false}={}) {
   if ( group ) tag.classList.add("group-check");
   tag.dataset.skillId = skill.id;
   tag.dataset.dc = dc;
-  let dcLabel = `DC ${dc}`;
+  let dcLabel = _loc("DICE.DCSpecific", {dc});
 
   // Passive checks only
   if ( passive ) {
-    dcLabel += ", Passive";
+    dcLabel = _loc("DICE.DCAdditionalPassive", {dcLabel});
     tag.classList.add("passive-check");
     tag.dataset.crucibleTooltip = "passiveCheck";
   }
 
   // Group checks only
-  if ( group ) dcLabel += ", Group";
+  if ( group ) dcLabel = _loc("DICE.DCAdditionalGroup", {dcLabel});
 
   // Create label
   tag.innerHTML = `${skill.label} (${dcLabel})`;

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -96,8 +96,8 @@ HOOKS.bindArmament = {
   canUse() {
     const boundArmamentId = this.actor.getFlag("crucible", this.id);
     const mainhandId = this.actor.equipment.weapons.mainhand.id;
-    if ( !mainhandId ) throw new Error("no mainhand weapon");
-    else if ( mainhandId === boundArmamentId ) throw new Error("weapon is already bound");
+    if ( !mainhandId ) throw new Error(_loc("SPELL.WARNINGS.BindArmamentNoMainhand"));
+    else if ( mainhandId === boundArmamentId ) throw new Error(_loc("SPELL.WARNINGS.BindArmamentAlreadyBound"));
   },
   preActivate() {
     const mainhandId = this.actor.equipment.weapons.mainhand.id;
@@ -124,10 +124,10 @@ HOOKS.bodyBlock = {
     for ( const outcome of targetAction.outcomes.values() ) {
       if ( outcome.target.uuid !== this.actor.uuid ) continue;
       if ( !targetAction.tags.has("melee") ) {
-        throw new Error("You may only use Body Block against an incoming melee attack.");
+        throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.BODY_BLOCK.MeleeOnly"));
       }
       if ( targetAction.message.flags.crucible.confirmed ) {
-        throw new Error("The attack against you has already been confirmed and can no longer be blocked.");
+        throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.BODY_BLOCK.AlreadyConfirmed"));
       }
       const results = game.system.api.dice.AttackRoll.RESULT_TYPES;
       for ( const r of outcome.rolls ) {
@@ -138,7 +138,7 @@ HOOKS.bodyBlock = {
         }
       }
     }
-    throw new Error("You may only use Body Block after an attack against you is defended by Armor or Glance.");
+    throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.BODY_BLOCK.InvalidOutcome"));
   }
 };
 
@@ -245,7 +245,7 @@ HOOKS.counterspell = {
     if ( targetMessage.getFlag("crucible", "confirmed") !== reverse ) {
       const desiredChange = _loc(`DICE.${reverse ? "Reverse" : "Confirm"}`);
       const problemState = _loc(`ACTION.${reverse ? "Unconfirmed" : "Confirmed"}`);
-      const errorText = `Cannot ${desiredChange} a counterspell if the targeted spell is already ${problemState}!`;
+      const errorText = _loc("SPELL.COUNTERSPELL.WARNINGS.CannotConfirm", {change: desiredChange, state: problemState});
       ui.notifications.warn(errorText);
       throw new Error(errorText);
     }
@@ -270,10 +270,10 @@ HOOKS.decisiveAction = {
 HOOKS.delay = {
   canUse() {
     if ( game.combat?.combatant?.actor !== this.actor ) {
-      throw new Error("You may only use the Delay action on your own turn in combat.");
+      throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.DELAY.WrongTurn"));
     }
     if ( this.actor.flags.crucible?.delay ) {
-      throw new Error("You may not delay your turn again this combat round.");
+      throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.DELAY.AlreadyDelayed"));
     }
   },
   // TODO refactor to roll()?
@@ -506,12 +506,12 @@ HOOKS.hamstring = {
     const mh = this.actor.equipment.weapons.mainhand;
     const oh = this.actor.equipment.weapons.offhand;
     if ( ![mh.system.damageType, oh.system.damageType].includes("slashing") ) {
-      throw new Error(`${this.name} requires a melee weapon which deals slashing damage.`);
+      throw new Error(_loc("ACTION.WARNINGS.RequiresSlashingMelee", {action: this.name}));
     }
   },
   preActivate(targets) {
     if ( this.usage.weapon.system.damageType !== "slashing" ) {
-      throw new Error(`${this.name} requires a melee weapon which deals slashing damage.`);
+      throw new Error(_loc("ACTION.WARNINGS.RequiresSlashingMelee", {action: this.name}));
     }
   }
 };
@@ -594,7 +594,7 @@ HOOKS.oozeSubdivide = {
     foundry.utils.mergeObject(this.usage.actorUpdates, {system: systemData});
   },
   canUse() {
-    if ( this.actor.size < 3 ) throw new Error(`You must be at least size 3 to use ${this.name}`);
+    if ( this.actor.size < 3 ) throw new Error(_loc("ACTION.WARNINGS.MinimumSize", {size: 3, action: this.name}));
   }
 };
 
@@ -673,7 +673,10 @@ HOOKS.rallyingTonic = {
 HOOKS.reactiveStrike = {
   canUse() {
     for ( const s of ["unaware", "flanked"] ) {
-      if ( this.actor.statuses.has(s) ) throw new Error(`You may not perform a Reactive Strike while ${s}.`);
+      if ( this.actor.statuses.has(s) ) {
+        const statusLabel = _loc(CONFIG.statusEffects[s]?.name ?? s);
+        throw new Error(_loc("ACTION.WARNINGS.BadStatus", {action: this.name, status: statusLabel}));
+      }
     }
   }
 };
@@ -730,7 +733,7 @@ HOOKS.refocus = {
   },
   preActivate(_targets) {
     if ( !["talisman1", "talisman2"].includes(this.usage.weapon?.category) ) {
-      throw new Error(`${this.name} requires use of a Talisman weapon.`);
+      throw new Error(_loc("ACTION.WARNINGS.RequiresTalisman", {action: this.name}));
     }
   },
   async confirm() {

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -617,7 +617,7 @@ HOOKS.snakeblood000000 = {
 HOOKS.sorcerer00000000 = {
   useAction(item, action) {
     if ( action.tags.has("iconicSpell") ) {
-      throw new Error(`As a ${item.name}, you cannot cast Iconic Spells.`);
+      throw new Error(_loc("SPELL.WARNINGS.SorcererNoIconic", {talent: item.name}));
     }
   },
   preActivateAction(item, action) {

--- a/module/models/actor-group.mjs
+++ b/module/models/actor-group.mjs
@@ -145,8 +145,8 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
    * @returns {Promise<void>}         The updated group Actor
    */
   async addMember(actor, quantity=1) {
-    if ( !(actor instanceof Actor) || actor.pack ) throw new Error("You can only add a World Actor");
-    if ( actor === this.parent ) throw new Error("You cannot add your own group!");
+    if ( !(actor instanceof Actor) || actor.pack ) throw new Error(_loc("ACTOR.GROUP.WARNINGS.NotWorldActor"));
+    if ( actor === this.parent ) throw new Error(_loc("ACTOR.GROUP.WARNINGS.NoAddSelf"));
 
     // Prepare operation data
     const toJoin = new Map();
@@ -233,11 +233,11 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
     const recipientHTML = [];
 
     // Verify inputs
-    if ( !Number.isInteger(number) || (number < 1) ) throw new Error("The number of milestones awarded must be a "
-      + "positive integer");
+    if ( !Number.isInteger(number) || (number < 1) ) throw new Error(_loc("AWARD.WARNINGS.InvalidMilestoneNumber"));
     const milestones = foundry.utils.deepClone(this._source.advancement.milestones);
-    if ( identifier in milestones ) throw new Error(`A milestone with identifier "${identifier}" has already 
-    been awarded to group "${this.parent.name}"`);
+    if ( identifier in milestones ) {
+      throw new Error(_loc("AWARD.WARNINGS.DuplicateMilestone", {identifier, group: this.parent.name}));
+    }
 
     // Configure group award
     milestones[identifier] = {number, reason};
@@ -259,7 +259,7 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
     recipientIds ||= Array.from(this.memberIds);
     for ( const id of recipientIds ) {
       const actor = game.actors.get(id);
-      if ( !actor || (actor.type !== "hero") ) throw new Error(`Actor ID "${id}" cannot be awarded a milestone`);
+      if ( !actor || (actor.type !== "hero") ) throw new Error(_loc("AWARD.WARNINGS.InvalidMilestoneRecipient", {id}));
       recipientHTML.push(`<li>${actor.name}</li>`);
       const actorMilestones = actor.system._source.advancement.milestones + number;
       actorUpdates.push({_id: id, system: {advancement: {milestones: actorMilestones}}});
@@ -295,8 +295,9 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
 
     // Configure group award
     const milestones = foundry.utils.deepClone(this._source.advancement.milestones);
-    if ( !(identifier in milestones) ) throw new Error(`There is no milestone award with identifier 
-    "${identifier}" on group "${this.parent.name}"`);
+    if ( !(identifier in milestones) ) {
+      throw new Error(_loc("AWARD.WARNINGS.CannotRevokeMilestone", {identifier, group: this.parent.name}));
+    }
     const number = milestones[identifier].number;
     delete milestones[identifier];
     actorUpdates.push({_id: this.parent.id, system: {advancement: {milestones: _replace(milestones)}}});
@@ -311,7 +312,7 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
     recipientIds ||= Array.from(this.memberIds);
     for ( const id of recipientIds ) {
       const actor = game.actors.get(id);
-      if ( !actor || (actor.type !== "hero") ) throw new Error(`Actor ID "${id}" have a milestone revoked`);
+      if ( !actor || (actor.type !== "hero") ) throw new Error(_loc("AWARD.WARNINGS.InvalidMilestoneRevokee", {id}));
       recipientHTML.push(`<li>${actor.name}</li>`);
       const actorMilestones = Math.max(actor.system._source.advancement.milestones - number, 0);
       actorUpdates.push({_id: id, system: {advancement: {milestones: actorMilestones}}});
@@ -340,7 +341,7 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
    * @returns {Promise<void>}
    */
   async awardMilestoneDialog(options={}) {
-    if ( !game.user.isGM ) throw new Error("You must be a Gamemaster user to award milestones.");
+    if ( !game.user.isGM ) throw new Error(_loc("AWARD.WARNINGS.RequiresGM"));
 
     // Prepare form data
     const heroes = this.members.reduce((obj, {actor}) => {
@@ -396,7 +397,7 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
    * @returns {Promise<void>}
    */
   async revokeMilestoneDialog() {
-    if ( !game.user.isGM ) throw new Error("You must be a Gamemaster user to revoke milestones.");
+    if ( !game.user.isGM ) throw new Error(_loc("AWARD.WARNINGS.RequiresGM"));
 
     // Prepare form data
     const heroes = this.members.reduce((obj, {actor}) => {

--- a/module/models/combat-combat.mjs
+++ b/module/models/combat-combat.mjs
@@ -80,8 +80,8 @@ export default class CrucibleCombatChallenge extends foundry.abstract.TypeDataMo
       <table class="initiative-table" data-combat-id="${this.parent.id}">
         <thead>
           <tr>
-              <th class="initiative-name">Combatant</th>
-              <th class="initiative-value" colspan="2">Result</th>
+              <th class="initiative-name">${_loc("COMBAT.INITIATIVE.Combatant")}</th>
+              <th class="initiative-value" colspan="2">${_loc("COMBAT.INITIATIVE.Result")}</th>
           </tr>
         </thead>
         <tbody>
@@ -90,7 +90,7 @@ export default class CrucibleCombatChallenge extends foundry.abstract.TypeDataMo
       </table>
       </section>`,
       rolls,
-      speaker: {user: game.user, alias: `Initiative - Round ${round}`},
+      speaker: {user: game.user, alias: _loc("COMBAT.INITIATIVE.Round", {round})},
       "flags.crucible.isInitiativeReport": true
     });
   }
@@ -146,13 +146,14 @@ export default class CrucibleCombatChallenge extends foundry.abstract.TypeDataMo
     const meters = [ui.combat.element.querySelector(".heroism-meter")];
     if ( ui.combat.popout?.rendered ) meters.push(ui.combat.popout.element.querySelector(".heroism-meter"));
     const heroism = game.combat.system.heroism;
-    const pct = `${Math.round(heroism.pct * 100)}%`;
+    const pct = Math.round(heroism.pct * 100);
     for ( const meter of meters ) {
       if ( !meter ) continue;
       const [bar, label] = meter.children;
       bar.style.width = pct;
-      label.innerText = `Heroism ${pct}`;
-      meter.dataset.tooltip = "Progress to next Heroism point";
+      label.innerText = _loc("COMBAT.HeroismPct", {pct});
+      meter.dataset.tooltip = "";
+      meter.ariaLabel = _loc("COMBAT.HeroismTooltip");
     }
   }
 }

--- a/module/models/fields.mjs
+++ b/module/models/fields.mjs
@@ -87,8 +87,7 @@ export class ItemIdentifierField extends fields.StringField {
    */
   static #validate(id) {
     if ( !ItemIdentifierField.#IDENTIFIER_REGEX.test(id) ) {
-      throw new Error(`Invalid Crucible identifier value "${id}" which must be alphanumeric without spaces or 
-      special characters`);
+      throw new Error(_loc("ITEM.WARNINGS.InvalidIdentifier", {id}));
     }
   }
 }

--- a/module/models/item-archetype.mjs
+++ b/module/models/item-archetype.mjs
@@ -51,7 +51,7 @@ export default class CrucibleArchetypeItem extends foundry.abstract.TypeDataMode
   static #validateAbilities(abilities, options) {
     if ( options.partial === true ) return;
     const sum = Object.values(abilities).reduce((t, n) => t + n, 0);
-    if ( sum !== 12 ) throw new Error(`The sum of ability scaling values must equal 12. Currently ${sum}`);
+    if ( sum !== 12 ) throw new Error(_loc("ARCHETYPE.WARNINGS.InvalidAbilities", {sum}));
   }
 
   /* -------------------------------------------- */
@@ -66,7 +66,7 @@ export default class CrucibleArchetypeItem extends foundry.abstract.TypeDataMode
     if ( spells.length < 2 ) return;
     const uuids = new Set();
     for ( const s of spells ) {
-      if ( uuids.has(s.item) ) throw new Error("There must not be duplicate spells on an archetype.");
+      if ( uuids.has(s.item) ) throw new Error(_loc("ARCHETYPE.WARNINGS.InvalidSpells"));
       uuids.add(s.item);
     }
   }

--- a/module/models/item-taxonomy.mjs
+++ b/module/models/item-taxonomy.mjs
@@ -58,7 +58,7 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
   static #validateAbilities(abilities, options) {
     if ( options.partial === true ) return;
     const sum = Object.values(abilities).reduce((t, n) => t + n, 0);
-    if ( sum !== 12 ) throw new Error(`The sum of initial ability values must equal 12. Currently ${sum}`);
+    if ( sum !== 12 ) throw new Error(_loc("TAXONOMY.WARNINGS.InvalidAbilities", {sum}));
   }
 
   /* -------------------------------------------- */
@@ -72,7 +72,7 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
   static #validateResistances(resistances, options) {
     if ( options.partial === true ) return;
     const sum = Object.values(resistances).reduce((t, n) => t + (n.immune ? 4 : n.value), 0);
-    if ( sum !== 0 ) throw new Error(`The sum of resistance scaling values must equal zero. Currently ${sum}`);
+    if ( sum !== 0 ) throw new Error(_loc("TAXONOMY.WARNINGS.InvalidResistances", {sum}));
   }
 
   /* -------------------------------------------- */

--- a/templates/dice/partials/action-use-header.hbs
+++ b/templates/dice/partials/action-use-header.hbs
@@ -9,7 +9,7 @@
 
     {{#if hasActionTags}}
     <div class="action-tags full-tags">
-        <label class="tag-icon" data-tooltip="Action Tags" data-tooltip-direction="LEFT">
+        <label class="tag-icon" data-tooltip="{{tags.action.tooltip}}" data-tooltip-direction="LEFT">
             <i class="fa-solid fa-bolt"></i>
         </label>
         {{crucibleTags tags.action tagType="action"}}
@@ -18,7 +18,7 @@
 
     {{#if hasContextTags}}
     <div class="context-tags full-tags">
-        <label class="tag-icon" data-tooltip="{{tags.context.label}}" data-tooltip-direction="LEFT">
+        <label class="tag-icon" data-tooltip="{{tags.context.tooltip}}" data-tooltip-direction="LEFT">
             <i class="{{tags.context.icon}}"></i>
         </label>
         {{crucibleTags tags.context tagType="context"}}


### PR DESCRIPTION
Closes #516 
The only _change_ in what an english-using user will see is that the "must be a GM" warnings for awarding & revoking milestones now just use the "must be a GM" award enricher text. This is because it's impossible for those dialogs to be opened any other way (we exit early without feedback if a non-gm clicks the milestone award button on a group sheet), and so I didn't think it made sense to create separate localizations for them.

As far as I am aware, the only remaining non-localized errors are ones which will only show up either in the console or as a result of something which can only be done programmatically.

I changed calls of `ui.notifications.warn("Something", {localize: true})` to `ui.notifications.warn(_loc("Something"))` for brevity and to make it more easily searchable where we're using localization, or for simplicity if we wanted to set up some sort of extension like i18n-ally.

**TBD**: Should the caught errors in `CrucibleAction##use` be logged in their entirety as they are now, or only their message? In their entirety means the forced `Error: ` prefix, but also means the stack automatically gets logged to console.