### PR TITLE
[#942] Ensure rolls in chat which shouldn't be visible aren't visible

### DIFF
--- a/templates/dice/standard-check-chat.hbs
+++ b/templates/dice/standard-check-chat.hbs
@@ -1,4 +1,5 @@
 <div class="{{cssClass}} line-item" data-action="expandRoll">
+    {{#unless isPrivate}}
     {{#if actor}}
     <img class="icon" src="{{actor.img}}" alt="{{actor.name}}">
     <div class="title">
@@ -16,4 +17,5 @@
     </div>
     {{/if}}
     {{> "systems/crucible/templates/dice/partials/standard-check-dice-result.hbs"}}
+    {{/unless}}
 </div>


### PR DESCRIPTION
Closes #942 
As a note, this will also result in hiding "private to GM" rolls until 14.361 (https://github.com/foundryvtt/foundryvtt/issues/14258)

Before:
<img width="294" height="122" alt="image" src="https://github.com/user-attachments/assets/f0762174-c943-43a0-8af8-d584e45f9465" />

After: 
<img width="293" height="61" alt="image" src="https://github.com/user-attachments/assets/9c39a3f3-2302-4916-a7ac-addb19e03d91" />
