### PR TITLE
[#997] Fix hint paragraph positioning in fieldsets

### DIFF
--- a/styles/applications.less
+++ b/styles/applications.less
@@ -252,6 +252,9 @@
       flex-direction: row;
       flex-wrap: wrap;
     }
+    & > .hint {
+      flex-basis: auto;
+    }
     legend {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Tiny fix for `.hint` paragraphs in flex column fieldsets. Tested in Firefox and Chromium.

Closes #997 