### PR TITLE
[#767] Rework `crucible.methods.generateId` and `SYSTEM.EFFECTS.getEffectId`, fix misc bugs

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -741,7 +741,7 @@ async function packageCompendium(documentName, packName, folder) {
  */
 function generateId(title, length) {
   const id = title.split(" ").map((w, i) => {
-    const p = w.slugify({replacement: "", strict: true});
+    const p = w.slugify({replacement: "", lowercase: false, strict: true});
     return i ? p.titleCase() : p;
   }).join("");
   return Number.isNumeric(length) ? id.slice(0, length).padEnd(length, "0") : id;

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -9,11 +9,12 @@
 
 /**
  * Get a standardized 16 character ID that can be used for the ActiveEffect.
- * @param {string} label    The active effect label
- * @param {string} [suffix] A suffix with which to end the returned ID
- * @returns {string}        The standardized ID
+ * @param {string} label            The active effect label
+ * @param {object} [options]        Additional options
+ * @param {string} [options.suffix] A suffix with which to end the returned ID
+ * @returns {string}                The standardized ID
  */
-export function getEffectId(label, suffix="") {
+export function getEffectId(label, {suffix=""}={}) {
   return `${crucible.api.methods.generateId(label, 16 - suffix.length)}${suffix}`;
 }
 

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -10,10 +10,11 @@
 /**
  * Get a standardized 16 character ID that can be used for the ActiveEffect.
  * @param {string} label    The active effect label
+ * @param {string} [suffix] A suffix with which to end the returned ID
  * @returns {string}        The standardized ID
  */
-export function getEffectId(label) {
-  return label.slugify({replacement: "", lowercase: false, strict: true}).slice(0, 16).padEnd(16, "0");
+export function getEffectId(label, suffix="") {
+  return `${crucible.api.methods.generateId(label, 16 - suffix.length)}${suffix}`;
 }
 
 /**

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -505,7 +505,7 @@ HOOKS.hamstring = {
   canUse() {
     const mh = this.actor.equipment.weapons.mainhand;
     const oh = this.actor.equipment.weapons.offhand;
-    if ( ![mh.system.damageType, oh.system.damageType].includes("slashing") ) {
+    if ( ![mh.system.damageType, oh?.system.damageType].includes("slashing") ) {
       throw new Error(_loc("ACTION.WARNINGS.RequiresSlashingMelee", {action: this.name}));
     }
   },
@@ -937,6 +937,7 @@ HOOKS.vampiricBite = {
     const biteData = foundry.utils.deepClone(SYSTEM.WEAPON.VAMPIRE_BITE);
     biteData.name = _loc(biteData.name);
     const bite = new cls(biteData, {parent: this.actor});
+    bite.system.prepareEquippedData();
     this.usage.weapon = bite;
     this.usage.context.tags.vampiricBite = this.name;
     foundry.utils.mergeObject(this.usage.bonuses, bite.system.actionBonuses);

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -48,7 +48,7 @@ HOOKS.armoredShell0000 = {
   prepareDefenses(item, defenses) {
     if ( !this.statuses.has("guarded") ) return;
     const offhand = this.equipment.weapons.offhand;
-    if ( offhand.category !== "shieldHeavy" ) return;
+    if ( offhand?.category !== "shieldHeavy" ) return;
     const halfArmor = Math.ceil(defenses.armor.base / 2);
     defenses.armor.base -= halfArmor;
     defenses.block.bonus += halfArmor;
@@ -222,7 +222,7 @@ HOOKS.concussiveblows0 = {
 HOOKS.conjurer00000000 = {
   prepareAction(_item, action) {
     if ( action.gesture?.id !== "create" ) return;
-    const effectIds = Array.fromRange(3, 1).map(i => SYSTEM.EFFECTS.getEffectId(`conjurercreate${i}`));
+    const effectIds = Array.fromRange(3, 1).map(i => SYSTEM.EFFECTS.getEffectId("conjurercreate", String(i)));
     const effectId = effectIds.find(id => !this.effects.has(id)) || effectIds[0];
     action.usage.summons[0].effectId = effectId;
   }

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -222,7 +222,7 @@ HOOKS.concussiveblows0 = {
 HOOKS.conjurer00000000 = {
   prepareAction(_item, action) {
     if ( action.gesture?.id !== "create" ) return;
-    const effectIds = Array.fromRange(3, 1).map(i => SYSTEM.EFFECTS.getEffectId("conjurercreate", String(i)));
+    const effectIds = Array.fromRange(3, 1).map(i => SYSTEM.EFFECTS.getEffectId("conjurercreate", {suffix: String(i)}));
     const effectId = effectIds.find(id => !this.effects.has(id)) || effectIds[0];
     action.usage.summons[0].effectId = effectId;
   }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1218,7 +1218,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
       // Prepare effect data
       const effect = {
-        _id: _id || SYSTEM.EFFECTS.getEffectId(this.id, String(i)),
+        _id: _id || SYSTEM.EFFECTS.getEffectId(this.id, {suffix: String(i)}),
         name: name || this.name,
         description: this.description,
         img: this.img,

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1218,7 +1218,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
       // Prepare effect data
       const effect = {
-        _id: _id || `${crucible.api.methods.generateId(this.id, 16 - String(i).length)}${i}`,
+        _id: _id || SYSTEM.EFFECTS.getEffectId(this.id, String(i)),
         name: name || this.name,
         description: this.description,
         img: this.img,


### PR DESCRIPTION
Closes #767 
For Hamstring & Armored Shell, optional chain for offhand. For Vampiric Bite, call `prepareEquippedData` on the data model of the synthetic weapon. For Adrenaline Surge & Vow of Animus, rework `generateId` and `getEffectId`:
- `generateId` now preserves casing
- `getEffectId` now calls `generateId`
- `getEffectId` now accepts an optional `suffix` which replaces the last `n` characters of the returned string with `suffix` (where `n` is the length of `suffix`)
- `getEffectId` with the `suffix` argument is now used when assigning effect `_id`s in `CrucibleAction##attachOutcomeEffects`

I would be down to rename `generateId` to `slugify`, and potentially move `getEffectId` into `crucible.api.methods`, and rename it to `generateId`.