### PR TITLE
Address missing/incorrect i18n

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -357,6 +357,7 @@
       "Action": "Action Tags",
       "Activation": "Activation Tags",
       "Context": "Context Tags",
+      "Target": "Target Tags",
       "TargetLimit": "Limit {limit}"
     },
     "TARGET_SCOPES": {
@@ -541,6 +542,18 @@
       "TalentTreeClose": "Close Talent Tree",
       "TalentTreeOpen": "Open Talent Tree",
       "ToggleTree": "Toggle Talent Tree"
+    },
+    "ADVERSARY": {
+      "ACTIONS": {
+        "DecreaseLevel": "Decrease Level",
+        "IncreaseLevel": "Increase Level"
+      },
+      "THREAT_RANKS": {
+        "Boss": "Boss",
+        "Elite": "Elite",
+        "Minion": "Minion",
+        "Normal": "Normal"
+      }
     },
     "CREATION": {
       "AbandonContent": "Discard creation progress and exit the creator?",
@@ -801,14 +814,6 @@
     "MilestoneAward": "Award Milestones",
     "MilestoneTooltip": "{progress} of {required} milestones until next level",
     "Progress": "Milestone Progress"
-  },
-  "ADVERSARY": {
-    "THREAT_RANKS": {
-      "Boss": "Boss",
-      "Elite": "Elite",
-      "Minion": "Minion",
-      "Normal": "Normal"
-    }
   },
   "ANCESTRY": {
     "FIELDS": {
@@ -1582,6 +1587,7 @@
       "InputDrop": "Drop Input Item",
       "InputRemove": "Remove Input Group",
       "Inputs": "Inputs",
+      "ItemRemove": "Remove Input Item",
       "OutputAdd": "Add Output Group",
       "OutputDrop": "Drop Output Item",
       "OutputRemove": "Remove Output Group",
@@ -1893,7 +1899,8 @@
       "PurchaseNode": "Spend talent point to purchase empty node \"{node}\"?",
       "PurchaseNodeReverse": "Remove point spent on empty node \"{node}\"?",
       "PurchaseNodeTitle": "Purchase Talent Node?",
-      "PurchaseTitle": "Purchase Talent: {name}"
+      "PurchaseTitle": "Purchase Talent: {name}",
+      "Reset": "Reset"
     },
     "FIELDS": {
       "actions": {

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -1118,7 +1118,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       baseAttribute: "baseStride",
       bonusAttribute: "strideBonus",
       minValue: 0,
-      editLabel: "ACTOR.ACTIONS.EditStride",
+      editLabel: "ACTOR.ACTIONS.EditMovement",
       baseLabel: "ACTOR.FIELDS.movement.stride.base"
     });
   }

--- a/module/const/system.mjs
+++ b/module/const/system.mjs
@@ -53,7 +53,7 @@ export const THREAT_RANKS = {
     id: "minion",
     actionMax: 4,
     heroismMax: 0,
-    label: "ADVERSARY.THREAT_RANKS.Minion",
+    label: "ACTOR.ADVERSARY.THREAT_RANKS.Minion",
     scaling: 0.5,
     icon: "fa-solid fa-chevron-down"
   },
@@ -61,7 +61,7 @@ export const THREAT_RANKS = {
     id: "normal",
     actionMax: 6,
     heroismMax: 1,
-    label: "ADVERSARY.THREAT_RANKS.Normal",
+    label: "ACTOR.ADVERSARY.THREAT_RANKS.Normal",
     scaling: 1.0,
     icon: "fa-solid fa-chevron-up"
   },
@@ -69,7 +69,7 @@ export const THREAT_RANKS = {
     id: "elite",
     actionMax: 8,
     heroismMax: 2,
-    label: "ADVERSARY.THREAT_RANKS.Elite",
+    label: "ACTOR.ADVERSARY.THREAT_RANKS.Elite",
     scaling: 1.5,
     icon: "fa-solid fa-chevrons-up"
   },
@@ -77,7 +77,7 @@ export const THREAT_RANKS = {
     id: "boss",
     actionMax: 10,
     heroismMax: 3,
-    label: "ADVERSARY.THREAT_RANKS.Boss",
+    label: "ACTOR.ADVERSARY.THREAT_RANKS.Boss",
     scaling: 2.0,
     icon: "fa-solid fa-skull"
   }

--- a/templates/dice/partials/action-use-header.hbs
+++ b/templates/dice/partials/action-use-header.hbs
@@ -27,7 +27,7 @@
 
     {{#if hasTargetTags}}
     <div class="target-tags full-tags">
-        <label class="tag-icon" data-tooltip="Target Tags" data-tooltip-direction="LEFT">
+        <label class="tag-icon" data-tooltip="ACTION.TAGS.Target" data-tooltip-direction="LEFT">
             <i class="fa-solid fa-bullseye"></i>
         </label>
         <div class="tags" data-tag-type="targets">

--- a/templates/hud/talent-tree-controls.hbs
+++ b/templates/hud/talent-tree-controls.hbs
@@ -11,11 +11,11 @@
         <div class="controls flexrow">
             <button type="button" class="reset frame-brown" data-action="reset">
                 <i class="fa-solid fa-undo"></i>
-                <label>{{localize "Reset"}}</label>
+                <label>{{localize "TALENT.ACTIONS.Reset"}}</label>
             </button>
             <button type="button" class="close frame-brown" data-action="closeTree">
                 <i class="fa-solid fa-times"></i>
-                <label>{{localize "Close"}}</label>
+                <label>{{localize "APPLICATION.ACTIONS.Close"}}</label>
             </button>
         </div>
     </nav>

--- a/templates/sheets/action/target.hbs
+++ b/templates/sheets/action/target.hbs
@@ -3,7 +3,7 @@
     <fieldset>
         <legend>{{fields.range.label}}</legend>
         <div class="form-group">
-            <label>{{localize "Distance"}}</label>
+            <label>{{localize "MEASUREMENT.Distance"}}</label>
             <div class="form-fields">
                 <label>{{fields.range.fields.minimum.label}}</label>
                 {{formInput fields.range.fields.minimum value=action.range.minimum}}

--- a/templates/sheets/actor/adversary-attributes.hbs
+++ b/templates/sheets/actor/adversary-attributes.hbs
@@ -121,7 +121,7 @@
             </div>
             <div class="defense extra stride">
                 <span class="value" role="button" tabindex="0" data-action="editStride"
-                      aria-label="{{localize 'ACTOR.ACTIONS.EditStride'}}" data-tooltip>
+                      aria-label="{{localize 'ACTOR.ACTIONS.EditMovement'}}" data-tooltip>
                     {{actor.system.movement.stride}}
                 </span>
                 <h4 class="label" data-tooltip="ACTOR.FIELDS.movement.stride.tooltip">

--- a/templates/sheets/actor/adversary-header.hbs
+++ b/templates/sheets/actor/adversary-header.hbs
@@ -5,10 +5,10 @@
             <span><i class="threat-icon {{threat.icon}}"></i> Level</span>
             <div class="controls flexcol">
                 <button type="button" class="icon fa-solid fa-caret-up {{#unless canLevelUp}}inactive{{/unless}}"
-                        data-tooltip aria-label="{{localize "ACTOR.ADVERSARY.ACTIONS.IncreaseLevel"}}" 
+                        data-tooltip aria-label="{{localize 'ACTOR.ADVERSARY.ACTIONS.IncreaseLevel'}}"
                         data-action="levelIncrease"></button>
                 <button type="button" class="icon fa-solid fa-caret-down {{#unless canLevelDown}}inactive{{/unless}}"
-                        data-tooltip aria-label="{{localize "ACTOR.ADVERSARY.ACTIONS.DecreaseLevel"}}" 
+                        data-tooltip aria-label="{{localize 'ACTOR.ADVERSARY.ACTIONS.DecreaseLevel'}}"
                         data-action="levelDecrease"></button>
             </div>
         </div>

--- a/templates/sheets/actor/adversary-header.hbs
+++ b/templates/sheets/actor/adversary-header.hbs
@@ -5,9 +5,11 @@
             <span><i class="threat-icon {{threat.icon}}"></i> Level</span>
             <div class="controls flexcol">
                 <button type="button" class="icon fa-solid fa-caret-up {{#unless canLevelUp}}inactive{{/unless}}"
-                        data-tooltip="Increase Level" data-action="levelIncrease"></button>
+                        data-tooltip aria-label="{{localize "ACTOR.ADVERSARY.ACTIONS.IncreaseLevel"}}" 
+                        data-action="levelIncrease"></button>
                 <button type="button" class="icon fa-solid fa-caret-down {{#unless canLevelDown}}inactive{{/unless}}"
-                        data-tooltip="Decrease Level" data-action="levelDecrease"></button>
+                        data-tooltip aria-label="{{localize "ACTOR.ADVERSARY.ACTIONS.DecreaseLevel"}}" 
+                        data-action="levelDecrease"></button>
             </div>
         </div>
         <input type="text" class="level" value="{{levelDisplay}}" disabled>

--- a/templates/sheets/actor/hero-attributes.hbs
+++ b/templates/sheets/actor/hero-attributes.hbs
@@ -149,7 +149,7 @@
             </div>
             <div class="defense extra stride">
                 <span class="value" role="button" tabindex="0" data-action="editStride"
-                      aria-label="{{localize 'ACTOR.ACTIONS.EditStride'}}" data-tooltip>
+                      aria-label="{{localize 'ACTOR.ACTIONS.EditMovement'}}" data-tooltip>
                     {{actor.system.movement.stride}}
                 </span>
                 <h4 class="label" data-tooltip="ACTOR.FIELDS.movement.stride.tooltip">

--- a/templates/sheets/skill-edit.hbs
+++ b/templates/sheets/skill-edit.hbs
@@ -53,7 +53,7 @@
 
     <footer class="form-footer">
         <button class="frame-brown" type="submit">
-            <i class="fa-solid fa-save"></i> {{localize "Save Changes"}}
+            <i class="fa-solid fa-save"></i> {{localize "EDITOR.Save"}}
         </button>
     </footer>
 </form>


### PR DESCRIPTION
Some stuff had hardcoded strings, some stuff didn't have crucible i18n, some stuff relied on top-level core keys which were moved in v14.

Also moved `ADVERSARY` under `ACTOR`, same as how `GROUP` is already there.

Found this stuff by finally enabling i18n-ally, but am not committing the `.vscode` folder with settings & custom framework. 