### PR TITLE
[#838] Fix validity criteria for weapon choices

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -907,9 +907,16 @@ export const TAGS = {
         throw new Error(_loc("ACTION.WARNINGS.NoReloadRequired"));
       }
     },
+    prepare() {
+      this.usage.weapon ??= this.getValidWeaponChoices()[0]?.item;
+      if ( this.usage.weapon ) {
+        Object.assign(this.usage.context, {label: "Reload", icon: "fa-solid fa-arrow-rotate-right", tags: {
+          [`weapon.${this.usage.weapon.id}`]: this.usage.weapon.name
+        }});
+      }
+    },
     preActivate() {
       this.usage.actorUpdates.items ||= [];
-      this.usage.weapon ??= this.getValidWeaponChoices()[0]?.item;
       if ( this.usage.weapon ) {
         this.usage.actorUpdates.items.push({_id: this.usage.weapon.id, "system.loaded": true});
       }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1736,30 +1736,43 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     const choices = [];
     if ( !["strike", "reload"].some(t => this.tags.has(t)) ) return choices;
     const {mainhand: mh, offhand: oh, natural} = this.actor.equipment.weapons;
+
+    // Check _source as well as current tags, to account for both premature tag removal based on weapon selection
+    // and propagated tags
+    const hasMelee = this._source.tags.includes("melee") || this.tags.has("melee");
+    const hasRanged = this._source.tags.includes("ranged") || this.tags.has("ranged");
     const isValidChoice = weapon => {
-      if ( this.tags.has("reload") ) return weapon.system.needsReload;
-      let isValid = this.tags.has("ranged") && weapon.config.category.ranged && !weapon.system.needsReload;
-      isValid ||= this.tags.has("melee") && !weapon.config.category.ranged;
-      if ( maxCost !== null ) isValid &&= (weapon.system.actionCost <= maxCost);
-      return isValid;
+      let available = true;
+      let eligible = true;
+      if ( weapon.config.category.reload ) {
+        available = this.tags.has("reload") ? weapon.system.needsReload : !weapon.system.needsReload;
+      } else if ( this.tags.has("reload") ) eligible = false;
+      if ( maxCost !== null ) available &&= weapon.system.actionCost <= maxCost;
+
+      // Any strike that's neither melee nor ranged shouldn't hard-disqualify weapons based on melee/ranged
+      if ( hasRanged || hasMelee ) {
+        eligible &&= hasRanged || !weapon.config.category.ranged;
+        eligible &&= hasMelee || weapon.config.category.ranged;
+      }
+      return {available, eligible};
     };
     const isNatural = this.tags.has("natural");
     if ( mh && !isNatural ) {
-      const isValid = isValidChoice(mh);
-      if ( !strict || isValid ) choices.push({
+      const {available, eligible} = isValidChoice(mh);
+      if ( eligible && (!strict || available) ) choices.push({
         item: mh,
         id: mh.id || "mainhandUnarmed",
         label: `${mh.name} (${SYSTEM.WEAPON.SLOTS.labels.MAINHAND})`,
-        isValid
+        isValid: available
       });
     }
     if ( oh && !isNatural ) {
-      const isValid = isValidChoice(oh);
-      if ( !strict || isValid ) choices.push({
+      const {available, eligible} = isValidChoice(oh);
+      if ( eligible && (!strict || available) ) choices.push({
         item: oh,
         id: oh.id || "offhandUnarmed",
         label: `${oh.name} (${SYSTEM.WEAPON.SLOTS.labels.OFFHAND})`,
-        isValid
+        isValid: available
       });
     }
     if ( !this.tags.has("ranged") ) {


### PR DESCRIPTION
Closes #838 
Also added some visual feedback in the action use dialog header (and resulting chat card) for which weapon is actually being reloaded.

Changes to checking weapon validity for a given action:
- When determining melee/ranged, check _source_ tags as well as current. This ensures something like Strike (which would have its `ranged` tag or `melee` tag removed depending on the currently-selected weapon) gets proper consideration for both types of weapons
- Return `available` and `eligible` instead of just `isValid`. Weapons for whom `eligible` is `false` aren't returned, even if `strict` is `false`. For example: A melee weapon will _never_ be in the list of valid weapons for Precise Shot, even with `isValid: false`