### PR TITLE
Effects standardization

### DIFF
--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -252,7 +252,7 @@ export function mending(actor, {ability="wisdom", amount, turns=1}={}) {
  * @param {Actor} actor
  * @param {Actor} target
  */
-export function inspired(actor, target) {
+export function inspired(actor) {
   return {
     _id: getEffectId("Inspired"),
     name: "Inspired",
@@ -352,7 +352,7 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
  * @param {Actor} actor
  * @param {Actor} target
  */
-export function staggered(actor, target) {
+export function staggered(actor) {
   return {
     _id: getEffectId("Staggered"),
     name: "Staggered",

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -152,10 +152,8 @@ export function corroding(actor, {ability="wisdom", amount, turns=3}={}) {
 /**
  * Generate a standardized decay effect, dealing wisdom in corruption damage to Health.
  * @param {Actor} actor
- * @param {object} options
- * @param {string} options.ability
- * @param {number} options.amount
- * @param {number} options.turns
+ * @param {CrucibleDoTConfig} options
+ * @returns {Partial<ActiveEffectData>}
  */
 export function decay(actor, {ability="wisdom", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
@@ -179,6 +177,7 @@ export function decay(actor, {ability="wisdom", amount, turns=3}={}) {
  * Generate a standardized entropy effect, applying the frightened status and dealing presence in void damage to Health.
  * @param {Actor} actor
  * @param {CrucibleDoTConfig} options
+ * @returns {Partial<ActiveEffectData>}
  */
 export function entropy(actor, {ability="presence", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
@@ -203,6 +202,7 @@ export function entropy(actor, {ability="presence", amount, turns=1}={}) {
  * Generate a standardized irradiated effect, dealing presence in radiant damage to both Health and Morale.
  * @param {Actor} actor
  * @param {CrucibleDoTConfig} options
+ * @returns {Partial<ActiveEffectData>}
  */
 export function irradiated(actor, {ability="presence", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
@@ -255,6 +255,7 @@ export function mending(actor, {ability="wisdom", amount, turns=1}={}) {
  * Generate a standardized inspired effect, restoring presence in morale to the target.
  * @param {Actor} actor
  * @param {CrucibleDoTConfig} options
+ * @returns {Partial<ActiveEffectData>}
  */
 export function inspired(actor, {ability="presence", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
@@ -356,6 +357,7 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
  * Generate a standardized staggered effect, applying the staggered status condition to the target.
  * @param {Actor} actor
  * @param {CrucibleDoTConfig} options
+ * @returns {Partial<ActiveEffectData>}
  */
 export function staggered(actor, {turns=1}={}) {
   return {

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -178,18 +178,20 @@ export function decay(actor, {ability="wisdom", amount, turns=3}={}) {
 /**
  * Generate a standardized entropy effect, applying the frightened status and dealing presence in void damage to Health.
  * @param {Actor} actor
+ * @param {CrucibleDoTConfig} options
  */
-export function entropy(actor) {
+export function entropy(actor, {ability="presence", amount, turns=1}={}) {
+  amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Entropy"),
     name: "Entropy",
     img: "icons/magic/unholy/orb-swirling-teal.webp",
-    duration: {value: 1, units: "rounds", expiry: "turnStart"},
+    duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor.uuid,
     statuses: ["frightened"],
     system: {
       dot: [{
-        amount: Math.floor(actor.system.abilities.presence.value / 2),
+        amount,
         damageType: "void",
         resource: "health"
       }]
@@ -200,21 +202,23 @@ export function entropy(actor) {
 /**
  * Generate a standardized irradiated effect, dealing presence in radiant damage to both Health and Morale.
  * @param {Actor} actor
+ * @param {CrucibleDoTConfig} options
  */
-export function irradiated(actor) {
+export function irradiated(actor, {ability="presence", amount, turns=1}={}) {
+  amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Irradiated"),
     name: "Irradiated",
     img: "icons/magic/light/beams-rays-orange-purple-large.webp",
-    duration: {value: 1, units: "rounds", expiry: "turnStart"},
+    duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor.uuid,
     system: {
       dot: [{
-        amount: actor.system.abilities.presence.value,
+        amount,
         damageType: "radiant",
         resource: "health"
       }, {
-        amount: actor.system.abilities.presence.value,
+        amount,
         damageType: "radiant",
         resource: "morale"
       }]
@@ -250,18 +254,19 @@ export function mending(actor, {ability="wisdom", amount, turns=1}={}) {
 /**
  * Generate a standardized inspired effect, restoring presence in morale to the target.
  * @param {Actor} actor
- * @param {Actor} target
+ * @param {CrucibleDoTConfig} options
  */
-export function inspired(actor) {
+export function inspired(actor, {ability="presence", amount, turns=1}={}) {
+  amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Inspired"),
     name: "Inspired",
     img: "icons/magic/light/explosion-star-glow-silhouette.webp",
-    duration: {value: 1, units: "rounds", expiry: "turnStart"},
+    duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor.uuid,
     system: {
       dot: [{
-        amount: actor.system.abilities.presence.value,
+        amount,
         resource: "morale",
         restoration: true
       }]
@@ -276,7 +281,7 @@ export function inspired(actor) {
  * @param {CrucibleDoTConfig} options
  * @returns {Partial<ActiveEffectData>}
  */
-export function dominated(actor, {ability="wisdom", amount, turns=3, damageType="psychic"}={}) {
+export function dominated(actor, {ability="wisdom", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Dominated"),
@@ -288,7 +293,7 @@ export function dominated(actor, {ability="wisdom", amount, turns=3, damageType=
     system: {
       dot: [{
         amount,
-        damageType,
+        damageType: "psychic",
         resource: "morale"
       }]
     }
@@ -350,14 +355,14 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
 /**
  * Generate a standardized staggered effect, applying the staggered status condition to the target.
  * @param {Actor} actor
- * @param {Actor} target
+ * @param {CrucibleDoTConfig} options
  */
-export function staggered(actor) {
+export function staggered(actor, {turns=1}={}) {
   return {
     _id: getEffectId("Staggered"),
     name: "Staggered",
     img: "icons/skills/melee/strike-hammer-destructive-orange.webp",
-    duration: {value: 1, units: "rounds", expiry: "turnStart"},
+    duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor.uuid,
     statuses: ["staggered"]
   };

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -409,7 +409,7 @@ HOOKS.lightbringer0000 = {
     if ( action.rune?.id !== "illumination" ) return;
     const damageHealth = outcome.resources.health < 0;
     const damageMorale = outcome.resources.morale < 0;
-    if ( damageHealth || damageMorale ) outcome.effects.push(SYSTEM.EFFECTS.irradiated(this, outcome.target));
+    if ( damageHealth || damageMorale ) outcome.effects.push(SYSTEM.EFFECTS.irradiated(this));
   }
 };
 
@@ -419,7 +419,7 @@ HOOKS.mender0000000000 = {
   applyCriticalEffects(_item, action, outcome, _self) {
     if ( action.rune?.id !== "life" ) return;
     const restoreHealth = outcome.resources.health > 0;
-    if ( restoreHealth ) outcome.effects.push(SYSTEM.EFFECTS.mending(this, outcome.target));
+    if ( restoreHealth ) outcome.effects.push(SYSTEM.EFFECTS.mending(this));
   }
 };
 
@@ -450,7 +450,7 @@ HOOKS.necromancer00000 = {
   applyCriticalEffects(_item, action, outcome, _self) {
     if ( action.rune?.id !== "death" ) return;
     const damageHealth = outcome.resources.health < 0;
-    if ( damageHealth ) outcome.effects.push(SYSTEM.EFFECTS.decay(this, outcome.target));
+    if ( damageHealth ) outcome.effects.push(SYSTEM.EFFECTS.decay(this));
   }
 };
 
@@ -522,7 +522,7 @@ HOOKS.poisoner00000000 = {
     if ( !hasEffect ) return;
     if ( !action.tags.has("melee") ) return;
     const dt = action.usage.weapon?.system.damageType;
-    if ( ["piercing", "slashing"].includes(dt) ) outcome.effects.push(SYSTEM.EFFECTS.poisoned(this, outcome.target));
+    if ( ["piercing", "slashing"].includes(dt) ) outcome.effects.push(SYSTEM.EFFECTS.poisoned(this));
   }
 };
 
@@ -778,7 +778,7 @@ HOOKS.thoughtbinder000 = {
     const damageHealth = outcome.resources.health < 0;
     const damageMorale = outcome.resources.morale < 0;
     if ( !(damageHealth || damageMorale) ) return;
-    const dominated = SYSTEM.EFFECTS.dominated(this, outcome.target);
+    const dominated = SYSTEM.EFFECTS.dominated(this);
     outcome.effects.push(dominated);
   }
 };
@@ -810,7 +810,7 @@ HOOKS.voidcaller000000 = {
     if ( action.rune?.id !== "oblivion" ) return;
     const damageHealth = outcome.resources.health < 0;
     const damageMorale = outcome.resources.morale < 0;
-    if ( (damageHealth || damageMorale) ) outcome.effects.push(SYSTEM.EFFECTS.entropy(this, outcome.target));
+    if ( (damageHealth || damageMorale) ) outcome.effects.push(SYSTEM.EFFECTS.entropy(this));
   }
 };
 

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -213,7 +213,7 @@ HOOKS.concussiveblows0 = {
     const damageHealth = outcome.resources.health < 0;
     if ( !damageHealth ) return;
     const dt = action.usage.weapon?.system.damageType;
-    if ( dt === "bludgeoning" ) outcome.effects.push(SYSTEM.EFFECTS.staggered(this, outcome.target));
+    if ( dt === "bludgeoning" ) outcome.effects.push(SYSTEM.EFFECTS.staggered(this));
   }
 };
 
@@ -353,7 +353,7 @@ HOOKS.inspirator000000 = {
   applyCriticalEffects(_item, action, outcome, _self) {
     if ( action.rune?.id !== "soul" ) return;
     const restoreMorale = outcome.resources.morale > 0;
-    if ( restoreMorale ) outcome.effects.push(SYSTEM.EFFECTS.inspired(this, outcome.target));
+    if ( restoreMorale ) outcome.effects.push(SYSTEM.EFFECTS.inspired(this));
   }
 };
 


### PR DESCRIPTION
make all effect functions optionally accept turns, amount, and ability (whenever applicable)
stop passing a target argument that wasn't used
consistently use actor.getAbilityBonus