### PR TITLE
[#772] Display all known languages on actor sheet, add dialogs to edit knowledge areas & known languages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -702,6 +702,8 @@
       }
     },
     "LABELS": {
+      "BackgroundKnowledgeTooltip": "This Knowledge Area is granted by your Background.",
+      "BackgroundLanguageTooltip": "This Language is granted by your Background.",
       "Capacity": "Carrying Capacity",
       "Currency": "Currency",
       "CurrentCapacity": "Current Capacity",
@@ -710,6 +712,7 @@
       "Knowledge": "Knowledge Areas",
       "KnowledgeHint": "Learn some Knowledge Areas from your Background or edit your Hero to gain some.",
       "Languages": "Known Languages",
+      "LanguagesHint": "Learn some Languages from your Background or edit your Hero to gain some.",
       "OverCapacity": "Over Capacity"
     },
     "SECTIONS": {

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -1158,7 +1158,11 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     });
     const propertyInput = propertyField.toInput({options: propertyOptions, type: "checkboxes", value: propertyValue});
     const title = `${_loc(`ACTOR.LABELS.${property.titleCase()}`)}: ${this.document.name}`;
-    const formData = await api.DialogV2.input({window: {title}, content: propertyInput.outerHTML});
+    const formData = await api.DialogV2.input({
+      window: {title},
+      classes: [`edit-details-property ${property}`],
+      content: propertyInput.outerHTML
+    });
     if ( !formData ) return;
     formData[propertyPath] = formData[propertyPath].filter(value => !toDisable.has(value));
     await this.actor.update(formData);

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -31,7 +31,8 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       resourcePip: {handler: CrucibleBaseActorSheet.#onResourcePip, buttons: [0, 2]},
       editEngagement: CrucibleBaseActorSheet.#onEditEngagement,
       editSize: CrucibleBaseActorSheet.#onEditSize,
-      editStride: CrucibleBaseActorSheet.#onEditStride
+      editStride: CrucibleBaseActorSheet.#onEditStride,
+      editDetailsProperty: CrucibleBaseActorSheet.#onEditDetailsProperty
     },
     form: {
       submitOnChange: true
@@ -180,7 +181,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       incomplete: {},
       inventory,
       isEditable: this.isEditable,
-      languages: this.#prepareLanguageOptions(),
+      languages: this.#prepareLanguages(),
       resistances: this.#prepareResistances(),
       resources: this.#prepareResources(),
       skillCategories: this.#prepareSkills(),
@@ -654,16 +655,27 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
   /* -------------------------------------------- */
 
   /**
-   * Prepare options provided to a multi-select element for which languages the character may know.
-   * @returns {FormSelectOption[]}
+   * Prepare the user-friendly list of languages that the actor has.
+   * @returns {string[]}
    */
-  #prepareLanguageOptions() {
-    const categories = crucible.CONFIG.languageCategories;
-    const options = [];
-    for ( const [value, {label, category}] of Object.entries(crucible.CONFIG.languages) ) {
-      options.push({value, label, group: categories[category]?.label});
+  #prepareLanguages() {
+    const languages = [];
+    const backgroundLanguages = this.document.system.details.background?.languages ?? new Set();
+    for ( const languageId of this.document.system.details.languages ) {
+      const label = crucible.CONFIG.languages[languageId]?.label;
+      if ( !label ) continue;
+      languages.push({
+        label,
+        fromBackground: backgroundLanguages.has(languageId),
+        tooltip: backgroundLanguages.has(languageId) ? _loc("ACTOR.LABELS.BackgroundLanguageTooltip") : null
+      });
     }
-    return options;
+    languages.sort((a, b) => {
+      if ( a.fromBackground && !b.fromBackground ) return -1;
+      if ( b.fromBackground && !a.fromBackground ) return 1;
+      return a.label.localeCompare(b.label);
+    });
+    return languages;
   }
 
   /* -------------------------------------------- */
@@ -1076,7 +1088,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
 
   /**
    * Handle click actions to edit engagement bonus.
-   * @this {HeroSheet}
+   * @this {CrucibleBaseActorSheet}
    * @type {ApplicationClickAction}
    */
   static async #onEditEngagement() {
@@ -1093,7 +1105,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
 
   /**
    * Handle click actions to edit size bonus.
-   * @this {HeroSheet}
+   * @this {CrucibleBaseActorSheet}
    * @type {ApplicationClickAction}
    */
   static async #onEditSize() {
@@ -1110,7 +1122,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
 
   /**
    * Handle click actions to edit stride bonus.
-   * @this {HeroSheet}
+   * @this {CrucibleBaseActorSheet}
    * @type {ApplicationClickAction}
    */
   static async #onEditStride() {
@@ -1121,6 +1133,35 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       editLabel: "ACTOR.ACTIONS.EditMovement",
       baseLabel: "ACTOR.FIELDS.movement.stride.base"
     });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle click actions to edit Knowledge Areas or Languages
+   * @this {CrucibleBaseActorSheet}
+   * @type {ApplicationClickAction}
+   */
+  static async #onEditDetailsProperty(_event, target) {
+    const property = target.dataset.property;
+    const propertyField = this.document.system.schema.getField(`details.${property}`);
+    const propertyPath = `system.details.${property}`;
+
+    // Determine which knowledge/languages are added during data prep, as they shouldn't be modifiable
+    const propertyValue = foundry.utils.getProperty(this.document, propertyPath);
+    const propertySource = new Set(foundry.utils.getProperty(this.document._source, propertyPath));
+    const toDisable = propertyValue.difference(propertySource);
+    const propertyOptions = Object.entries(crucible.CONFIG[property]).map(([value, {label, category}]) => {
+      const toAdd = {value, label, disabled: toDisable.has(value)};
+      if ( category && (property === "languages") ) toAdd.group = crucible.CONFIG.languageCategories[category]?.label;
+      return toAdd;
+    });
+    const propertyInput = propertyField.toInput({options: propertyOptions, type: "checkboxes", value: propertyValue});
+    const title = `${_loc(`ACTOR.LABELS.${property.titleCase()}`)}: ${this.document.name}`;
+    const formData = await api.DialogV2.input({window: {title}, content: propertyInput.outerHTML});
+    if ( !formData ) return;
+    formData[propertyPath] = formData[propertyPath].filter(value => !toDisable.has(value));
+    await this.actor.update(formData);
   }
 
   /* -------------------------------------------- */
@@ -1152,8 +1193,18 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
 
     // Process user-input dialog
     const title = `${_loc(editLabel)}: ${this.actor.name}`;
-    const formData = await foundry.applications.api.DialogV2.input({window: {title}, content});
+    const formData = await api.DialogV2.input({window: {title}, content});
     if (formData) await this.actor.update(formData);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * A common helper method that handles editing knowledge or languages via an input dialog.
+   * @param {"languages"|"knowledge"} property
+   */
+  async #editDetailsProperty(property) {
+
   }
 
   /* -------------------------------------------- */

--- a/module/applications/sheets/hero-sheet.mjs
+++ b/module/applications/sheets/hero-sheet.mjs
@@ -36,7 +36,6 @@ export default class HeroSheet extends CrucibleBaseActorSheet {
       ancestryName: s.system.details.ancestry?.name || _loc("ANCESTRY.SHEET.Choose"),
       backgroundName: s.system.details.background?.name || _loc("BACKGROUND.SHEET.Choose"),
       capacity: a.system.capacity,
-      knowledgeOptions: this.#prepareKnowledgeOptions(),
       knowledge: this.#prepareKnowledge(),
       talentTreeButtonText: _loc(`ACTOR.ACTIONS.TalentTree${game.system.tree.actor === a ? "Close" : "Open"}`)
     });
@@ -68,30 +67,27 @@ export default class HeroSheet extends CrucibleBaseActorSheet {
   /* -------------------------------------------- */
 
   /**
-   * Prepare options provided to a multi-select element for which knowledge areas the character may know.
-   * @returns {FormSelectOption[]}
-   */
-  #prepareKnowledgeOptions() {
-    const options = [];
-    for ( const [value, {label, skill}] of Object.entries(crucible.CONFIG.knowledge) ) {
-      const s = SYSTEM.SKILLS[skill];
-      options.push({value, label, group: s?.label});
-    }
-    return options;
-  }
-
-  /**
    * Prepare the user-friendly list of knowledge areas that the actor has.
    * @returns {string[]}
    */
   #prepareKnowledge() {
-    const knowledgeNames = [];
-    for ( const knowledgeId of this.actor.system.details.knowledge ) {
-      if ( crucible.CONFIG.knowledge[knowledgeId] ) {
-        knowledgeNames.push(crucible.CONFIG.knowledge[knowledgeId].label);
-      }
+    const knowledgeAreas = [];
+    const backgroundKnowledge = this.document.system.details.background?.knowledge ?? new Set();
+    for ( const knowledgeId of this.document.system.details.knowledge ) {
+      const label = crucible.CONFIG.knowledge[knowledgeId]?.label;
+      if ( !label ) continue;
+      knowledgeAreas.push({
+        label,
+        fromBackground: backgroundKnowledge.has(knowledgeId),
+        tooltip: backgroundKnowledge.has(knowledgeId) ? _loc("ACTOR.LABELS.BackgroundKnowledgeTooltip") : null
+      });
     }
-    return knowledgeNames;
+    knowledgeAreas.sort((a, b) => {
+      if ( a.fromBackground && !b.fromBackground ) return -1;
+      if ( b.fromBackground && !a.fromBackground ) return 1;
+      return a.label.localeCompare(b.label);
+    });
+    return knowledgeAreas;
   }
 
   /* -------------------------------------------- */

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -1072,7 +1072,8 @@
 
 .edit-details-property.languages {
   multi-checkbox {
-    display: block;
+    display: flex;
+    flex-direction: column;
     .checkbox-group {
       display: grid;
       grid-template-columns: repeat(3, 1fr);

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -927,7 +927,9 @@
       }
     }
 
-    .tags.training {
+    .tags.training,
+    .tags.knowledge-areas,
+    .tags.languages {
       justify-content: flex-start;
     }
   }

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -940,8 +940,8 @@
         font-size: var(--font-size-12);
         text-align: center;
       }
-      multi-select.languages {
-        width: 100%;
+      .tag.background-granted {
+        border-color: var(--color-border-highlight);
       }
     }
   }

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -1065,3 +1065,17 @@
   font-size: var(--font-size-13);
   font-family: var(--font-serif);
 }
+
+/* ----------------------------------------- */
+/*  Known Languages Dialog                   */
+/* ----------------------------------------- */
+
+.edit-details-property.languages {
+  multi-checkbox {
+    display: block;
+    .checkbox-group {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+}

--- a/templates/sheets/actor/skills.hbs
+++ b/templates/sheets/actor/skills.hbs
@@ -38,7 +38,7 @@
                 {{localize "ACTOR.LABELS.Knowledge"}}
                 <a class="control icon fa-solid fa-gear" data-action="editDetailsProperty" data-property="knowledge"></a>
             </h3>
-            <div class="tags flexrow">
+            <div class="tags knowledge-areas">
                 {{#each knowledge}}
                 <span
                     class="larger tag knowledge-area{{#if fromBackground}} background-granted{{/if}}"
@@ -56,7 +56,7 @@
                 {{localize "ACTOR.LABELS.Languages"}}
                 <a class="control icon fa-solid fa-gear" data-action="editDetailsProperty" data-property="languages"></a>
             </h3>
-            <div class="tags flexrow">
+            <div class="tags languages">
                 {{#each languages}}
                 <span
                     class="larger tag language{{#if fromBackground}} background-granted{{/if}}"

--- a/templates/sheets/actor/skills.hbs
+++ b/templates/sheets/actor/skills.hbs
@@ -34,19 +34,40 @@
     {{/each}}
     <footer class="tab-footer skills-footer flexrow">
         <div class="sheet-section flexcol">
-            <h3>{{localize "ACTOR.LABELS.Knowledge"}}</h3>
+            <h3>
+                {{localize "ACTOR.LABELS.Knowledge"}}
+                <a class="control icon fa-solid fa-gear" data-action="editDetailsProperty" data-property="knowledge"></a>
+            </h3>
             <div class="tags flexrow">
                 {{#each knowledge}}
-                <span class="larger tag knowledge-area">{{this}}</span>
+                <span
+                    class="larger tag knowledge-area{{#if fromBackground}} background-granted{{/if}}"
+                    {{#if tooltip}} data-tooltip="{{tooltip}}"{{/if}}
+                >
+                    {{label}}
+                </span>
                 {{else}}
                 <p class="hint">{{localize "ACTOR.LABELS.KnowledgeHint"}}</p>
                 {{/each}}
             </div>
         </div>
         <div class="sheet-section flexcol">
-            <h3>{{localize "ACTOR.LABELS.Languages"}}</h3>
-            {{formInput fields.details.fields.languages value=source.system.details.languages
-                        options=languages classes="languages"}}
+            <h3>
+                {{localize "ACTOR.LABELS.Languages"}}
+                <a class="control icon fa-solid fa-gear" data-action="editDetailsProperty" data-property="languages"></a>
+            </h3>
+            <div class="tags flexrow">
+                {{#each languages}}
+                <span
+                    class="larger tag language{{#if fromBackground}} background-granted{{/if}}"
+                    {{#if tooltip}} data-tooltip="{{tooltip}}"{{/if}}
+                >
+                    {{label}}
+                </span>
+                {{else}}
+                <p class="hint">{{localize "ACTOR.LABELS.LanguagesHint"}}</p>
+                {{/each}}
+            </div>
         </div>
     </footer>
 </section>


### PR DESCRIPTION
Closes #772 
We can't disable individual `option`s that aren't selected without https://github.com/foundryvtt/foundryvtt/issues/13612, so for now background- or effect-granted languages/knowledge areas are not disabled in the dialogs. They _are_ still ignored for the purposes of submission.
<img width="1288" height="762" alt="image" src="https://github.com/user-attachments/assets/6a22aa6e-49cd-4232-877d-5784fba8d4e4" />
<img width="392" height="607" alt="image" src="https://github.com/user-attachments/assets/ec29ac15-350e-4b53-9c41-06b2e5763908" />
