### PR TITLE
Mark non-talisman weapons ineligible for talisman-tag actions, improve talisman tag's `canUse`

### DIFF
--- a/_source/talent/Talisman_Weapon_Training_talismanWeaponTr.yml
+++ b/_source/talent/Talisman_Weapon_Training_talismanWeaponTr.yml
@@ -39,12 +39,12 @@ system:
       effects: []
       tags:
         - talisman
-        - ranged
         - harmless
         - rallying
       summon:
         actorUuid: null
         permanent: true
+      metadata: {}
   iconicSpells: 0
   training:
     type: talisman
@@ -60,12 +60,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.360'
   systemId: crucible
   systemVersion: 0.9.0
   createdTime: 1772307160151
-  modifiedTime: 1773514792622
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1776096196827
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 ownership:
   default: 0
   AnoypGxxNIMOS0XY: 3

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -312,9 +312,9 @@ export const TAGS = {
     canUse() {
       const {mainhand: mh, offhand: oh} = this.actor.equipment.weapons;
       const categories = ["talisman1", "talisman2"];
-      if ( !categories.includes(mh?.category) && !categories.includes(oh?.category) ) return false;
-      if ( !this.usage.strikes.every(w => w.config.category.training.includes("talisman")) ) {
-        throw new Error(_loc("ACTION.WARNINGS.RequiresTalisman"));
+      if ( (!categories.includes(mh?.category) && !categories.includes(oh?.category))
+        || !this.usage.strikes.every(w => w.config.category.training.includes("talisman")) ) {
+        throw new Error(_loc("ACTION.WARNINGS.RequiresTalisman", {action: this.name}));
       }
     }
   },

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -310,6 +310,9 @@ export const TAGS = {
     tooltip: "ACTION.TAG.TalismanTooltip",
     category: "requirements",
     canUse() {
+      const {mainhand: mh, offhand: oh} = this.actor.equipment.weapons;
+      const categories = ["talisman1", "talisman2"];
+      if ( !categories.includes(mh?.category) && !categories.includes(oh?.category) ) return false;
       if ( !this.usage.strikes.every(w => w.config.category.training.includes("talisman")) ) {
         throw new Error(_loc("ACTION.WARNINGS.RequiresTalisman"));
       }

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -753,16 +753,6 @@ HOOKS.recover = {
 /* -------------------------------------------- */
 
 HOOKS.refocus = {
-  canUse() {
-    const {mainhand: mh, offhand: oh} = this.actor.equipment.weapons;
-    const categories = ["talisman1", "talisman2"];
-    return categories.includes(mh.category) || (oh && categories.includes(oh.category));
-  },
-  preActivate() {
-    if ( !["talisman1", "talisman2"].includes(this.usage.weapon?.category) ) {
-      throw new Error(_loc("ACTION.WARNINGS.RequiresTalisman", {action: this.name}));
-    }
-  },
   postActivate() {
     const talisman = this.usage.weapon;
     const rollEvent = this.selfEvents?.roll[0];

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1774,6 +1774,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         available = this.tags.has("reload") ? weapon.system.needsReload : !weapon.system.needsReload;
       } else if ( this.tags.has("reload") ) eligible = false;
       if ( maxCost !== null ) available &&= (weapon.system.actionCost <= maxCost);
+      if ( this.tags.has("talisman") && !["talisman1", "talisman2"].includes(weapon.system.category)) eligible = false;
 
       // Any strike that's neither melee nor ranged shouldn't hard-disqualify weapons based on melee/ranged
       if ( hasRanged || hasMelee ) {


### PR DESCRIPTION
Changes:
1. `talisman` tag? Only valid weapons are `talisman1` or `talisman2` category
2. Remove `canUse` from refocus, instead improving the `talisman` tag's `canUse`:
3. `talisman` tag's `canUse` returns false if no equipped talisman, preventing it from being shown in favorites. I _think_ we can probably remove the remaining `this.usage.strikes` check, due to the implementation of (1) it shouldn't be possible to end up in a state where a non-talisman is being used, but left it just in case
4. Removed refocus's `preActivate`, as it's rendered useless by (1) and (3)