### PR TITLE
[#948] Ensure non-stacking equipment bought in creation doesn't stack

### DIFF
--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -1136,8 +1136,11 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
     for ( const {item, quantity, scaledPrice} of Object.values(this._state.equipment) ) {
       if ( quantity <= 0 ) continue;
       const itemData = this._clone._cleanItemData(item);
-      itemData.system.quantity = quantity;
-      creationData.items.push(itemData);
+      delete itemData._id;
+      if ( itemData.system.properties.includes("stackable") ) {
+        itemData.system.quantity = quantity;
+        creationData.items.push(itemData);
+      } else creationData.items.push(...new Array(quantity).fill(itemData));
       spent += scaledPrice * quantity;
     }
     creationData.system.currency = SYSTEM.ACTOR.STARTING_EQUIPMENT_BUDGET - spent;

--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -1140,7 +1140,8 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
       if ( itemData.system.properties.includes("stackable") ) {
         itemData.system.quantity = quantity;
         creationData.items.push(itemData);
-      } else creationData.items.push(...new Array(quantity).fill(itemData));
+      } 
+      else creationData.items.push(...new Array(quantity).fill(itemData));
       spent += scaledPrice * quantity;
     }
     creationData.system.currency = SYSTEM.ACTOR.STARTING_EQUIPMENT_BUDGET - spent;


### PR DESCRIPTION
Closes #948 
Also remove `_id` from such equipment, as it seems to me that physical items obtained during character creation shouldn't mandatorily retain their compendium source's ID.