### PR TITLE
[#843, 864] Improve system interaction with detached windows

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -629,6 +629,16 @@ Hooks.once("ready", async function() {
 /* -------------------------------------------- */
 
 /**
+ * On open detached windows, apply crucible interaction listeners
+ */
+Hooks.on("openDetachedWindow", (_id, window) => {
+  window.document.body.addEventListener("pointerenter", interaction.onPointerEnter, true);
+  window.document.body.addEventListener("pointerleave", interaction.onPointerLeave, true);
+});
+
+/* -------------------------------------------- */
+
+/**
  * Perform one-time data migrations for the current world.
  * @param {string} priorVersion
  * @returns {Promise<void>}

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -276,7 +276,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
     // Minimize open windows
     const minimizedWindows = [];
     for ( const app of foundry.applications.instances.values() ) {
-      if ( !app.minimized ) minimizedWindows.push(app);
+      if ( !app.minimized && !app.window.windowId ) minimizedWindows.push(app);
     }
     await Promise.allSettled(minimizedWindows.map(app => app.minimize()));
 
@@ -502,7 +502,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
     // Minimize open windows
     const minimizedWindows = [];
     for ( const app of foundry.applications.instances.values() ) {
-      if ( !app.minimized ) minimizedWindows.push(app);
+      if ( !app.minimized && !app.window.windowId ) minimizedWindows.push(app);
     }
     await Promise.allSettled(minimizedWindows.map(app => app.minimize()));
 


### PR DESCRIPTION
Two changes:
1. When minimizing application instances, skip those with a `window.windowId`, as they are detached and therefore cannot get in the way of placement (closes #864)
2. Hook on `openDetachedWindow`, add event listeners so that crucible tooltips function in them (closes #842)