### PR TITLE
Improve Group Skill check rendering using Dice So Nice

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -1002,7 +1002,7 @@ async function resetAllActorTalents() {
 
 Hooks.once("diceSoNiceReady", dice3d => {
   // Improve Group Skill Checks rendering by hiding only the roll result
-  dice3d.setMessageUpdateHideSelector(".dice-result");
+  dice3d.setMessageUpdateHideSelector?.(".dice-result");
 });
 
 /* -------------------------------------------- */

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -997,6 +997,15 @@ async function resetAllActorTalents() {
 }
 
 /* -------------------------------------------- */
+/*  Module Hooks                                */
+/* -------------------------------------------- */
+
+Hooks.once("diceSoNiceReady", dice3d => {
+  // Improve Group Skill Checks rendering by hiding only the roll result
+  dice3d.setMessageUpdateHideSelector(".dice-result");
+});
+
+/* -------------------------------------------- */
 /*  ESModules API                               */
 /* -------------------------------------------- */
 


### PR DESCRIPTION
This change improves the UI feels during a group skill check by only hiding the relevant Roll result and keeping the name of the actor visible instead of hiding the entire line and creating a more jarring UI shift.  


Only works with DsN v6+. Will not break older versions.  

<img width="315" height="246" alt="image" src="https://github.com/user-attachments/assets/e922ba3e-15f3-40d5-af6d-69fbb21d131c" />

<img width="315" height="246" alt="image" src="https://github.com/user-attachments/assets/ffbf6151-57a1-464d-9aaf-c52086a0c190" />  