### PR TITLE
Ensure targets are displayed regardless of number of rolls

### DIFF
--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -2467,7 +2467,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       if ( !event.roll ) continue;
       const isNewTarget = !targetActors.has(event.target);
       if ( isNewTarget ) targetActors.add(event.target);
-      event.roll.data.newTarget = isNewTarget && (targetActors.size > 1);
+      event.roll.data.newTarget = isNewTarget && (this.eventsByTarget.size > 1);
       event.roll.data.index = rolls.length;
       rolls.push(event.roll);
     }
@@ -2494,6 +2494,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       context: this.usage.context,
       hasActionTags: !tags.action.empty,
       hasContextTags: !tags.context.empty,
+      hasTargetTags: (targets.length === 1) || (targets.length && !this.eventsByTarget.values().some(e => e.roll)),
       hasTargets: !["self", "none"].includes(this.target.type),
       tags,
       targets,


### PR DESCRIPTION
Two changes here:
1. `hasTargetTags` needs to be in the context for the template render, specifically for 1-target actions (because they'll never be considered a "new" target) or multi-target actions which _don't_ rely on target rolls (e.g. Inspire Heroism).
2. Since we're populating `targetActors` in the same loop that we assign `roll.data.newTarget`, we can't rely on the size of that Set, since it'll always be 1 for the first "new" actor (and therefore they'll not be considered new). So we instead rely on the existing `eventsByTarget` getter Map's size.