### PR TITLE
Revert to previous canvas layer after closing region-using action use dialog

### DIFF
--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -51,6 +51,12 @@ export default class ActionUseDialog extends StandardCheckDialog {
   #regionPreview = null;
 
   /**
+   * The previously-viewed canvas layer, so once the dialog is closed for region-requiring actions we can revert.
+   * @type {InteractionLayer|null}
+   */
+  #previousCanvasLayer = null;
+
+  /**
    * Tracks whether the dialog was submitted successfully via _onRoll.
    * Used by #clearMovementPlan to avoid cancelling planned movement on a successful submission,
    * since _onClose fires for both cancellation and submission.
@@ -317,15 +323,15 @@ export default class ActionUseDialog extends StandardCheckDialog {
     };
 
     // Place the region and record its created data
-    const canvasLayer = canvas.activeLayer;
+    this.#previousCanvasLayer = canvas.activeLayer;
     const region = await canvas.regions.placeRegion(regionData, {create: false, onMove, onChange});
-    canvasLayer.activate();
     await Promise.allSettled(minimizedWindows.map(app => app.maximize()));
 
     // Handle user workflow cancellation
     if ( !region ) {
       this.#regionTargets = null;
       canvas.tokens.setTargets([]);
+      this.#previousCanvasLayer.activate();
       return;
     }
 
@@ -462,6 +468,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
   #clearRegionPreview() {
     this.#regionPreview?.destroy({children: true});
     this.#regionPreview = null;
+    this.#previousCanvasLayer?.activate();
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Can only revert if we don't need the preview, otherwise the preview gets destroyed. I think it might make sense to have this "preview" be an actual created region that we just explicitly clean up for if need be. But for now this is a simple, clean solution.