### PR TITLE
[#734] Convert common & dress clothing to armor

### DIFF
--- a/_source/equipment/Common_Clothing_commonClothing00.yml
+++ b/_source/equipment/Common_Clothing_commonClothing00.yml
@@ -1,41 +1,43 @@
+folder: D03SIA37tnsn3qBB
 name: Common Clothing
+type: armor
+_id: commonClothing00
 img: icons/equipment/chest/shirt-collared-brown.webp
-type: accessory
 system:
   identifier: clothingCommon
-  category: clothing
-  enchantment: mundane
-  quality: standard
-  price: 20
+  category: unarmored
   quantity: 1
   weight: 1
+  price: 20
+  quality: standard
+  broken: false
+  enchantment: mundane
   equipped: false
   invested: false
+  properties: []
   description:
     public: >-
       <p>A shirt, pair of pants, undergarments, socks and shoes or boots
-      suitable for menial labour or travel, cannot be worn with armor.</p>
+      suitable for menial labor or travel.</p>
     private: ''
-  broken: false
-  properties: []
   actions: []
   actorHooks: []
-folder: GVbpo5LtAY44QZPD
+  armor:
+    base: 0
 effects: []
+sort: 0
 ownership:
   default: 0
-  ifaQA7jTJsr3UWFE: 3
+  4uFKaoDjEQwkkXjq: 3
 flags: {}
 _stats:
+  coreVersion: '14.356'
+  systemId: crucible
+  systemVersion: 0.9.0
+  createdTime: 1773691189137
+  modifiedTime: 1773691215429
+  lastModifiedBy: 4uFKaoDjEQwkkXjq
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
-  systemId: crucible
-  systemVersion: 0.8.6
-  createdTime: 1768583216182
-  modifiedTime: 1773514792263
-  lastModifiedBy: ifaQA7jTJsr3UWFE
-_id: commonClothing00
-sort: 100000
 _key: '!items!commonClothing00'

--- a/_source/equipment/Dress_Clothing_dressClothing000.yml
+++ b/_source/equipment/Dress_Clothing_dressClothing000.yml
@@ -1,16 +1,20 @@
+folder: D03SIA37tnsn3qBB
 name: Dress Clothing
+type: armor
+_id: dressClothing000
 img: icons/equipment/chest/robe-layered-red.webp
-type: accessory
 system:
   identifier: clothingDress
-  category: clothing
-  enchantment: mundane
-  quality: standard
-  price: 60
+  category: unarmored
   quantity: 1
   weight: 2
+  price: 60
+  quality: standard
+  broken: false
+  enchantment: mundane
   equipped: false
   invested: false
+  properties: []
   description:
     public: >-
       <p>A regal set of fine vestments fit for attending celebrations and high
@@ -18,26 +22,24 @@ system:
       fine shirt or corset, a vest or bodice, trousers or petticoat, belt or
       braces, stockings and fine shoes.</p>
     private: ''
-  broken: false
-  properties: []
   actions: []
   actorHooks: []
-folder: GVbpo5LtAY44QZPD
+  armor:
+    base: 0
 effects: []
+sort: 0
 ownership:
   default: 0
-  ifaQA7jTJsr3UWFE: 3
+  4uFKaoDjEQwkkXjq: 3
 flags: {}
 _stats:
+  coreVersion: '14.356'
+  systemId: crucible
+  systemVersion: 0.9.0
+  createdTime: 1773691236008
+  modifiedTime: 1773691264240
+  lastModifiedBy: 4uFKaoDjEQwkkXjq
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
-  systemId: crucible
-  systemVersion: 0.8.6
-  createdTime: 1768583364829
-  modifiedTime: 1773514792265
-  lastModifiedBy: ifaQA7jTJsr3UWFE
-_id: dressClothing000
-sort: 200000
 _key: '!items!dressClothing000'

--- a/_source/equipment/Unarmored_D03SIA37tnsn3qBB.yml
+++ b/_source/equipment/Unarmored_D03SIA37tnsn3qBB.yml
@@ -1,0 +1,20 @@
+type: Item
+folder: P66MZ5Z1cWYB1TwJ
+name: Unarmored
+color: null
+sorting: a
+_id: D03SIA37tnsn3qBB
+description: ''
+sort: 0
+flags: {}
+_stats:
+  coreVersion: '14.356'
+  systemId: crucible
+  systemVersion: 0.9.0
+  createdTime: 1773690390537
+  modifiedTime: 1773690390537
+  lastModifiedBy: 4uFKaoDjEQwkkXjq
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+_key: '!folders!D03SIA37tnsn3qBB'


### PR DESCRIPTION
Closes #734 **if** "Weather Clothing" is intended to be worn atop existing armor. Otherwise need to convert that as well.

Changed the description of Common Clothing:
- `labour` -> `labor` (it was that or rename `armor` to `armour`)
- Removed the stipulation that it cannot be worn with armor, since that wasn't present for dress clothing & is now enforced by virtue of being armor