### PR TITLE
[#765] Special handling to reverse `system.loaded` changes on strike/reload

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -686,6 +686,12 @@ export const TAGS = {
           this.usage.actorUpdates.items.push({_id: w.id, "system.loaded": false});
         }
       }
+    },
+    async confirm(reverse) {
+      if ( !reverse ) return;
+      for ( const itemUpdate of (this.selfEvents.actorUpdate.actorUpdates.items ?? []) ) {
+        if ( itemUpdate.system?.loaded === false ) itemUpdate.system.loaded = true;
+      }
     }
   },
 
@@ -912,6 +918,12 @@ export const TAGS = {
       this.usage.weapon ??= this.getValidWeaponChoices()[0]?.item;
       if ( this.usage.weapon ) {
         this.usage.actorUpdates.items.push({_id: this.usage.weapon.id, "system.loaded": true});
+      }
+    },
+    async confirm(reverse) {
+      if ( !reverse ) return;
+      for ( const itemUpdate of (this.selfEvents.actorUpdate.actorUpdates.items ?? []) ) {
+        if ( itemUpdate.system?.loaded ) itemUpdate.system.loaded = false;
       }
     }
   },


### PR DESCRIPTION
Closes #765 
Worth considering a more generic way of handling reversion of changes like this, but this feels like a solid solution at least for the time being.