### PR TITLE
Restyle intermediate waypoints to be less small, but to be a different shape

### DIFF
--- a/module/canvas/token-ruler.mjs
+++ b/module/canvas/token-ruler.mjs
@@ -63,10 +63,11 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
   _getWaypointStyle(waypoint) {
     const style = super._getWaypointStyle(waypoint);
 
-    // Undo core's treatment of starting waypoint as translucent, size-down intermediate waypoints
-    // TODO: If #11895 goes in, modify shape of intermediate waypoints to diamonds
-    if ( !waypoint.previous ) style.alpha = 1;
-    else if ( waypoint.next?.subpathId === waypoint.subpathId ) style.radius /= 2;
+    // Modify size & shape of intermediate waypoints to slightly smaller diamonds
+    if ( waypoint.previous && (waypoint.next?.subpathId === waypoint.subpathId) ) {
+      style.radius /= 1.5;
+      style.shape = "diamond";
+    }
     return style;
   }
 }

--- a/module/canvas/token-ruler.mjs
+++ b/module/canvas/token-ruler.mjs
@@ -49,13 +49,8 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
     };
 
     // Display elevation when it changes or when different from the level.elevation.bottom
-    if ( context.elevation ) {
-      // TODO: Remove/adjust this modification after core implements
-      if ( game.release.build < 359 ) {
-        if ( Number.isFinite(canvas.level.elevation.bottom) ) context.elevation.total -= canvas.level.elevation.bottom;
-      }
-      context.displayElevation = !context.elevation.hidden && (!sameElevation || context.elevation.total);
-    }
+    context.displayElevation = context.elevation && !context.elevation.hidden
+      && (!sameElevation || context.elevation.total);
     return context;
   }
 


### PR DESCRIPTION
Core also un-translucent-ed the starting waypoint, so was able to remove that logic.

Marking as blocked because it requires at least 14.359.

Also removed the to-be-unnecessary release build check for implementing relative elevation display on the ruler.