### PR TITLE
Fix region anchoring & max distance snapping

### DIFF
--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -278,7 +278,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
     await Promise.allSettled(minimizedWindows.map(app => app.minimize()));
 
     // Build the onMove callback
-    const onMove = ({shape, position, snap}) => {
+    const onMove = ({shape, position, document, snap}) => {
       switch (regionConfig.anchor) {
         case "self": // Lock position and rotate based on mouse position
           if ( regionConfig.directionDelta ) {
@@ -291,7 +291,9 @@ export default class ActionUseDialog extends StandardCheckDialog {
           const maxDistance = range.maximum ?? 0;
           if ( maxDistance === 0 ) Object.assign(position, origin);
           else {
-            const d = canvas.grid.measurePath([position, origin]).distance;
+            origin.elevation ??= 0;
+            const closestElevation = Math.clamp(origin.elevation, document.elevation.bottom, document.elevation.top);
+            const d = canvas.grid.measurePath([origin, {elevation: closestElevation, ...position}]).distance;
             if ( d <= maxDistance ) return;
             const rawAngle = Math.toDegrees(Math.atan2(position.y - origin.y, position.x - origin.x));
             position = canvas.grid.getTranslatedPoint(origin, rawAngle, maxDistance);


### PR DESCRIPTION
1. Swap `position` and `origin`, since the former will always be 2d and the latter may be 3d, which would break `measurePath`
2. Restore `shape.move` for distance-constrained region placement
3. Restore `return false` for crucible-managed region placement (by returning early in `default`)