### PR TITLE
Fix ember hook patches

### DIFF
--- a/module/hooks/ember.mjs
+++ b/module/hooks/ember.mjs
@@ -10,7 +10,7 @@ const EMBER_050 = {
     crystalizeWounds: {
       preActivate() {
         const health = this.actor.level * 2;
-        this.selfEvents.activation.resources = [{resource: "health", delta: health}];
+        this.selfEvents.activation.resources.push({resource: "health", delta: health});
         const res = this.actor.abilities.toughness.value;
         Object.assign(this.effects[0].system, {
           changes: [
@@ -23,7 +23,7 @@ const EMBER_050 = {
     },
     extremeMetabolism: {
       preActivate() {
-        this.selfEvents.activation.resources = [{resource: "action", delta: 1}];
+        this.selfEvents.activation.resources.push({resource: "action", delta: 1});
         const dodgeBonus = Math.ceil(this.actor.abilities.dexterity.value / 2);
         Object.assign(this.effects[0].system, {
           changes: [
@@ -185,10 +185,9 @@ const EMBER_PATCHES = {
  */
 export function applyEmberPatches() {
   ember = globalThis.ember;
-  const emberModule = game.modules.get("ember");
-  if ( !emberModule?.active ) return;
+  if ( !ember?.active ) return;
   for ( const [emberVersion, patches] of Object.entries(EMBER_PATCHES) ) {
-    if ( foundry.utils.isNewerVersion(emberModule.version, emberVersion) ) continue;
+    if ( foundry.utils.isNewerVersion(ember.version, emberVersion) ) continue;
     for ( const [hookType, hooks] of Object.entries(patches) ) {
       foundry.utils.mergeObject(crucible.api.hooks[hookType], hooks, {inplace: true, applyOperators: true});
     }

--- a/module/hooks/ember.mjs
+++ b/module/hooks/ember.mjs
@@ -3,33 +3,33 @@
 /*  Ember 0.5.0 - Remove in Crucible 0.9.2      */
 /* -------------------------------------------- */
 
-const ember = globalThis.ember;
+let ember;
 
 const EMBER_050 = {
   action: {
     crystalizeWounds: {
       preActivate() {
         const health = this.actor.level * 2;
-        this.recordEvent({type: "activation", resources: [{resource: "health", delta: health}]});
+        this.selfEvents.activation.resources = [{resource: "health", delta: health}];
         const res = this.actor.abilities.toughness.value;
-        Object.assign(this.effects[0], {
+        Object.assign(this.effects[0].system, {
           changes: [
-            {key: "system.resistances.bludgeoning.bonus", value: res, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.resistances.piercing.bonus", value: res, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.resistances.slashing.bonus", value: res, mode: CONST.ACTIVE_EFFECT_MODES.ADD}
+            {key: "system.resistances.bludgeoning.bonus", value: res, type: "add"},
+            {key: "system.resistances.piercing.bonus", value: res, type: "add"},
+            {key: "system.resistances.slashing.bonus", value: res, type: "add"}
           ]
         });
       }
     },
     extremeMetabolism: {
       preActivate() {
-        this.recordEvent({type: "activation", resources: [{resource: "action", delta: 1}]});
+        this.selfEvents.activation.resources = [{resource: "action", delta: 1}];
         const dodgeBonus = Math.ceil(this.actor.abilities.dexterity.value / 2);
-        Object.assign(this.effects[0], {
+        Object.assign(this.effects[0].system, {
           changes: [
-            {key: "system.movement.strideBonus", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.defenses.dodge.bonus", value: dodgeBonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.resources.action.bonus", value: 1, mode: CONST.ACTIVE_EFFECT_MODES.ADD}
+            {key: "system.movement.strideBonus", value: 2, type: "add"},
+            {key: "system.defenses.dodge.bonus", value: dodgeBonus, type: "add"},
+            {key: "system.resources.action.bonus", value: 1, type: "add"}
           ]
         });
       }
@@ -63,13 +63,13 @@ const EMBER_050 = {
         const effectEvent = this.selfEvents?.all.find(e => e.effects.length);
         if ( !effectEvent ) return;
         const res = this.actor.level + 1;
-        Object.assign(effectEvent.effects[0], {
+        Object.assign(effectEvent.effects[0].system, {
           _id: "emberLivingStone",
           changes: [
-            {key: "system.resistances.bludgeoning.bonus", value: res, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.resistances.piercing.bonus", value: res, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.resistances.slashing.bonus", value: res, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "system.movement.strideBonus", value: -2, mode: CONST.ACTIVE_EFFECT_MODES.ADD}
+            {key: "system.resistances.bludgeoning.bonus", value: res, type: "add"},
+            {key: "system.resistances.piercing.bonus", value: res, type: "add"},
+            {key: "system.resistances.slashing.bonus", value: res, type: "add"},
+            {key: "system.movement.strideBonus", value: -2, type: "add"}
           ]
         });
       }
@@ -91,20 +91,22 @@ const EMBER_050 = {
       }
     },
     emberBlaze: {
-      async confirm() {
+      confirm: _del,
+      postActivate() {
+        const {action: actionAdjust=0, focus: focusAdjust=0} = this.selfEvents.activation.resourceTotals;
+        const {action, focus} = this.actor.resources;
         this.recordEvent({resources: [
-          {resource: "action", delta: this.actor.resources.action.maximum},
-          {resource: "focus", delta: this.actor.resources.focus.maximum}
+          {resource: "action", delta: action.max - action.value - actionAdjust},
+          {resource: "focus", delta: focus.max - focus.value - focusAdjust}
         ]});
       }
     },
     oozeMagneticDisarm: {
-      async confirm(_reverse) {
+      confirm: _del,
+      postActivate() {
         const health = this.actor.system.abilities.toughness.value;
-        const allSucceeded = this.events
-          .filter(e => (e.target !== this.actor) && e.roll)
-          .every(e => e.roll.isSuccess);
-        if ( allSucceeded ) this.recordEvent({resources: [{resource: "health", delta: health}]});
+        const isSuccess = this.eventsByTarget.values().next().value?.isSuccess;
+        if ( isSuccess ) this.recordEvent({resources: [{resource: "health", delta: health}]});
       }
     }
   },
@@ -182,10 +184,11 @@ const EMBER_PATCHES = {
  * Called during the "setup" Foundry hook, after Ember has registered its hooks in "init".
  */
 export function applyEmberPatches() {
-  const ember = game.modules.get("ember");
-  if ( !ember?.active ) return;
+  ember = globalThis.ember;
+  const emberModule = game.modules.get("ember");
+  if ( !emberModule?.active ) return;
   for ( const [emberVersion, patches] of Object.entries(EMBER_PATCHES) ) {
-    if ( foundry.utils.isNewerVersion(ember.version, emberVersion) ) continue;
+    if ( foundry.utils.isNewerVersion(emberModule.version, emberVersion) ) continue;
     for ( const [hookType, hooks] of Object.entries(patches) ) {
       foundry.utils.mergeObject(crucible.api.hooks[hookType], hooks, {inplace: true, applyOperators: true});
     }


### PR DESCRIPTION
Issues fixed:
- `const ember = globalThis.ember` is no good when called outside of a hook, ember hasn't yet registered itself. So made it a `let` and assigned it prior to applying patches (and renamed the existing `ember` const in there to `emberModule` for clarity).
- Any any effect changes modified `mode` -> `type` (didn't break anything, but why not).
- Crystalize Wounds and Extreme Metabolism were recording activation events, but that's a no-go since they're already defined and are singletons. So modify existing instead.
- Anything adding changes should be targeting an effect's `system.changes`, not just `changes`.
- Ember Blaze should be `postActivate` otherwise we lose knowledge of "what were your resource values before you used this?"
- Magnetic Disarm should be `postActivate`, and simplified the filtering for success.