### PR TITLE
[#981] Add localization for composed item names

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1519,6 +1519,10 @@
       "RecoverDetail": "Recover the dropped {item}",
       "UnEquip": "Un-equip {typeLabel}"
     },
+    "COMPOSED_NAME": {
+      "Prefix": "{prefixes} {name}",
+      "Suffix": "{name} of {suffixes}" 
+    },
     "FIELDS": {
       "actions": {
         "label": "Item Actions"

--- a/module/models/item-physical.mjs
+++ b/module/models/item-physical.mjs
@@ -306,10 +306,14 @@ export default class CruciblePhysicalItem extends foundry.abstract.TypeDataModel
       else suffixes.push(adj);
     }
     if ( !prefixes.length && !suffixes.length && !quality ) return null;
+    const listFormatter = new Intl.ListFormat(game.i18n.lang, {style: "narrow", type: "unit"});
     let name = baseName;
-    if ( prefixes.length ) name = prefixes.join(" ") + " " + name;
-    else if ( quality ) name = _loc(quality.label) + " " + name;
-    if ( suffixes.length ) name += " of " + suffixes.join(" ");
+    let prefixString;
+    if ( prefixes.length ) prefixString = listFormatter.format(prefixes);
+    else if ( quality ) prefixString = _loc(quality.label);
+    const suffixString = suffixes.length ? listFormatter.format(suffixes) : null;
+    if ( prefixString ) name = _loc("ITEM.COMPOSED_NAME.Prefix", {prefixes: prefixString, name});
+    if ( suffixString ) name = _loc("ITEM.COMPOSED_NAME.Suffix", {suffixes: suffixString, name});
     return name;
   }
 


### PR DESCRIPTION
Closes #981 
Realized we probably don't actually need a "full name" version which is "{prefixes} {name} of {suffixes}", as in theory having prefixes shouldn't have an impact on what the suffixes look like, and vice versa. If that ends up not being the case for some languages then we can refactor.