### PR TITLE
[774] Consider adding group test hotkey with custom dialog for fast on the …

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -22,6 +22,7 @@ import * as hooks from "./module/hooks/_module.mjs";
 import {handleSocketEvent} from "./module/socket.mjs";
 import {registerEnrichers} from "./module/enrichers.mjs";
 import * as chat from "./module/chat.mjs";
+import {registerKeybindings} from "./module/hotkeys.mjs";
 import * as interaction from "./module/interaction.mjs";
 import Enum from "./module/const/enum.mjs";
 import CrucibleTalentNode from "./module/const/talent-node.mjs";
@@ -395,13 +396,7 @@ Hooks.once("init", async function() {
   });
 
   // Register keybindings
-  game.keybindings.register("crucible", "confirm", {
-    name: "KEYBINDINGS.ConfirmAction",
-    hint: "KEYBINDINGS.ConfirmActionHint",
-    editable: [{key: "KeyX"}],
-    restricted: true,
-    onDown: chat.onKeyboardConfirmAction
-  });
+  registerKeybindings();
 
   // Patch door sound radius - can we do this better elsewhere?
   Object.defineProperty(foundry.canvas.placeables.Wall.prototype, "soundRadius", {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1275,6 +1275,7 @@
       "Title": "Group Check",
       "ChatTitle": "{skill} Check (DC {dc})",
       "DialogTitle": "{skill} Check: {name}",
+      "QuickSelection": "Group Check Quick Selection",
       "NoUserForActor": "No active user found for: {name}",
       "STATUSES": {
         "Pending": "Pending",
@@ -1461,7 +1462,9 @@
   },
   "KEYBINDINGS": {
     "ConfirmAction": "Confirm Action",
-    "ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken."
+    "ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken.",
+    "GroupCheckQuickSelection": "Group Check Quick Selection",
+    "GroupCheckQuickSelectionHint": "Open the group check quick selection window for the current party."
   },
   "KNOWLEDGE": {
     "Alchemy": "Alchemy",

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -39,3 +39,5 @@ export {default as CrucibleCombatTracker} from "./sidebar/combat-tracker.mjs";
 // Canvas Apps
 export {default as CrucibleTokenHUD} from "./hud/token-hud.mjs";
 
+// Tool Apps
+export {default as GroupCheckQuickSelection} from "./tools/group-check-quick-selection.mjs";

--- a/module/applications/tools/group-check-quick-selection.mjs
+++ b/module/applications/tools/group-check-quick-selection.mjs
@@ -1,0 +1,95 @@
+const {api} = foundry.applications;
+
+/**
+ * Open the group check quick selection window.
+ * @param {KeyboardEventContext} _context    The context data of the event
+ * @returns {Promise<Application|void>}
+ */
+export function openGroupCheckQuickSelection(_context) {
+  return new GroupCheckQuickSelection().render(true);
+}
+
+/**
+ * A quick launcher for opening prefilled group skill check dialogs.
+ */
+export default class GroupCheckQuickSelection extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["crucible", "themed", "theme-dark", "dice-roll"],
+    window: {
+      contentClasses: ["standard-check", "standard-form"],
+      resizable: true,
+      title: "DICE.GROUP_CHECK.QuickSelection"
+    },
+    position: {
+      width: 400
+    },
+    actions: {
+      selectSkill: GroupCheckQuickSelection.#onSelectSkill
+    }
+  };
+
+  /** @override */
+  static PARTS = {
+    main: {
+      template: "systems/crucible/templates/tools/group-check/quick-selection.hbs"
+    }
+  };
+
+  /**
+   * The party actors prefilled into the request dialog.
+   * @type {CrucibleActor[]}
+   */
+  #partyActors = [];
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    this.#partyActors = Array.from(crucible.party?.system.actors ?? []).filter(Boolean);
+    Object.assign(context, {
+      partyActors: this.#partyActors,
+      skillCategories: this.#prepareSkills()
+    });
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Organize skills by category in alphabetical order.
+   * @returns {Record<string, object>}
+   */
+  #prepareSkills() {
+    const categories = foundry.utils.deepClone(SYSTEM.SKILL.CATEGORIES);
+    for ( const skill of Object.values(SYSTEM.SKILLS) ) {
+      const category = categories[skill.category];
+      category.skills ||= {};
+      category.skills[skill.id] = skill;
+    }
+    return categories;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Open a prefilled group check dialog for the selected skill.
+   * @this {GroupCheckQuickSelection}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement} target
+   * @returns {Promise<void>}
+   */
+  static async #onSelectSkill(_event, target) {
+    if ( !game.user.isGM ) {
+      ui.notifications.warn("DICE.GROUP_CHECK.RequiresGM", {localize: true});
+      return;
+    }
+
+    const skillId = target.dataset.skillId;
+    const roll = new crucible.api.dice.StandardCheck({type: skillId});
+    roll.dialog({request: true, requestedActors: this.#partyActors});
+    await this.close();
+  }
+}

--- a/module/hotkeys.mjs
+++ b/module/hotkeys.mjs
@@ -1,0 +1,23 @@
+import {onKeyboardConfirmAction} from "./chat.mjs";
+import {openGroupCheckQuickSelection} from "./applications/tools/group-check-quick-selection.mjs";
+
+/**
+ * Register system keybindings.
+ */
+export function registerKeybindings() {
+  game.keybindings.register("crucible", "confirm", {
+    name: "KEYBINDINGS.ConfirmAction",
+    hint: "KEYBINDINGS.ConfirmActionHint",
+    editable: [{key: "KeyX"}],
+    restricted: true,
+    onDown: onKeyboardConfirmAction
+  });
+
+  game.keybindings.register("crucible", "groupCheckQuickSelection", {
+    name: "KEYBINDINGS.GroupCheckQuickSelection",
+    hint: "KEYBINDINGS.GroupCheckQuickSelectionHint",
+    editable: [{key: "KeyG"}],
+    restricted: true,
+    onDown: openGroupCheckQuickSelection
+  });
+}

--- a/styles/theme.less
+++ b/styles/theme.less
@@ -318,6 +318,15 @@
     }
   }
 
+  .asbestos {
+    --asbestos-min: 40px;
+    --asbestos-max: 80px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(var(--asbestos-min), var(--asbestos-max)));
+    gap: 0.75rem;
+    align-items: stretch;
+  }
+
   // Form Elements
   textarea {
     padding: 0.5rem;

--- a/templates/tools/group-check/quick-selection.hbs
+++ b/templates/tools/group-check/quick-selection.hbs
@@ -1,0 +1,30 @@
+<div class="scrollable">
+    <div class="flexcol">
+        {{#if partyActors.length}}
+        <div class="tags flexrow">
+            {{#each partyActors as |actor|}}
+            <span class="tag flex0">{{actor.name}}</span>
+            {{/each}}
+        </div>
+        {{else}}
+        <p class="hint">{{localize "WARNING.NoParty"}}</p>
+        {{/if}}
+    </div>
+
+    {{#each skillCategories as |category|}}
+    <section class="sheet-section item-section flexcol" style="--resource-color: {{category.color.css}};">
+        <h3>{{localize "SKILL.CategoryHeader" category=category.label}}</h3>
+        <p class="hint">{{localize category.hint}}</p>
+        <div class="asbestos">
+            {{#each category.skills as |skill|}}
+            <div class="framed button flexcol" data-action="selectSkill" data-skill-id="{{skill.id}}">
+                <div class="icon-frame">
+                    <img class="icon" src="{{skill.icon}}" alt="{{localize skill.label}}">
+                </div>
+                <span>{{localize skill.label}}</span>
+            </div>
+            {{/each}}
+        </div>
+    </section>
+    {{/each}}
+</div>


### PR DESCRIPTION
here is an example of the quick group check selection window.
let me know if you want it, otherwise i ll add it to crucibletongs module

* adds hotkey g to open quick select. quick select just shows all available skills and then opens the group check dialog
* moves hotkey config into its own file (more hotkeys in the future for ember speed runs)
* adds new category for crucible classes called "tools"
* adds a reusable grid class (i think there was none) called .asbestos. crucible must be fireproof and the shent build blue crystal things everywhere in ancient times so some amount of asbestos in crucible is logical


Fixes #774