### PR TITLE
[#725] Update token ruler logic for clearer info presentation, fix non-direct movement bug

### DIFF
--- a/module/canvas/token-ruler.mjs
+++ b/module/canvas/token-ruler.mjs
@@ -14,19 +14,54 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
     const grid = canvas.scene?.grid;
     if ( !grid || (grid.distance !== 1) || (grid.units !== "ft") ) return;
 
-    // Recover prior cost (potentially across chains)
-    state.priorCost ??= actor.getMovementActionCost(waypoint.previous?.measurement.cost || 0).cost;
+    // Get measurement of prior subpath, if on new subpath
+    state.priorCost ??= 0;
+    state.priorDistance ??= 0;
+    if ( state.priorSubpathId !== waypoint.subpathId ) {
+      let previous = waypoint.previous;
+      while ( previous ) {
+        if ( previous.subpathId !== waypoint.subpathId ) break;
+        previous = previous.previous;
+      }
+      state.priorCost = waypoint.previous?.measurement.cost || 0;
+      state.priorDistance = waypoint.previous?.measurement.distance || 0;
+      state.priorSubpathId = waypoint.subpathId;
+    }
 
-    // Measure new segment
-    const movement = actor.getMovementActionCost(waypoint.measurement.cost);
-    const deltaCost = movement.cost - state.priorCost;
-    state.priorCost = movement.cost;
+    // Do not draw waypoint label for non-meaningful waypoints. Meaningful waypoints:
+    // - Are the final waypoint of a subpath
+    // - Change movement action
+    // - Change elevation
+    const isFinalOfSubpath = waypoint.next?.subpathId !== waypoint.subpathId;
+    const sameAction = waypoint.previous?.action === waypoint.action;
+    const sameElevation = waypoint.previous?.elevation === waypoint.elevation;
+    if ( !isFinalOfSubpath && sameElevation && sameAction) return;
 
-    context.distance.units = grid.units;
-    context.cost = {units: "A", delta: deltaCost};
-    context.cost.total = Number.isFinite(movement.cost) ? movement.cost : "Impossible";
-    context.cost.showTotal = !waypoint.next;
-    context.displayElevation = context.elevation && !context.elevation.hidden;
+    // Calculate cost of this subpath & set context appropriately
+    const movement = actor.getMovementActionCost(waypoint.measurement.cost - state.priorCost);
+    const freeMovementId = actor.system.status.freeMovementId;
+    const deltaCost = movement.cost - ((freeMovementId && (freeMovementId === waypoint.subpathId)) ? 1 : 0);
+    Object.assign(context.distance, {
+      units: grid.units,
+      total: (context.distance.total - state.priorDistance).toNearest(0.01).toLocaleString(game.i18n.lang)
+    });
+    context.cost = {
+      units: "A",
+      delta: Number.isFinite(deltaCost) ? deltaCost : "Impossible",
+      displayCost: isFinalOfSubpath
+    };
+    context.displayElevation = context.elevation && !context.elevation.hidden && (!sameElevation || waypoint.elevation);
     return context;
+  }
+
+  /** @override */
+  _getWaypointStyle(waypoint) {
+    const style = super._getWaypointStyle(waypoint);
+
+    // Undo core's treatment of starting waypoint as translucent, size-down intermediate waypoints
+    // TODO: If #11895 goes in, modify shape of intermediate waypoints to diamonds
+    if ( !waypoint.previous ) style.alpha = 1;
+    else if ( waypoint.next?.subpathId === waypoint.subpathId ) style.radius /= 2;
+    return style;
   }
 }

--- a/module/canvas/token-ruler.mjs
+++ b/module/canvas/token-ruler.mjs
@@ -18,11 +18,6 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
     state.priorCost ??= 0;
     state.priorDistance ??= 0;
     if ( state.priorSubpathId !== waypoint.subpathId ) {
-      let previous = waypoint.previous;
-      while ( previous ) {
-        if ( previous.subpathId !== waypoint.subpathId ) break;
-        previous = previous.previous;
-      }
       state.priorCost = waypoint.previous?.measurement.cost || 0;
       state.priorDistance = waypoint.previous?.measurement.distance || 0;
       state.priorSubpathId = waypoint.subpathId;
@@ -35,9 +30,11 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
     const isFinalOfSubpath = waypoint.next?.subpathId !== waypoint.subpathId;
     const sameAction = waypoint.previous?.action === waypoint.action;
     const sameElevation = waypoint.previous?.elevation === waypoint.elevation;
-    if ( !isFinalOfSubpath && sameElevation && sameAction) return;
+    if ( !isFinalOfSubpath && sameElevation && sameAction ) return;
 
-    // Calculate cost of this subpath & set context appropriately
+    // Calculate cost of this subpath & set context appropriately - free movement will be included in
+    // getMovementActionCost if the actor has not yet used their free movement, otherwise it will be applied
+    // retroactively by comparing freeMovementId against the subpath ID
     const movement = actor.getMovementActionCost(waypoint.measurement.cost - state.priorCost);
     const freeMovementId = actor.system.status.freeMovementId;
     const deltaCost = movement.cost - ((freeMovementId && (freeMovementId === waypoint.subpathId)) ? 1 : 0);
@@ -50,7 +47,15 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
       delta: Number.isFinite(deltaCost) ? deltaCost : "Impossible",
       displayCost: isFinalOfSubpath
     };
-    context.displayElevation = context.elevation && !context.elevation.hidden && (!sameElevation || waypoint.elevation);
+
+    // Display elevation when it changes or when different from the level.elevation.bottom
+    if ( context.elevation ) {
+      // TODO: Remove/adjust this modification after core implements
+      if ( game.release.build < 359 ) {
+        if ( Number.isFinite(canvas.level.elevation.bottom) ) context.elevation.total -= canvas.level.elevation.bottom;
+      }
+      context.displayElevation = !context.elevation.hidden && (!sameElevation || context.elevation.total);
+    }
     return context;
   }
 

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -245,7 +245,6 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
     if ( crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document) ) {
       options.planned = true;
     }
-    options.split = true; // Always split movement subpaths for discrete drag operations
     return options;
   }
 

--- a/templates/hud/token-ruler-waypoint-label.hbs
+++ b/templates/hud/token-ruler-waypoint-label.hbs
@@ -5,9 +5,8 @@
     <label class="action-label">{{localize action.label}}</label>
     {{/if}}
 
+    {{#if cost.displayCost}}
     <span class="total-measurement">{{distance.total}}{{distance.units}}</span>
-    {{#if distance.delta}}
-    <span class="delta-measurement">({{distance.delta}})</span>
     {{/if}}
 
     {{#if displayElevation}}
@@ -17,11 +16,9 @@
     <span class="delta-elevation">({{elevation.delta}})</span>
     {{/if}}
     {{/if}}
-
-    <span class="total-measurement delta-cost">{{cost.delta}}{{cost.units}}</span>
-    {{#if cost.showTotal}}
-    <span class="delta-measurement sep">=</span>
-    <span class="total-measurement total-cost">[{{cost.total}}{{cost.units}}]</span>
+    {{#if cost.displayCost}}
+    <span class="delta-measurement sep">|</span>
+    <span class="total-measurement total-cost">{{cost.delta}}{{cost.units}}</span>
     {{/if}}
     {{#if secret}}
     <i class="icon fa-solid fa-eye-slash"></i>


### PR DESCRIPTION
Closes #725 
Fixes an issue mentioned in the bug reports channel where normal movement could not be waypointed.

Will not be fully functional until V14 Testing 2 (requires https://github.com/foundryvtt/foundryvtt/issues/13985)

Example of multiple varying-in-complexity movements:
<img width="1144" height="556" alt="image" src="https://github.com/user-attachments/assets/bc20f1ac-cb5e-4297-9cfe-7a5a24d2558a" />