### PR TITLE
Fix runes

### DIFF
--- a/_source/talent/Rune__Control_runeControl00000.yml
+++ b/_source/talent/Rune__Control_runeControl00000.yml
@@ -5,7 +5,7 @@ system:
   description: >-
     <p>The orderly force of discipline and permanence. The Control rune governs
     thought, reason, and persistence.</p><p>The Control rune scales using
-    <strong>Intellect</strong>, targets <strong>Willpower</strong>, and deals
+    <strong>Wisdom</strong>, targets <strong>Willpower</strong>, and deals
     <strong>Psychic</strong> damage to <strong>Morale</strong>. It is opposed by
     the chaotic rune of <strong>Kinesis</strong>.</p>
   actions:

--- a/_source/talent/Rune__Flame_runeFlame0000000.yml
+++ b/_source/talent/Rune__Flame_runeFlame0000000.yml
@@ -4,8 +4,8 @@ img: icons/magic/fire/barrier-wall-flame-ring-yellow.webp
 system:
   description: >-
     <p>The chaotic force of elemental, thermal energy. The Flame rune governs
-    fire and heat.</p><p>The Flame rune scales using <strong>Intellect</strong>, targets
-    <strong>Reflex</strong>, and deals <strong>Fire</strong> damage to
+    fire and heat.</p><p>The Flame rune scales using <strong>Intellect</strong>,
+    targets <strong>Reflex</strong>, and deals <strong>Fire</strong> damage to
     <strong>Health</strong>. It is opposed by the orderly rune of
     <strong>Frost</strong>.</p>
   actions:

--- a/_source/talent/Rune__Flame_runeFlame0000000.yml
+++ b/_source/talent/Rune__Flame_runeFlame0000000.yml
@@ -4,7 +4,7 @@ img: icons/magic/fire/barrier-wall-flame-ring-yellow.webp
 system:
   description: >-
     <p>The chaotic force of elemental, thermal energy. The Flame rune governs
-    fire and heat.</p><p>The Flame rune scales using Intellect, targets
+    fire and heat.</p><p>The Flame rune scales using <strong>Intellect</strong>, targets
     <strong>Reflex</strong>, and deals <strong>Fire</strong> damage to
     <strong>Health</strong>. It is opposed by the orderly rune of
     <strong>Frost</strong>.</p>

--- a/module/const/spellcraft.mjs
+++ b/module/const/spellcraft.mjs
@@ -17,7 +17,7 @@ export const RUNES = {
     damageType: "psychic",
     opposed: "kinesis",
     defense: "willpower",
-    scaling: "intellect",
+    scaling: "wisdom",
     nameFormat: NAME_FORMATS.NOUN
   },
   death: {


### PR DESCRIPTION
The control rune was scaling with Intellect when it is supposed to scale with Wisdom. This closes https://github.com/foundryvtt/crucible/issues/745
The flame rune was just missing the `<strong>` tag around the word Intellect. This is such a minor formatting thing that making an issue for it feels weird.
(sorry for closing a PR and then opening a new one, I was reorganizing my fork)