### PR TITLE
[#762] Compare almost all item fields when determining whether some item can stack on an existing item

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -1224,10 +1224,10 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     // Expand the stack of an existing stackable item
     const isPhysical = item.system instanceof crucible.api.models.CruciblePhysicalItem;
     if ( isPhysical && item.system.properties.has("stackable") ) {
-      const existingItem = this.actor.itemTypes[item.type].find(i => (i.system.identifier === item.system.identifier)
-        && i.system.properties.has("stackable"));
-      if ( existingItem ) {
-        await existingItem.update({ "system.quantity": existingItem.system.quantity + item.system.quantity});
+      const existing = this.actor.itemTypes[item.type].filter(i => (i.system.identifier === item.system.identifier));
+      const toStack = existing.find(i => item.isStackableWith(i));
+      if ( toStack ) {
+        await toStack.update({ "system.quantity": toStack.system.quantity + item.system.quantity});
         return;
       }
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -410,6 +410,29 @@ export default class CrucibleItem extends foundry.documents.Item {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Test whether an item is stackable with another item
+   * @param {CrucibleItem} other
+   * @returns {boolean}
+   */
+  isStackableWith(other) {
+    if ( !(this.system instanceof crucible.api.models.CruciblePhysicalItem) ) return false;
+    if ( !this.system.properties.has("stackable") ) return false;
+    const cleanData = this.toObject();
+    const cleanOther = other.toObject();
+    for ( const data of [cleanData, cleanOther] ) {
+      delete data._id;
+      delete data._stats;
+      delete data.system.quantity;
+      delete data.sort;
+      delete data.ownership;
+      delete data.folder;
+    }
+    return foundry.utils.equals(cleanData, cleanOther);
+  }
+
+  /* -------------------------------------------- */
   /*  Randomization                               */
   /* -------------------------------------------- */
 


### PR DESCRIPTION
Closes #762 
`CrucibleItem#isStackableWith` can receive refinement as needed. Currently will definitely not have any false positives (erring on the side of being over restrictive).