### PR TITLE
[#892, #949] Ensure "Roll" button always results in rolling

### DIFF
--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -369,7 +369,7 @@ export default class StandardCheckDialog extends DialogV2 {
    */
   async _onRoll(_event, _button, _dialog) {
     this.roll.data.messageMode = this.messageMode;
-    if ( this.isGroupCheck && (this.#requestActors.size > 0) ) {
+    if ( (this.isGroupCheck || this.request) && (this.#requestActors.size > 0) ) {
       await this.#rollGroupCheck();
       return null;
     }

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -749,10 +749,14 @@ function renderSkillCheck(element) {
  * Handle a click on a skill check enriched element, creating and optionally displaying a skill check roll.
  * @param {Event} event
  */
-function onClickSkillCheck(event) {
+async function onClickSkillCheck(event) {
   event.preventDefault();
   const {check, actor} = prepareSkillCheck(event);
-  return check.dialog({request: game.user.isGM && !actor});
+  const response = await check.dialog({request: game.user.isGM && !actor});
+  if ( response === null ) return;
+  const skill = SYSTEM.SKILLS[response.data.type];
+  const flavor = skill ? _loc("ACTION.SkillCheck", {skill: skill.label}) : "";
+  return check.toMessage({flavor});
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Closes #892 
Closes #949 
Two scenarios where "Roll" did nothing, but now does something:
1. Non-`group` enricher clicked with no inferred actor. Lets you select actors to request, but "Roll" does nothing, while "Request" works as expected. Now is treated as a group roll. Example: `[[/skillCheck athletics 12]]` clicked as GM with no selected or assigned actor. Fix was checking `this.isGroupCheck || this.request`, as in _either_ case we won't be wired up to do anything with the returned roll itself, so should handle it in `_onRoll`.
2. Non-`group` enricher clicked _with_ an inferred actor. `onClickSkillCheck` would previously just return the roll, but no handling to actually `toMessage` it. Now, if there's a non-null return from the check dialog (i.e. if there _is_ an inferred actor, since this is the only time `_onRoll` will return non-null), will `toMessage` the result. Example is the same `[[/skillCheck athletics 12]]` enricher but with a single selected token.