### PR TITLE
Update Crucible movement planning to use new upstream v14 API

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -240,89 +240,13 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   /* -------------------------------------------- */
 
   /** @override */
-  _addDragWaypoint(point, options) {
-    const dialog = crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document);
-    if ( dialog?.action.usage.movement.direct !== false ) {
-      ui.notifications.warn(_loc("ACTION.WARNINGS.DirectMovementOnly"));
-      return;
-    }
-    return super._addDragWaypoint(point, options);
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  _canDragLeftStart(user, event, {notify=true}={}) {
-    if ( crucible.api.dice.ActionUseDialog.activeMovementPlan
-      && !crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document) ) {
-      if ( notify ) ui.notifications.warn(_loc("ACTION.WARNINGS.WrongMovementToken"));
-      return false;
-    }
-    return super._canDragLeftStart(user, event, {notify});
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  constrainMovementPath(waypoints, options) {
-    const [path, constrained] = super.constrainMovementPath(waypoints, options);
-    if ( !options?.preview ) return [path, constrained];
-
-    // If we are in an action movement plan, constrain according to range limits
-    const dialog = crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document);
-    if ( !dialog ) return [path, constrained];
-    const {minimum: minRange, maximum: maxRange} = dialog.action.range;
-    if ( !minRange && !maxRange ) return [path, constrained];
-    const measurement = this.measureMovementPath(path, {...options.measureOptions, preview: options.preview});
-
-    // Below minimum range: treat the entire path as unreachable
-    if ( minRange && (measurement.cost < minRange) ) return [[path[0]], true];
-
-    // Above maximum range: truncate at the first waypoint that exceeds the budget
-    if ( maxRange && (measurement.cost > maxRange) ) {
-      for ( let i = 1; i < measurement.waypoints.length; i++ ) {
-        if ( measurement.waypoints[i].cost > maxRange ) {
-          path.length = i;
-          break;
-        }
-      }
-      return [path, true];
-    }
-    return [path, constrained];
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  _getDragConstrainOptions() {
-    const options = super._getDragConstrainOptions();
-    const dialog = crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document);
-    if ( dialog ) {
-      const {movement} = dialog.action.usage;
-      if ( movement.ignoreWalls ) options.ignoreWalls = true;
-    }
-    return options;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
   _getDragLeftDropUpdateOptions() {
     const options = super._getDragLeftDropUpdateOptions();
     if ( crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document) ) {
       options.planned = true;
     }
+    options.split = true; // Always split movement subpaths for discrete drag operations
     return options;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  _getDragMovementAction() {
-    const dialog = crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document);
-    const forcedAction = dialog?.action.usage.movement.action;
-    if ( forcedAction ) return forcedAction;
-    return super._getDragMovementAction();
   }
 
   /* -------------------------------------------- */
@@ -353,33 +277,6 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
         ??= segment.actionConfig.getCostFunction(this.document, options);
       return calculateActionCost(terrainCost, from, to, distance, segment);
     };
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  _shouldPreventDragLeftDrop(event) {
-    if ( super._shouldPreventDragLeftDrop(event) ) return true;
-    const dialog = crucible.api.dice.ActionUseDialog.getActiveMovementPlan(this.document);
-    if ( !dialog ) return false;
-    const {movement} = dialog.action.usage;
-    const {minimum: minRange, maximum: maxRange} = dialog.action.range;
-    const context = event.interactionData?.contexts?.[this.id];
-    const foundPath = context?.foundPath ?? [];
-    const cost = foundPath.length > 1 ? this.measureMovementPath(foundPath).cost : 0;
-    if ( (movement.direct !== false) && context?.waypoints?.length ) {
-      ui.notifications.warn(_loc("ACTION.WARNINGS.DirectMovementOnly"));
-      return true;
-    }
-    if ( minRange && (cost < minRange) ) {
-      ui.notifications.warn(_loc("ACTION.WARNINGS.MovementTooShort"));
-      return true;
-    }
-    if ( maxRange && ((cost > maxRange) || context?.unreachableWaypoints?.length) ) {
-      ui.notifications.warn(_loc("ACTION.WARNINGS.MovementTooFar"));
-      return true;
-    }
-    return false;
   }
 
   /* -------------------------------------------- */

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -1104,9 +1104,7 @@ export const TAGS = {
     },
     prepare() {
       const stride = this.actor.system.movement.stride;
-      const costFeet = this.movement
-        ? (this.movement.passed.cost + this.movement.pending.cost)
-        : stride;
+      const costFeet = this.movement ? this.movement.cost : stride;
       const {cost, useFreeMove} = this.actor.getMovementActionCost(costFeet);
       if ( useFreeMove ) this.usage.freeMove = true;
       if ( this.id === "move" ) this.cost.action = cost; // Standard movement cost
@@ -1144,8 +1142,7 @@ export const TAGS = {
 
       // Remove prone condition upon movement confirmation if movement is not exclusively crawling
       if ( this.actor.statuses.has("prone") ) {
-        const isNonCrawlMovement = this.movement?.pending?.waypoints?.some(w => w.action !== "crawl")
-          || this.movement?.passed?.waypoints?.some(w => w.action !== "crawl");
+        const isNonCrawlMovement = this.movement?.waypoints?.some(w => w.action !== "crawl");
         if ( isNonCrawlMovement ) await this.actor.toggleStatusEffect("prone", {active: false});
       }
 

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -32,25 +32,10 @@ export default class ActionUseDialog extends StandardCheckDialog {
   static TEMPLATE = "systems/crucible/templates/dice/action-use-dialog.hbs";
 
   /**
-   * A registry of ActionUseDialog instances that are currently in a movement planning state.
-   * @type {Map<string, ActionUseDialog>}
-   */
-  static #movementPlans = new Map();
-
-  /* -------------------------------------------- */
-
-  /**
    * Targets acquired from the most recently placed region for this Action.
    * @type {ActionUseTarget[]|null}
    */
   #regionTargets = null;
-
-  /**
-   * The Hooks ID for a pending planToken listener registered during movement planning.
-   * Stored so it can be cleaned up if the dialog closes before planning completes.
-   * @type {number|null}
-   */
-  #planMovementHookId = null;
 
   /**
    * A lazy action clone used for per-frame target preview during movement planning.
@@ -483,23 +468,18 @@ export default class ActionUseDialog extends StandardCheckDialog {
   /* -------------------------------------------- */
 
   /**
-   * Is any movement planning workflow currently active?
-   * @type {boolean}
-   */
-  static get activeMovementPlan() {
-    return ActionUseDialog.#movementPlans.size > 0;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Get the active movement planning dialog for the given token, if any.
+   * Returns non-null only while the movement drag is in flight (not after the plan is confirmed).
    * @param {CrucibleToken|string} token    The token document or its ID
    * @returns {ActionUseDialog|null}
    */
   static getActiveMovementPlan(token) {
     const id = typeof token === "string" ? token : token.id;
-    return ActionUseDialog.#movementPlans.get(id) ?? null;
+    if ( canvas.tokens._movementPlanningContext?.object?.document?.id !== id ) return null;
+    for ( const app of foundry.applications.instances.values() ) {
+      if ( (app instanceof ActionUseDialog) && (app.action.token?.id === id) ) return app;
+    }
+    return null;
   }
 
   /* -------------------------------------------- */
@@ -511,10 +491,8 @@ export default class ActionUseDialog extends StandardCheckDialog {
    * @returns {Promise<void>}
    */
   static async #onPlanMovement(_event) {
-    const {token, target} = this.action;
-
-    // Register this dialog as actively planning movement for this token
-    ActionUseDialog.#movementPlans.set(token.id, this);
+    const {token, target, usage} = this.action;
+    const movementUsage = usage.movement;
 
     // Minimize open windows
     const minimizedWindows = [];
@@ -529,36 +507,38 @@ export default class ActionUseDialog extends StandardCheckDialog {
       this.#previewMovementAction = this.action.clone({}, {lazy: true});
     }
 
-    // Await the planToken hook for this specific token
-    await new Promise(resolve => {
-      this.#planMovementHookId = Hooks.on("planToken", document => {
-        if ( document !== token ) return;
-        Hooks.off("planToken", this.#planMovementHookId);
-        this.#planMovementHookId = null;
-        resolve();
-      });
+    // Await the movement plan
+    const plan = await token.object.planMovement({
+      allowedActions: movementUsage.action ? [movementUsage.action] : null,
+      minCost: this.action.range?.minimum ?? undefined,
+      maxCost: this.action.range?.maximum ?? undefined,
+      direct: movementUsage.direct ?? true,
+      constrainOptions: movementUsage.constrainOptions ?? {}
     });
     this.#previewMovementAction = null;
 
-    // Deregister from the planning map
-    ActionUseDialog.#movementPlans.delete(token.id);
+    // Restore minimized windows
+    await Promise.allSettled(minimizedWindows.map(app => app.maximize()));
 
-    // Store the planned movement on the action
-    const movement = token.movement;
-    if ( movement?.state === "planned" ) {
-      Object.defineProperty(this.action, "movement", {value: movement, configurable: true});
-      this.action.prepare(); // Re-prepare to update action cost based on the planned distance
-      this.roll = crucible.api.dice.StandardCheck.fromAction(this.action);
+    // Handle user cancellation
+    if ( !plan ) {
+      canvas.tokens.setTargets([]);
+      await this.render();
+      return;
     }
+
+    // Measure the cost of the planned path, then store the movement on the action
+    const {cost} = token.object.measureMovementPath([plan.origin, ...plan.waypoints]);
+    const movement = {id: plan.id, origin: plan.origin, waypoints: plan.waypoints, cost, plan};
+    Object.defineProperty(this.action, "movement", {value: movement, configurable: true});
+    this.action.prepare();
+    this.roll = crucible.api.dice.StandardCheck.fromAction(this.action);
 
     // Acquire targets from the planned movement path and highlight on canvas
     const targets = this.action.acquireTargets({strict: false});
     if ( targets.length ) canvas.tokens.setTargets(targets.map(t => t.token?.id).filter(Boolean));
     else canvas.tokens.setTargets([]);
-
-    // Restore minimized windows and re-render
-    await Promise.allSettled(minimizedWindows.map(app => app.maximize()));
-    this.render();
+    await this.render();
   }
 
   /* -------------------------------------------- */
@@ -577,9 +557,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
       return;
     }
     const foundPath = plannedMovement.foundPath;
-    const isBlink = (foundPath.length > 1) && (foundPath[1].action === "blink");
-    const pendingWaypoints = isBlink ? foundPath.slice(1) : foundPath;
-    const previewMovement = {origin: foundPath[0], pending: {waypoints: pendingWaypoints}};
+    const previewMovement = {origin: foundPath[0], waypoints: foundPath.slice(1)};
     Object.defineProperty(this.#previewMovementAction, "movement", {value: previewMovement, configurable: true});
     const targets = this.#previewMovementAction.acquireTargets({strict: false});
     if ( targets.length ) canvas.tokens.setTargets(targets.map(t => t.token?.id).filter(Boolean));
@@ -592,19 +570,21 @@ export default class ActionUseDialog extends StandardCheckDialog {
    * Clear any in-progress movement plan, cancelling a planned token movement if one exists.
    */
   #clearMovementPlan() {
-    if ( this.#planMovementHookId !== null ) {
-      Hooks.off("planToken", this.#planMovementHookId);
-      this.#planMovementHookId = null;
-    }
     this.#previewMovementAction = null;
-    ActionUseDialog.#movementPlans.delete(this.action.token?.id);
-    if ( !this.#submitted ) {
-      if ( this.action.movement?.state === "planned" ) {
-        this.action.token.stopMovement();
-        Object.defineProperty(this.action, "movement", {value: null, configurable: true});
-      }
-      canvas.tokens.setTargets([]);
+    if ( this.#submitted ) return;
+    const token = this.action.token;
+
+    // Cancel in-flight planning if this dialog's token is the active planner
+    if ( canvas.tokens._movementPlanningContext?.object?.document === token ) {
+      canvas.tokens._cancelMovementPlanning();
     }
+
+    // Cancel any already-confirmed movement stored on this action
+    if ( this.action.movement ) {
+      token?.stopMovement();
+      Object.defineProperty(this.action, "movement", {value: null, configurable: true});
+    }
+    canvas.tokens.setTargets([]);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -14,9 +14,11 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
   async _onDelete(options, userId) {
     await super._onDelete(options, userId);
     if ( !game.user.isActiveGM ) return;
-    for ( const uuid of this.system.regions ) {
-      const region = await fromUuid(uuid);
-      if ( region ) await region.delete();
+    if ( this.system.regions ) {
+      for ( const uuid of this.system.regions ) {
+        const region = await fromUuid(uuid);
+        if ( region ) await region.delete();
+      }
     }
   }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -7,6 +7,7 @@ const {DialogV2} = foundry.applications.api;
 
 /**
  * @import {TRAINING_TYPES} from "../const/talents.mjs";
+ * @import {TokenMovementOperation} from "@client/documents/_types.mjs";
  */
 
 /**
@@ -408,17 +409,29 @@ export default class CrucibleActor extends Actor {
 
   /**
    * Use the Movement action to travel a certain measured distance.
-   * @param {number} costFeet     The cost of the movement in feet, inclusive of difficult terrain and other modifiers.
-   * @param {CrucibleActionUsageOptions} options  Options passed to CrucibleAction#use
-   * @param {boolean} [options.useFreeMove]       Consume a free move, if available
-   * @param {TokenMovementOperation} [options.movement] A recorded movement ID in Token movement history
-   * @param {Set<string>} [options.actions]       The movement actions used as part of this move
-   * @returns {CrucibleAction}    The performed Action
+   * @param {number} costFeet                                 The cost of the movement in feet, inclusive of terrain
+   *                                                          modifiers.
+   * @param {object & CrucibleActionUsageOptions} [options]   Options which configure the movement action usage.
+   * @param {TokenMovementOperation} options.movement           The movement operation from which waypoints and
+   *                                                            actions are derived.
+   * @returns {Promise<void>}
    */
-  async useMove(costFeet, {useFreeMove=true, movement, actions, ...useOptions}={}) {
+  async useMove(costFeet, {movement, ...useOptions}={}) {
 
-    // Annotate movement actions.
-    actions ||= new Set(["walk"]);
+    // Build the Crucible-shaped movement object and derive actions from the TokenMovementOperation.
+    const waypoints = [];
+    const actions = new Set();
+    for ( const w of movement.passed.waypoints ) {
+      waypoints.push(w);
+      actions.add(w.action);
+    }
+    for ( const w of movement.pending.waypoints ) {
+      waypoints.push(w);
+      actions.add(w.action);
+    }
+
+    // Annotate movement actions
+    if ( !actions.size ) actions.add("walk"); // Should never happen?
     const actionLabels = [];
     const actionDescriptions = [];
     for ( const a of actions ) {
@@ -432,10 +445,11 @@ export default class CrucibleActor extends Actor {
 
     // Adjust action name and description
     const move = this.actions.move;
+    const crucibleMovement = {id: movement.id, origin: movement.origin, waypoints, cost: costFeet, operation: movement};
     const action = move.clone({
       name: `${move._source.name} (${actionLabels.join(", ")})`,
       description: `<p>${move._source.description}</p>${actionDescriptions.join("")}`
-    }, {movement});
+    }, {movement: crucibleMovement});
     await action.use(useOptions);
   }
 

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -92,9 +92,7 @@ export default class CrucibleToken extends foundry.documents.TokenDocument {
       this._confirmedMovements.delete(movement.id);
       return;
     }
-    const actions = new Set();
-    for ( const w of movement.passed.waypoints ) actions.add(w.action);
-    for ( const w of movement.pending.waypoints ) actions.add(w.action);
-    this.actor.useMove(movement.passed.cost + movement.pending.cost, {dialog: false, movement: movement, actions});
+    const costFeet = movement.passed.cost + movement.pending.cost;
+    this.actor.useMove(costFeet, {dialog: false, movement});
   }
 }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -52,7 +52,23 @@ import CrucibleActionConfig from "../applications/config/action-config.mjs";
  * @property {string} [action]              Force all waypoints in the planned path to use a specific movement action
  * @property {boolean} [direct=true]        Require the planned path to be a single direct segment with no intermediate
  *                                          waypoints. Otherwise, a multi-segment path is allowed. (default true)
- * @property {boolean} [ignoreWalls]        Allow the planned movement to pass through walls
+ * @property {object} [constrainOptions]    Movement constraint options passed to `Token#planMovement`
+ */
+
+/**
+ * @typedef CrucibleActionMovement
+ * The normalized movement data attached to a movement-tagged CrucibleAction.
+ * Both the planned movement (from ActionUseDialog) and the reactive movement (from Actor#useMove) conform to this shape.
+ * The waypoints array never includes the origin; it contains only the steps taken after the starting position.
+ * @property {string} [id]                  The movement plan ID
+ * @property {TokenPosition} origin         The starting position of the movement
+ * @property {TokenMovementWaypoint[]} waypoints  The movement path steps, not including the origin
+ * @property {number} [cost]                The measured cost of the path in feet
+ * @property {object} [plan]                The resolved result of Token#planMovement, present when movement was planned
+ *                                          via ActionUseDialog. TODO: upstream V14 has no named typedef for this return
+ *                                          type; raise an issue requesting one.
+ * @property {TokenMovementOperation} [operation]  The TokenMovementOperation provided to Actor#useMove, present when
+ *                                                 movement was actualized via a drag event
  */
 
 /**
@@ -345,7 +361,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
   /**
    * A planned or realized token movement associated with this action, used for movement-tagged actions.
-   * @type {TokenMovementData|TokenMovementOperation|null}
+   * @type {CrucibleActionMovement|null}
    */
   movement = this.movement; // Defined during constructor
 
@@ -930,8 +946,13 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
    */
   #acquireTargetsFromMovement() {
     if ( !this.movement ) return [];
-    const waypoints = this.#getMovementWaypoints();
-    if ( waypoints.length < 2 ) return [];
+    const sparseWaypoints = this.movement.waypoints;
+    if ( !sparseWaypoints.length ) return [];
+
+    // Expand sparse waypoints into every intermediate grid cell traversed.
+    // Blink is a teleport action which getCompleteMovementPath would not expand, treat it as walk instead.
+    const expandedWaypoints = sparseWaypoints.map(w => (w.action === "blink" ? {...w, action: "walk"} : w));
+    const waypoints = this.token.getCompleteMovementPath([this.movement.origin, ...expandedWaypoints]).slice(1);
 
     // Identify 3d grid space offsets covered by the token's traversed path. Record the bounding offsets.
     const visitedSpaces = new Set();
@@ -939,7 +960,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     let minJ = Infinity;
     let maxI = -Infinity;
     let maxJ = -Infinity;
-    for ( let w = 1; w < waypoints.length; w++ ) {
+    for ( let w = 0; w < waypoints.length; w++ ) {
       for ( const {i, j, k} of this.token.getOccupiedGridSpaceOffsets(waypoints[w]) ) {
         visitedSpaces.add(`${i},${j},${k}`);
         if ( i < minI ) minI = i;
@@ -950,7 +971,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     }
 
     // Remove spaces occupied by the token's starting position
-    for ( const {i, j, k} of this.token.getOccupiedGridSpaceOffsets(waypoints[0]) ) {
+    for ( const {i, j, k} of this.token.getOccupiedGridSpaceOffsets(this.movement.origin) ) {
       visitedSpaces.delete(`${i},${j},${k}`);
     }
 
@@ -972,36 +993,6 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const targets = [];
     for ( const token of hitTokens ) targets.push(CrucibleAction.#getTargetFromToken(token.document));
     return targets;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Get the effective waypoints for the planned movement path.
-   * For most movement actions this is the literal array of `pending.waypoints`.
-   * For blink, `pending.waypoints` contains only the destination waypoint since it is a teleport.
-   * For the purposes of targeting, fill the intermediate waypoints that would have been visited for a normal move.
-   * @returns {TokenMovementWaypoint[]}
-   */
-  #getMovementWaypoints() {
-    const waypoints = this.movement.pending.waypoints;
-    if ( !waypoints.length || (waypoints[0].action !== "blink") ) return waypoints;
-    const token = this.token;
-    const dimensions = {width: token.width, height: token.height, shape: token._source.shape};
-    const expanded = [];
-    let w0 = token._positionToGridOffset({...this.movement.origin, ...dimensions});
-    expanded.push(this.movement.origin);
-    for ( const point of waypoints ) {
-      const w1 = token._positionToGridOffset({...point, ...dimensions});
-      const steps = canvas.grid.getDirectPath([w0, w1]);
-      for ( let s=1; s<steps.length-1; s++ ) {
-        const {x, y} = token._gridOffsetToPosition(steps[s], dimensions);
-        expanded.push({x, y, elevation: point.elevation, action: "blink"});
-      }
-      expanded.push(point);
-      w0 = w1;
-    }
-    return expanded;
   }
 
   /* -------------------------------------------- */
@@ -1426,6 +1417,13 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
    */
   _configureUsage() {
     this.usage.hasDice = false; // Actions don't involve a roll unless otherwise configured
+
+    // Reset cost fields to their source values so that repeated prepare() calls do not accumulate costs
+    const sc = this._source.cost;
+    this.cost.action = sc.action;
+    this.cost.focus = sc.focus;
+    this.cost.heroism = sc.heroism;
+    this.cost.hands = sc.hands;
 
     // Configure tags
     if ( this.target.type === "movement" ) this.tags.add("movement");
@@ -2069,18 +2067,36 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const token = fromUuidSync(tokenUuid);
     const region = fromUuidSync(regionUuid);
 
-    // Reference current movement or recover past movement data
+    // Rebuild movement data for the action
     let movement = null;
     if ( movementId && token ) {
-      if ( token.movement?.id === movementId ) movement = token.movement;
+      let waypoints;
+      let origin;
+      if ( token.movement?.id === movementId ) {  // Use most recent movement data
+        const m = token.movement;
+        waypoints = [...(m.passed.waypoints ?? []), ...(m.pending.waypoints ?? [])];
+        origin = m.origin;
+      }
+
+      // Reconstruct movement data from history
+      // Unfortunately requires double iteration, first to find the subpathId then to reconstruct it
+      // The movement origin is the last waypoint prior to this movement, unless this is the first movement
       else {
-        const waypoints = token.movementHistory.filter(w => w.movementId === movementId);
-        if ( waypoints.length ) movement = {
-          id: movementId,
-          state: "stopped",
-          passed: {waypoints, cost: waypoints.reduce((t, w) => t + (w.cost ?? 0), 0)},
-          pending: {waypoints: [], cost: 0}
-        };
+        const subpathId = token.movementHistory.find(w => w.movementId === movementId)?.subpathId;
+        let firstIdx;
+        waypoints = token.movementHistory.filter((w, i) => {
+          if ( w.subpathId === subpathId ) {
+            firstIdx ??= i;
+            return true;
+          }
+          return false;
+        });
+        origin = token.movementHistory[firstIdx - 1] || waypoints[0];
+      }
+      if ( waypoints.length ) {
+        const movementCost = waypoints.reduce((t, w) => t + (w.cost ?? 0), 0);
+        // FIXME we have a design problem here, there could be multiple movementIds in the waypoints for a subpath
+        movement = /** @type {CrucibleActionMovement} */ {id: movementId, origin, waypoints, cost: movementCost};
       }
     }
 

--- a/module/models/spell-action.mjs
+++ b/module/models/spell-action.mjs
@@ -251,6 +251,17 @@ export default class CrucibleSpellAction extends CrucibleAction {
   _configureUsage() {
     super._configureUsage();
 
+    // The base class resets cost fields from _source, but for composed spells the action cost is computed
+    // dynamically from gesture and inflection components and is not stored in _source (which retains schema
+    // defaults). Re-apply the computed cost so that hooks in _prepare() start from the correct baseline.
+    if ( this.isComposed && this.gesture ) {
+      const cost = CrucibleSpellAction.#prepareCost.call(this);
+      this.cost.action = cost.action;
+      this.cost.focus = cost.focus;
+      this.cost.heroism = cost.heroism;
+      this.cost.hands = cost.hands;
+    }
+
     // Composed spells have dice by default that are disabled per-Gesture
     this.usage.hasDice ||= this.isComposed;
 


### PR DESCRIPTION
V14 added a high-level `Token#planMovement` API, which can replace much of the custom machinery I had to build to do this before. 

@roth-michael could you help review this code and do some local testing to verify that movement (both unplanned and planned) is working as expected?

This might also intersect with #754 in a way that makes sense to do one before the other (unsure which order would be better).