### PR TITLE
[#893] Increase "Requested Actors" div height

### DIFF
--- a/styles/dice.less
+++ b/styles/dice.less
@@ -40,7 +40,7 @@
   /** Requested Rolls (right panel) */
   .standard-check .request-form {
     .requested-actors {
-      max-height: 280px;
+      height: 280px;
       overflow-y: auto;
       padding: 0.5rem;
       gap: 0.5rem;


### PR DESCRIPTION
Closes #893 
No reason not to have `height` instead of `max-height` here, this makes the entire area droppable but changes nothing about presentation.