### PR TITLE
[#743] Fix missing weapon choice for some offhand scenarios, re-add weapon context tags to action use dialog

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -601,6 +601,8 @@ export const TAGS = {
     prepare() {
       if ( !this.usage.weapon ) {
         const valid = this.getValidWeaponChoices({maxCost: this.actor.resources.action.value});
+
+        // Prefer mainhand weapon -> offhand weapon -> natural weapons
         for ( const weapon of valid ) {
           if ( !weapon.isValid ) continue;
           this.usage.weapon = weapon.item;

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -600,9 +600,13 @@ export const TAGS = {
     },
     prepare() {
       if ( !this.usage.weapon ) {
-        const valid = this.getValidWeaponChoices();
-        valid.sort((a, b) => a.item.system.actionCost - b.item.system.actionCost);
-        this.usage.weapon = valid[0]?.item;
+        const valid = this.getValidWeaponChoices({maxCost: this.actor.resources.action.value});
+        for ( const weapon of valid ) {
+          if ( !weapon.isValid ) continue;
+          this.usage.weapon = weapon.item;
+          break;
+        }
+        this.usage.weapon ??= valid[0]?.item;
       }
       const {strikes, weapon} = this.usage;
 
@@ -634,6 +638,8 @@ export const TAGS = {
           if ( !weaponRange ) weaponRange = weapon.system.range;
           else weaponRange = Math.min(weaponRange, weapon.system.range);
         }
+        contextTags[weapon.id] ||= {id: weapon.id, name: weapon.name, count: 0};
+        contextTags[weapon.id].count += 1;
         if ( i === 0 ) Object.assign(this.usage.bonuses, weapon.system.actionBonuses);
       }
 
@@ -649,7 +655,8 @@ export const TAGS = {
       // Context tags
       Object.assign(this.usage.context, {label: "Strikes", icon: "fa-solid fa-swords", tags: {}});
       for ( const v of Object.values(contextTags) ) {
-        this.usage.context.tags[`weapon.${v.id}`] = v.count > 1 ? `${v.name} (x${v.count})` : v.name;
+        const count = v.count * n;
+        this.usage.context.tags[`weapon.${v.id}`] = count > 1 ? `${v.name} (x${count})` : v.name;
       }
 
       // Configure action range

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1376,7 +1376,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
    * @param {object} [options]              Additional options
    * @param {boolean} [options.strict]      Whether to filter out invalid items or only mark them invalid
    * @param {number|null} [options.maxCost] If provided, consider weapons with greater action cost invalid
-   * @returns {{item: CrucibleWeaponItem, label: string}[]}
+   * @returns {{item: CrucibleWeaponItem, label: string, id: string, isValid: boolean}[]}
    */
   getValidWeaponChoices({strict=false, maxCost=null}={}) {
     const choices = [];

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1374,8 +1374,8 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
    * Get all equipped weapons which fulfil the requirements for this action, optionally excluding those which are
    * valid generally, but are not currently due to a lack of resource or being unloaded
    * @param {object} [options]              Additional options
-   * @param {boolean} [options.strict]      Whether to filter out items which can't be used due to a transient condition
-   * @param {number|null} [options.maxCost] If provided, filter out weapons with greater action cost
+   * @param {boolean} [options.strict]      Whether to filter out invalid items or only mark them invalid
+   * @param {number|null} [options.maxCost] If provided, consider weapons with greater action cost invalid
    * @returns {{item: CrucibleWeaponItem, label: string}[]}
    */
   getValidWeaponChoices({strict=false, maxCost=null}={}) {
@@ -1384,21 +1384,33 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
     const isValidChoice = weapon => {
       if ( this.tags.has("reload") ) return weapon.system.needsReload;
-      let isValid = this.tags.has("ranged") && weapon.config.category.ranged && !(strict && weapon.system.needsReload);
+      let isValid = this.tags.has("ranged") && weapon.config.category.ranged && !weapon.system.needsReload;
       isValid ||= this.tags.has("melee") && !weapon.config.category.ranged;
       if ( maxCost !== null ) isValid &&= weapon.system.actionCost <= maxCost;
       return isValid;
     };
     const isNatural = this.tags.has("natural");
-    if ( mh && !isNatural && isValidChoice(mh) ) {
-      choices.push({item: mh, id: mh.id || "mainhandUnarmed", label: `${mh.name} (${SYSTEM.WEAPON.SLOTS.labels.MAINHAND})`});
+    if ( mh && !isNatural ) {
+      const isValid = isValidChoice(mh);
+      if ( !strict || isValid ) choices.push({
+        item: mh,
+        id: mh.id || "mainhandUnarmed",
+        label: `${mh.name} (${SYSTEM.WEAPON.SLOTS.labels.MAINHAND})`,
+        isValid
+      });
     }
-    if ( oh && !isNatural && isValidChoice(oh) ) {
-      choices.push({item: oh, id: oh.id || "offhandUnarmed", label: `${oh.name} (${SYSTEM.WEAPON.SLOTS.labels.OFFHAND})`});
+    if ( oh && !isNatural ) {
+      const isValid = isValidChoice(oh);
+      if ( !strict || isValid ) choices.push({
+        item: oh,
+        id: oh.id || "offhandUnarmed",
+        label: `${oh.name} (${SYSTEM.WEAPON.SLOTS.labels.OFFHAND})`,
+        isValid
+      });
     }
     if ( !this.tags.has("ranged") ) {
       for ( const n of natural ) {
-        choices.push({item: n, id: n.id, label: `${n.name} (${SYSTEM.WEAPON.PROPERTIES.natural.label})`});
+        choices.push({item: n, id: n.id, label: `${n.name} (${SYSTEM.WEAPON.PROPERTIES.natural.label})`, isValid: true});
       }
     }
     return choices;

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1386,7 +1386,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       if ( this.tags.has("reload") ) return weapon.system.needsReload;
       let isValid = this.tags.has("ranged") && weapon.config.category.ranged && !weapon.system.needsReload;
       isValid ||= this.tags.has("melee") && !weapon.config.category.ranged;
-      if ( maxCost !== null ) isValid &&= weapon.system.actionCost <= maxCost;
+      if ( maxCost !== null ) isValid &&= (weapon.system.actionCost <= maxCost);
       return isValid;
     };
     const isNatural = this.tags.has("natural");
@@ -1410,7 +1410,14 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     }
     if ( !this.tags.has("ranged") ) {
       for ( const n of natural ) {
-        choices.push({item: n, id: n.id, label: `${n.name} (${SYSTEM.WEAPON.PROPERTIES.natural.label})`, isValid: true});
+        const isValid = (maxCost !== null) ? (n.system.actionCost <= maxCost) : true;
+        if ( strict && !isValid ) continue;
+        choices.push({
+          item: n,
+          id: n.id,
+          label: `${n.name} (${SYSTEM.WEAPON.PROPERTIES.natural.label})`,
+          isValid
+        });
       }
     }
     return choices;

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -676,7 +676,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     weapons.dualWield = weapons.unarmed || (mh?.id && oh?.id && !weapons.shield);
     weapons.dualMelee = weapons.dualWield && !mhCategory.ranged && !ohCategory.ranged;
     weapons.dualRanged = weapons.dualWield && mhCategory.ranged && ohCategory.ranged;
-    weapons.hasChoice = weapons.dualWield || (weapons.natural.length > 0) || (weapons.melee && weapons.ranged);
+    weapons.hasChoice = (weapons.natural.length > 0) || !weapons.twoHanded;
 
     // Special Properties
     weapons.reload = mhCategory.reload || ohCategory.reload;


### PR DESCRIPTION
Closes #743 

Changes:
- `weapons.hasChoice` is now only not true if no natural weapons and a two-handed weapon is wielded
- If `strict` not passed to `getValidWeaponChoices`, all possible weapons are returned (besides natural - maybe we could change that), but with `isValid: false`. This lets us properly select a default weapon, for instance, in the `strike` tag's `prepare` hook
- Re-added context tags to show what weapon is being used for a `strike` (I think maybe these got accidentally lost)