### PR TITLE
Fix logic in luminary band hook

### DIFF
--- a/module/hooks/accessory.mjs
+++ b/module/hooks/accessory.mjs
@@ -50,7 +50,7 @@ HOOKS.luminary = {
   prepareAction(item, action) {
     if ( !action.tags.has("composed") || !action.inflection?.id ) return;
     const {enchantment} = item.system.config;
-    this.usage.boons[item.system.identifier] = {label: item.name, number: enchantment.bonus};
+    action.usage.boons[item.system.identifier] = {label: item.name, number: enchantment.bonus};
   }
 };
 


### PR DESCRIPTION
Pretty minor one. `this` is the actor for accessory hooks.