### PR TITLE
[#906] Ensure existing affixes are considered invalid during randomization

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -577,6 +577,7 @@ export default class CrucibleItem extends foundry.documents.Item {
     // Step 4: Select random affixes to fill the needed tier budget
     const eligibleAffixes = allAffixes.filter(a => {
       if ( a.type !== "affix" ) return false;
+      if ( a.system.identifier in baseItem.system.affixes ) return false;
       const types = a.system.itemTypes;
       return !types.size || types.has(baseItem.type);
     });


### PR DESCRIPTION
Closes #906 