### PR TITLE
Remove unclear references to Finesse/Brute, fix some tag rules & i18n

### DIFF
--- a/_source/rules/Character_Mechanics_characterMechani.yml
+++ b/_source/rules/Character_Mechanics_characterMechani.yml
@@ -332,27 +332,26 @@ pages:
         below.</p><h2 class="divider">Strength</h2><p>Strength is a physical
         power attribute describing a creature's potency, brawn and might.
         Strength affects <strong>Fortitude</strong> defense, carrying
-        <strong>Capacity</strong>, and the use of weaponry with the
-        <strong>Brute</strong> trait. Each point of Strength increases base
-        <strong>Health</strong> by 2.</p><section class="gameplay"><p>Characters
-        with high Strength are typically capable of feats of physical prowess.
-        They may wield oversized or heavy weaponry, wear heavy suits of armor,
-        or use their brawn to physically subdue their
-        opponents.</p></section><p>Creatures with zero Strength are incapable of
-        exerting physical influence on the world around them. They may not
-        possess equipment nor can they physically interact with objects. They
-        may not perform any Action which scales only using the physical ability
-        scores of Strength, Toughness, and Dexterity.</p><h2
-        class="divider">Toughness</h2><p>Toughness is a physical resilience
-        attribute describing physical hardiness and tenacity. Toughness affects
-        the <strong>Fortitude</strong> defense. Each point of Toughness
-        increases base <strong>Health</strong> by 4.</p><section
-        class="gameplay"><p>Characters with high Toughness can typically
-        withstand considerable physical strain, demonstrating both grit and
-        endurance in demanding situations. They may thrive amidst the center of
-        danger, using their tenacity to hold or break the frontlines of
-        combat.</p></section><p>Creatures with zero Toughness are incorporeal or
-        otherwise have no meaningful physical form. They have no
+        <strong>Capacity</strong>, and the use of weaponry which scales with
+        Strength. Each point of Strength increases base <strong>Health</strong>
+        by 2.</p><section class="gameplay"><p>Characters with high Strength are
+        typically capable of feats of physical prowess. They may wield oversized
+        or heavy weaponry, wear heavy suits of armor, or use their brawn to
+        physically subdue their opponents.</p></section><p>Creatures with zero
+        Strength are incapable of exerting physical influence on the world
+        around them. They may not possess equipment nor can they physically
+        interact with objects. They may not perform any Action which scales only
+        using the physical ability scores of Strength, Toughness, and
+        Dexterity.</p><h2 class="divider">Toughness</h2><p>Toughness is a
+        physical resilience attribute describing physical hardiness and
+        tenacity. Toughness affects the <strong>Fortitude</strong> defense. Each
+        point of Toughness increases base <strong>Health</strong> by
+        4.</p><section class="gameplay"><p>Characters with high Toughness can
+        typically withstand considerable physical strain, demonstrating both
+        grit and endurance in demanding situations. They may thrive amidst the
+        center of danger, using their tenacity to hold or break the frontlines
+        of combat.</p></section><p>Creatures with zero Toughness are incorporeal
+        or otherwise have no meaningful physical form. They have no
         <strong>Health</strong> pool and can become neither @Condition[weakened]
         nor @Condition[dead]. Any amount of Health they would have possessed
         contributes to their <strong>Morale</strong> pool instead. The creature
@@ -361,16 +360,15 @@ pages:
         attribute that reflects agility and precision of movement. Dexterity
         affects <strong>Initiative</strong> in taking action, the
         <strong>Dodge</strong> component of Physical Defense,
-        <strong>Reflex</strong> defense, and the use of weaponry with the
-        <strong>Finesse</strong> trait.</p><section
-        class="gameplay"><p>Characters with high Dexterity typically act
-        swiftly, favoring quickness and precision of movement over pure power.
-        They may wield weapons that allow for nimble movement or offer ranged
-        capabilities, seeking to outmaneuver their foes before they even get a
-        chance to act.</p></section><p>Creatures with zero Dexterity are
-        inherently sluggish or ponderous. Their <strong>Initiative</strong> is
-        always zero and they may not perform any actions with the
-        <strong>Reaction</strong> tag.</p><h2
+        <strong>Reflex</strong> defense, and the use of weaponry which scales
+        with Dexterity.</p><section class="gameplay"><p>Characters with high
+        Dexterity typically act swiftly, favoring quickness and precision of
+        movement over pure power. They may wield weapons that allow for nimble
+        movement or offer ranged capabilities, seeking to outmaneuver their foes
+        before they even get a chance to act.</p></section><p>Creatures with
+        zero Dexterity are inherently sluggish or ponderous. Their
+        <strong>Initiative</strong> is always zero and they may not perform any
+        actions with the <strong>Reaction</strong> tag.</p><h2
         class="divider">Wisdom</h2><p>Wisdom is a mental power attribute
         describing a creature's force of conviction, depth of knowledge, and
         patience. Wisdom affects <strong>Willpower</strong> defense and size of
@@ -426,12 +424,12 @@ pages:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '13.351'
+      coreVersion: '14.356'
       systemId: crucible
       systemVersion: 0.9.0
       createdTime: 1761771265716
-      modifiedTime: 1768862328846
-      lastModifiedBy: AnoypGxxNIMOS0XY
+      modifiedTime: 1773776410891
+      lastModifiedBy: 4uFKaoDjEQwkkXjq
     _key: '!journal.pages!characterMechani.abilityScores000'
   - _id: talents000000000
     name: Talents

--- a/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
+++ b/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
@@ -488,21 +488,21 @@ pages:
         describes the breadth of the wall and a <strong>Distance</strong> which
         describes the maximum range at which the center of the wall may be
         placed.</p><h2 class="divider">Action Tags</h2><table><thead><tr><th
-        style="width:30%">Tag</th><th>Rules
-        Effect</th></tr></thead><tbody><tr><td><p>Dual
+        style="width:30%"><p>Tag</p></th><th><p>Rules
+        Effect</p></th></tr></thead><tbody><tr><td><p>Dual
         Wield</p></td><td><p>Requires one-handed or unarmed weapons equipped in
         both hands.</p></td></tr><tr><td><p>One Handed</p></td><td><p>Requires
         use of a one-handed
         weapon.</p></td></tr><tr><td><p>Finesse</p></td><td><p>Requires use of a
-        melee weapon that scales using
-        Dexterity.</p></td></tr><tr><td><p>Heavy</p></td><td><p>Requires use of
-        a melee weapon that scales using
+        weapon that scales using
+        Dexterity.</p></td></tr><tr><td><p>Brute</p></td><td><p>Requires use of
+        a weapon that scales using
         Strength.</p></td></tr><tr><td><p>Melee</p></td><td><p>Requires use of a
-        melee weapon.</p></td></tr><tr><td><p>Ranged</p></td><td><p>Requires use
-        of a ranged
-        weapon.</p></td></tr><tr><td><p>Shield</p></td><td><p>Requires a shield
-        equipped.</p></td></tr><tr><td><p>Unarmed</p></td><td><p>Requires both
-        hands to be
+        melee weapon or being
+        unarmed.</p></td></tr><tr><td><p>Ranged</p></td><td><p>Requires use of a
+        ranged weapon.</p></td></tr><tr><td><p>Shield</p></td><td><p>Requires a
+        shield equipped.</p></td></tr><tr><td><p>Unarmed</p></td><td><p>Requires
+        both hands to be
         empty.</p></td></tr><tr><td><p>Unarmored</p></td><td><p>Requires no
         armor to be
         equipped.</p></td></tr><tr><td><p>Movement</p></td><td><p>Involves
@@ -510,19 +510,19 @@ pages:
         turn.</p></td></tr><tr><td><p>Reaction</p></td><td><p>Can only be
         performed on some other creature's
         turn.</p></td></tr><tr><td><p>Spell</p></td><td><p>Involves casting a
-        spell.</p></td></tr><tr><td><p>Mainhand</p></td><td><p>Involves
-        performing a weapon attack with the mainhand-equipped
-        weapon.</p></td></tr><tr><td><p>Twohand</p></td><td><p>Involves
+        spell.</p></td></tr><tr><td><p>Main-Hand</p></td><td><p>Involves
+        performing a weapon attack with the main-hand-equipped
+        weapon.</p></td></tr><tr><td><p>Two-Handed</p></td><td><p>Involves
         performing a weapon attack with a two-handed equipped
-        weapon.</p></td></tr><tr><td><p>Offhand</p></td><td><p>Involves
-        performing a weapon attack with the offhand-equipped
+        weapon.</p></td></tr><tr><td><p>Off-Hand</p></td><td><p>Involves
+        performing a weapon attack with the off-hand-equipped
         weapon.</p></td></tr><tr><td><p>Reload</p></td><td><p>Reloads a ranged
         weapon that requires
         reloading.</p></td></tr><tr><td><p>Deadly</p></td><td><p>Gains a +1
-        damage overflow
+        damage
         multiplier.</p></td></tr><tr><td><p>Difficult</p></td><td><p>Incurs +1
         Bane.</p></td></tr><tr><td><p>Empowered</p></td><td><p>Increases base
-        damage by +6.</p></td></tr><tr><td><p>Exposing</p></td><td><p>Adds +2
+        damage by +6.</p></td></tr><tr><td><p>Accurate</p></td><td><p>Adds +2
         Boons.</p></td></tr><tr><td><p>Harmless</p></td><td><p>Always deals zero
         damage.</p></td></tr><tr><td><p>Weakened</p></td><td><p>Reduces base
         damage by -6.</p></td></tr><tr><td><p>Fortitude</p></td><td><p>Targets
@@ -551,10 +551,10 @@ pages:
     _stats:
       systemId: crucible
       systemVersion: 0.8.6
-      coreVersion: '13.342'
+      coreVersion: '14.356'
       createdTime: 1684374854931
-      modifiedTime: 1684721315135
-      lastModifiedBy: AnoypGxxNIMOS0XY
+      modifiedTime: 1773778941668
+      lastModifiedBy: 4uFKaoDjEQwkkXjq
       compendiumSource: null
       duplicateSource: null
       exportSource: null

--- a/_source/talent/Light_Weapon_Training_lightWeaponTrain.yml
+++ b/_source/talent/Light_Weapon_Training_lightWeaponTrain.yml
@@ -15,8 +15,8 @@ system:
       condition: ''
       description: >-
         <p>You dart forward nimbly, making a strike with sudden and unexpected
-        swiftness to perform a <strong>Strike </strong>with a
-        <strong>Finesse</strong> weapon against a single target with an
+        swiftness to perform a <strong>Strike </strong>with a weapon which
+        scales using <strong>Dexterity</strong> against a single target, with an
         increased range of <strong>+2 feet</strong>.</p><p>The attack is
         <strong>Difficult</strong>, but you do not move from your current
         position nor does this attack provoke Disengagement.</p>
@@ -62,10 +62,10 @@ _stats:
   exportSource: null
   coreVersion: '14.356'
   systemId: crucible
-  systemVersion: 0.9.-alpha
+  systemVersion: 0.9.0
   createdTime: 1772307160138
-  modifiedTime: 1773514792593
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1773776810356
+  lastModifiedBy: 4uFKaoDjEQwkkXjq
 ownership:
   default: 0
   AnoypGxxNIMOS0XY: 3

--- a/_source/talent/Weak_Points_weakpoints000000.yml
+++ b/_source/talent/Weak_Points_weakpoints000000.yml
@@ -5,10 +5,9 @@ img: icons/skills/melee/strike-sword-stabbed-brown.webp
 system:
   description: >-
     <p>You identify moments of opportunity to strike at an enemy's weak points.
-    When attacking a target that is <strong>Unaware</strong>,
-    <strong>Flanked</strong>, or <strong>Exposed</strong> using a weapon which
-    scales with <strong>Dexterity</strong>, you gain +2 damage to any
-    Strike.</p>
+    When attacking a target that is @Condition[unaware], @Condition[flanked], or
+    @Condition[exposed] using a weapon which scales with
+    <strong>Dexterity</strong>, you gain +2 damage to any Strike.</p>
   actions: []
   nodes:
     - dex0b
@@ -25,9 +24,9 @@ flags: {}
 _stats:
   systemId: crucible
   systemVersion: 0.9.0
-  coreVersion: '14.356'
+  coreVersion: '14.358'
   createdTime: 1772307160154
-  modifiedTime: 1773776889263
+  modifiedTime: 1774794070385
   lastModifiedBy: 4uFKaoDjEQwkkXjq
   compendiumSource: null
   duplicateSource: null

--- a/_source/talent/Weak_Points_weakpoints000000.yml
+++ b/_source/talent/Weak_Points_weakpoints000000.yml
@@ -4,10 +4,11 @@ _id: weakpoints000000
 img: icons/skills/melee/strike-sword-stabbed-brown.webp
 system:
   description: >-
-    You identify moments of opportunity to strike at an enemy's weak points.
+    <p>You identify moments of opportunity to strike at an enemy's weak points.
     When attacking a target that is <strong>Unaware</strong>,
-    <strong>Flanked</strong>, or <strong>Exposed</strong> using Finesse
-    weaponry, you gain +2 damage to any Strike.
+    <strong>Flanked</strong>, or <strong>Exposed</strong> using a weapon which
+    scales with <strong>Dexterity</strong>, you gain +2 damage to any
+    Strike.</p>
   actions: []
   nodes:
     - dex0b
@@ -26,8 +27,8 @@ _stats:
   systemVersion: 0.9.0
   coreVersion: '14.356'
   createdTime: 1772307160154
-  modifiedTime: 1773514792627
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1773776889263
+  lastModifiedBy: 4uFKaoDjEQwkkXjq
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/lang/en.json
+++ b/lang/en.json
@@ -250,13 +250,13 @@
       "Deadly": "Deadly",
       "DeadlyTooltip": "This action has the potential to deal a tremendous amount of damage, increasing the damage multiplier for any damage dealt by x1.",
       "Difficult": "Difficult",
-      "DifficultTooltip": "This action is complicated or challenging to perform. You incur 2 additional banes when attempting the action.",
+      "DifficultTooltip": "This action is complicated or challenging to perform. You incur 1 additional bane when attempting the action.",
       "Disarm": "Disarm",
       "DisarmTooltip": "This action, if successful, causes the target's weapon to be dropped.",
       "DualWield": "Dual Wield",
       "DualWieldTooltip": "This action requires wielding two separate weapons or being entirely unarmed to perform.",
       "Empowered": "Empowered",
-      "EmpoweredTooltip": "This action is powerful and deals additional damage, gaining a +2 damage bonus if successful.",
+      "EmpoweredTooltip": "This action is powerful and deals additional damage, gaining a +6 damage bonus if successful.",
       "Finesse": "Finesse",
       "FinesseTooltip": "This action requires a certain amount of finesse to perform. You must be wielding a weapon which scales using Dexterity.",
       "Flanking": "Flanking",
@@ -337,7 +337,7 @@
       "Vocal": "Vocal",
       "VocalTooltip": "This action requires its user to speak or otherwise vocalize sound.",
       "Weakened": "Weakened",
-      "WeakenedTooltip": "This action is weaker than normal attacks and has a -2 damage bonus."
+      "WeakenedTooltip": "This action is weaker than normal attacks and has a -6 damage bonus."
     },
     "TAG_CATEGORIES": {
       "Attack": "Attack",


### PR DESCRIPTION
Changes to character mechanics, because github has those big sections instead of the precise changes:
Before:
> Strength affects Fortitude defense, carrying Capacity, and the use of weaponry __with the Brute trait__.
> Dexterity affects Initiative in taking action, the Dodge component of Physical Defense, Reflex defense, and the use of weaponry __with the Finesse trait__.

After:
> Strength affects Fortitude defense, carrying Capacity, and the use of weaponry __which scales with Strength__.
> Dexterity affects Initiative in taking action, the Dodge component of Physical Defense, Reflex defense, and the use of weaponry __which scales with Dexterity__.

