### PR TITLE
Improve module support with the Initiative Report message

### DIFF
--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -17,7 +17,7 @@ export default class CrucibleCombatant extends Combatant {
   getInitiativeRoll(formula) {
     const boons = {};
     const banes = {};
-    const rollData = {ability: this.abilityBonus, skill: 0, enchantment: 0, boons, banes};
+    const rollData = {actorId: this.actor?.id, ability: this.abilityBonus, skill: 0, enchantment: 0, boons, banes};
     if ( this.actor ) {
       if ( this.actor.isIncapacitated || !this.actor.abilities.dexterity.value ) rollData.incapacitated = true;
       else if ( this.actor.statuses.has("unaware") ) rollData.unaware = true;

--- a/module/models/combat-combat.mjs
+++ b/module/models/combat-combat.mjs
@@ -81,7 +81,10 @@ export default class CrucibleCombatChallenge extends foundry.abstract.TypeDataMo
     });
     const speaker = ChatMessage.getSpeaker();
     speaker.alias = _loc("COMBAT.INITIATIVE.Round", {round});
-    return ChatMessage.create({content, rolls, speaker, "flags.crucible.isInitiativeReport": true});
+    return ChatMessage.create({content, rolls, speaker, flags: {
+      crucible: {isInitiativeReport: true},
+      core: {initiativeRoll: true}
+    }});
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
1- Similar to how Group Skill Checks append actorId to the roll.data, Crucible Initiative grouped message needs this too to support per-actor DsN appearance
2- Add the native core flag "initiativeRoll" to the initiative report. This adds support for modules using this flag to react to initative messages, like Dice So Nice "Skip Animation on Initiative Roll" setting.

Fix #932