### PR TITLE
[#881] Propagate `strike` tag from `talisman` tag

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -309,6 +309,7 @@ export const TAGS = {
     label: "ACTION.TAG.Talisman",
     tooltip: "ACTION.TAG.TalismanTooltip",
     category: "requirements",
+    propagate: ["strike"],
     canUse() {
       const {mainhand: mh, offhand: oh} = this.actor.equipment.weapons;
       const categories = ["talisman1", "talisman2"];


### PR DESCRIPTION
Closes #881 
Future consideration: Refocus isn't quite an "Attack" activity insofar as how it should be sorted, but `strike`s go in there no matter what.