### PR TITLE
Update `CrucibleActor#_cachedResources` only after max resources have been prepared

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -22,10 +22,6 @@ const {DialogV2} = foundry.applications.api;
  * The Actor document subclass in the Crucible system which extends the behavior of the base Actor class.
  */
 export default class CrucibleActor extends Actor {
-  constructor(...args) {
-    super(...args);
-    this.#updateCachedResources();
-  }
 
   /**
    * The Actions which this Actor has available to use.
@@ -239,6 +235,14 @@ export default class CrucibleActor extends Actor {
     // TODO: This is a temporary fix for double item prep
     if ( phase !== "final" ) this.system.prepareItems(items);
     super.applyActiveEffects(phase);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    if ( foundry.utils.isEmpty(this._cachedResources) ) this._updateCachedResources();
   }
 
   /* -------------------------------------------- */
@@ -2561,7 +2565,7 @@ export default class CrucibleActor extends Actor {
         const commit = (activeGM === game.user) && (activeGM?.viewedScene === canvas.id);
         for ( const token of tokens ) token.refreshFlanking(commit);
       }
-      this.#updateCachedResources();
+      this._updateCachedResources();
       this.#updateGroups();
     }
 
@@ -2854,8 +2858,9 @@ export default class CrucibleActor extends Actor {
 
   /**
    * Update cached resources for this Actor.
+   * @internal
    */
-  #updateCachedResources() {
+  _updateCachedResources() {
     this._cachedResources ||= {};
     const resources = this.system.schema.get("resources");
     if ( !resources ) return;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -242,7 +242,7 @@ export default class CrucibleActor extends Actor {
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    if ( foundry.utils.isEmpty(this._cachedResources) ) this._updateCachedResources();
+    this._updateCachedResources(false);
   }
 
   /* -------------------------------------------- */
@@ -2858,9 +2858,11 @@ export default class CrucibleActor extends Actor {
 
   /**
    * Update cached resources for this Actor.
+   * @param {boolean} force Whether to force update of cached resources
    * @internal
    */
-  _updateCachedResources() {
+  _updateCachedResources(force=true) {
+    if ( !force && !foundry.utils.isEmpty(this._cachedResources) ) return;
     this._cachedResources ||= {};
     const resources = this.system.schema.get("resources");
     if ( !resources ) return;


### PR DESCRIPTION
Calling in constructor was too early, as resources aren't prepared and therefore only have `value`s. Moved into `prepareDerivedData`, which meant changing `CrucibleActor##updateCachedResources` from a hard private to an internal `CrucibleActor#_updateCachedResources` (because of synthetic actors... I think? For some reason despite being `CrucibleActor`s, they were throwing type errors about the receiver not being an instance of class `CrucibleActor`).