### PR TITLE
[#761] Ensure `cfg.color` is actual object before accessing `heal`/`high`

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1387,7 +1387,7 @@ export default class CrucibleActor extends Actor {
       for ( const {label, amount} of entries ) {
         if ( !label ) continue;
         let color;
-        if ( typeof cfg.color === "object" ) {
+        if ( foundry.utils.isPlainObject(cfg.color) ) {
           color = amount > 0 ? cfg.color.heal : cfg.color.high;
           pipColors.add(cfg.color.high.css);
         } else {


### PR DESCRIPTION
Just checking `typeof` isn't sufficient, as the `typeof` for a `Color` is `"object"`. We need to check whether it's a plain object, otherwise it'll always get hit.