### PR TITLE
[#990] Ensure `_source` contains items when "creating" new Hero at the end of creation workflow

### DIFF
--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -1112,6 +1112,8 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
 
     // Update the actor and render the regular sheet
     this.#complete = true;
+    // TODO: Determine whether this is the ideal fix, we should do something different, or core needs a fix here
+    this.document.updateSource({items: creationData.items}, creationOptions);
     await this.document.update(creationData, creationOptions);
     await this.close({dialog: false});
   }
@@ -1136,7 +1138,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
     for ( const {item, quantity, scaledPrice} of Object.values(this._state.equipment) ) {
       if ( quantity <= 0 ) continue;
       const itemData = this._clone._cleanItemData(item);
-      delete itemData._id;
+      itemData._id = foundry.utils.randomID();
       if ( itemData.system.properties.includes("stackable") ) {
         itemData.system.quantity = quantity;
         creationData.items.push(itemData);


### PR DESCRIPTION
Closes #990 
Two-parter:
1. `updateSource` with `items` so that they don't erroneously get their `ownership` field added during data cleaning
2. Give equipment a random ID, rather than deleting, so that when the `sourceIdMap` is created during cleaning, it actually has values for the equipment

As mentioned in the issue, there's potentially a Core issue to be fixed here.