### PR TITLE
[#940] Add thermal vision detection mode

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -436,6 +436,13 @@ Hooks.once("init", async function() {
 
   // Replace core layer class with custom grid layer class
   CONFIG.Canvas.layers.grid.layerClass = canvas.grid.CrucibleGridLayer;
+
+  // Crucible-specific detection modes
+  CONFIG.Canvas.detectionModes.thermalVision = new canvas.detectionModes.DetectionModeThermalVision({
+    id: "thermalVision",
+    label: "DETECTION_MODES.ThermalVision",
+    type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.SIGHT
+  });
 });
 
 /* -------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -1363,6 +1363,9 @@
     "Willpower": "Willpower",
     "Wounds": "Healing Threshold"
   },
+  "DETECTION_MODES": {
+    "ThermalVision": "Thermal Vision"
+  },
   "DICE": {
     "DIFFICULTIES": {
       "Challenging": "Challenging",

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -2,6 +2,7 @@ import CrucibleTokenRuler from "./token-ruler.mjs";
 import CrucibleTokenHUD from "../applications/hud/token-hud.mjs";
 import {MOVEMENT_ACTIONS, TRAVEL_PACES} from "../const/actor.mjs";
 
+export * as detectionModes from "./detection-modes/_module.mjs";
 export * as tree from "./tree/_module.mjs";
 export * as grid from "./grid/_module.mjs";
 export * as vfx from "./vfx/_module.mjs";

--- a/module/canvas/detection-modes/_module.mjs
+++ b/module/canvas/detection-modes/_module.mjs
@@ -1,0 +1,1 @@
+export {default as DetectionModeThermalVision} from "./thermal-vision.mjs";

--- a/module/canvas/detection-modes/thermal-vision.mjs
+++ b/module/canvas/detection-modes/thermal-vision.mjs
@@ -1,0 +1,63 @@
+export default class DetectionModeThermalVision extends foundry.canvas.perception.DetectionMode {
+  /** @override */
+  static getDetectionFilter() {
+    this._detectionFilter ??= foundry.canvas.rendering.filters.GlowOverlayFilter.create({glowColor: [1, 0.5, 0, 1]});
+    return this._detectionFilter;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canDetect(visionSource, target) {
+
+    // Thermal vision only works on creatures
+    if ( !(target instanceof foundry.canvas.placeables.Token) ) return false;
+    const source = visionSource.object.document;
+
+    // Cannot see if blinded or incapacitated
+    if ( source.hasStatusEffect(CONFIG.specialStatusEffects.BLIND) ) return false;
+    if ( source.hasStatusEffect(CONFIG.specialStatusEffects.INCAPACITATED) ) return false;
+
+    // If constrained by walls, cannot see if either source or target is burrowing
+    if ( this.walls ) {
+      if ( source.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
+      if ( target.document.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
+    }
+
+    // Allow for specific creature overrides
+    // TODO: Check the appropriate (as yet nonexistent) system.details field for this
+    const override = target.actor?.flags?.ember?.warmBlooded;
+    if ( typeof override === "boolean" ) return override;
+
+    // If target is a Hero, default is detectable
+    if ( target.actor?.type === "hero" ) return true;
+
+    // Otherwise, check adversary creature category
+    // TODO: Determine whether Thermal Vision should represent detection of heat-emitting creatures, or any creatures
+    // with a variance in temperature. If the former, can remove this array & just check `=== "warm"`. If the latter,
+    // should add "cold" to the `temps` array.
+    const temps = ["warm"];
+    return temps.includes(SYSTEM.ACTOR.CREATURE_CATEGORIES[target.actor.system.details.taxonomy?.category]?.warmBodied);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _testLOS(visionSource, mode, target, test) {
+
+    // If outside vision angle, can't detect
+    if ( this.angle && !this._testAngle(visionSource, mode, target, test) ) return false;
+
+    // If not constrained by walls, can detect
+    if ( !this.walls ) return true;
+
+    // Otherwise, standard sight check, but ignoring darkness sources
+    return !CONFIG.Canvas.polygonBackends.sight.testCollision(visionSource.origin, test.point, {
+      type: "sight",
+      mode: "any",
+      source: visionSource,
+      useThreshold: true,
+      priority: Infinity
+    });
+  }
+}

--- a/module/const/actor.mjs
+++ b/module/const/actor.mjs
@@ -2,98 +2,116 @@ import {freezeEnum} from "./enum.mjs";
 
 /**
  * Creature types supported by the system.
- * @type {Record<string, {label: string, skill: string, knowledge: string}>}
+ * @type {Record<string, {label: string, skill: string, knowledge: string, temperature: "warm"|"neutral"|"cold"}>}
  */
 export const CREATURE_CATEGORIES = {
   beast: {
     label: "TAXONOMY.CATEGORIES.Beast",
     skill: "medicine",
-    knowledge: "beasts"
+    knowledge: "beasts",
+    temperature: "warm"
   },
   celestial: {
     label: "TAXONOMY.CATEGORIES.Celestial",
     skill: "arcana",
-    knowledge: "celestials"
+    knowledge: "celestials",
+    temperature: "warm"
   },
   construct: {
     label: "TAXONOMY.CATEGORIES.Construct",
     skill: "science",
-    knowledge: "machines"
+    knowledge: "machines",
+    temperature: "neutral"
   },
   dragon: {
     label: "TAXONOMY.CATEGORIES.Dragon",
     skill: "arcana",
-    knowledge: "dragons"
+    knowledge: "dragons",
+    temperature: "warm"
   },
   elemental: {
     label: "TAXONOMY.CATEGORIES.Elemental",
     skill: "arcana",
-    knowledge: "elementals"
+    knowledge: "elementals",
+    temperature: "neutral"
   },
   elementalEarth: {
     label: "TAXONOMY.CATEGORIES.ElementalEarth",
     skill: "arcana",
-    knowledge: "elementals"
+    knowledge: "elementals",
+    temperature: "neutral"
   },
   elementalFire: {
     label: "TAXONOMY.CATEGORIES.ElementalFire",
     skill: "arcana",
-    knowledge: "elementals"
+    knowledge: "elementals",
+    temperature: "warm"
   },
   elementalFrost: {
     label: "TAXONOMY.CATEGORIES.ElementalFrost",
     skill: "arcana",
-    knowledge: "elementals"
+    knowledge: "elementals",
+    temperature: "cold"
   },
   elementalStorm: {
     label: "TAXONOMY.CATEGORIES.ElementalStorm",
     skill: "arcana",
-    knowledge: "elementals"
+    knowledge: "elementals",
+    temperature: "neutral"
   },
   fey: {
     label: "TAXONOMY.CATEGORIES.Fey",
     skill: "arcana",
-    knowledge: "fey"
+    knowledge: "fey",
+    temperature: "warm"
   },
   fiend: {
     label: "TAXONOMY.CATEGORIES.Fiend",
     skill: "arcana",
-    knowledge: "fiends"
+    knowledge: "fiends",
+    temperature: "warm"
   },
   giant: {
     label: "TAXONOMY.CATEGORIES.Giant",
     skill: "society",
-    knowledge: "legends"
+    knowledge: "legends",
+    temperature: "warm"
   },
   humanoid: {
     label: "TAXONOMY.CATEGORIES.Humanoid",
     skill: "society",
-    knowledge: null
+    knowledge: null,
+    temperature: "warm"
   },
   monstrosity: {
     label: "TAXONOMY.CATEGORIES.Monstrosity",
     skill: "medicine",
-    knowledge: "monsters"
+    knowledge: "monsters",
+    temperature: "warm"
   },
   ooze: {
     label: "TAXONOMY.CATEGORIES.Ooze",
     skill: "science",
-    knowledge: null
+    knowledge: null,
+    temperature: "neutral"
   },
   plant: {
     label: "TAXONOMY.CATEGORIES.Plant",
     skill: "wilderness",
-    knowledge: null
+    knowledge: null,
+    temperature: "neutral"
   },
   outsider: {
     label: "TAXONOMY.CATEGORIES.Outsider",
     skill: "arcana",
-    knowledge: "outsiders"
+    knowledge: "outsiders",
+    temperature: "neutral"
   },
   undead: {
     label: "TAXONOMY.CATEGORIES.Undead",
     skill: "arcana",
-    knowledge: "undeath"
+    knowledge: "undeath",
+    temperature: "neutral"
   }
 };
 

--- a/module/hooks/ember.mjs
+++ b/module/hooks/ember.mjs
@@ -192,4 +192,11 @@ export function applyEmberPatches() {
       foundry.utils.mergeObject(crucible.api.hooks[hookType], hooks, {inplace: true, applyOperators: true});
     }
   }
+
+  // TODO: Once ember stops clobbering Thermal Vision, remove this
+  CONFIG.Canvas.detectionModes.thermalVision = new crucible.api.canvas.detectionModes.DetectionModeThermalVision({
+    id: "thermalVision",
+    label: "DETECTION_MODES.ThermalVision",
+    type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.SIGHT
+  });
 }


### PR DESCRIPTION
Closes #940 
Ember-related TODOs:
- Currently checking `flags.ember.warmBlooded` for max compatibility's sake. Once we have a mechanism for handling overrides of default temperature in the system itself, we can move to use that
- Currently re-registering the detection mode in `applyEmberPatches` - once Ember no longer overrides our assignment we can remove that

System-related TODOs:
- Add something to Ancestries that represents a Hero equivalent of a creature category's `temperature`
- Add a property `system.details.temperature` (or similar) for overriding the default (default either being from Ancestry or creature category from Taxonomy), respect that instead of looking for `flags.ember.warmBlooded`
- Determine whether we want Thermal Vision (the talent) to operate as-is (i.e. detection of heat-emitting creatures) or allow detection of any actor which varies from the "norm" (e.g. Frost Elementals, which would be colder than normal)