### PR TITLE
[#782] Don't consider ability/talent over/underspending issues from the Hero sheet at level 0

### DIFF
--- a/module/applications/sheets/hero-sheet.mjs
+++ b/module/applications/sheets/hero-sheet.mjs
@@ -52,10 +52,12 @@ export default class HeroSheet extends CrucibleBaseActorSheet {
     const issues = [];
     if ( !s.system.details.ancestry?.name ) issues.push("ACTOR.WARNINGS.NoAncestry");
     if ( !s.system.details.background?.name ) issues.push("ACTOR.WARNINGS.NoBackground");
-    if ( points.ability.available < 0 ) issues.push("ACTOR.WARNINGS.OverspentAbility");
-    else if ( points.ability.requireInput ) issues.push("ACTOR.WARNINGS.UnderspentAbility");
-    if ( points.talent.available < 0 ) issues.push("ACTOR.WARNINGS.OverspentTalent");
-    else if ( points.talent.available ) issues.push("ACTOR.WARNINGS.UnderspentTalent");
+    if ( !isL0 ) {
+      if ( points.ability.available < 0 ) issues.push("ACTOR.WARNINGS.OverspentAbility");
+      else if ( points.ability.requireInput ) issues.push("ACTOR.WARNINGS.UnderspentAbility");
+      if ( points.talent.available < 0 ) issues.push("ACTOR.WARNINGS.OverspentTalent");
+      else if ( points.talent.available ) issues.push("ACTOR.WARNINGS.UnderspentTalent");
+    }
     i.progress = !!issues.length;
     if ( i.progress ) {
       const items = issues.reduce((s, text) => `${s}<li>${_loc(text)}</li>`, "");

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1876,7 +1876,7 @@ export default class CrucibleActor extends Actor {
         this.system.details.ancestry?.name,
         this.system.details.background?.name,
         !this.points.ability.requireInput,
-        !this.points.talent.available
+        this.points.talent.available <= 0
       ];
       if ( !steps.every(k => k) ) return ui.notifications.warn(_loc("WALKTHROUGH.LevelZeroIncomplete"));
     }


### PR DESCRIPTION
Closes #782 
2 changes:
1. Don't check available talent points or ability points on the Hero sheet when determining whether to show the "Level Up" button for someone at level 0. Still require an ancestry/background, but excess/missing points can be ignored at level 0 when not going through the creation app.
2. In `CrucibleActor#levelUp`, in the level-0-specific checks, consider negative talent points (i.e. overspent) to be acceptable, instead of just precisely 0 talent points. This will never be the case in the creation app, but may be the case for a level 2+ actor who has been leveled down to 0.