### PR TITLE
Make wounds/madness defenses (Healing & Rallying Thresholds) localization clearer

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1310,12 +1310,12 @@
     "Block": "Block",
     "Dodge": "Dodge",
     "Fortitude": "Fortitude",
-    "Madness": "Madness",
+    "Madness": "Rallying Threshold",
     "Parry": "Parry",
     "Physical": "Physical",
     "Reflex": "Reflex",
     "Willpower": "Willpower",
-    "Wounds": "Wounds"
+    "Wounds": "Healing Threshold"
   },
   "DICE": {
     "DIFFICULTIES": {


### PR DESCRIPTION
Think this probably was just an oversight - we don't use it anywhere except on hovering the thresholds on an actor sheet.