### PR TITLE
[#986] Outline invalid scaling values in red on details sheets

### DIFF
--- a/module/applications/sheets/item-archetype-sheet.mjs
+++ b/module/applications/sheets/item-archetype-sheet.mjs
@@ -152,7 +152,12 @@ export default class CrucibleArchetypeItemSheet extends CrucibleBackgroundItemSh
   #updateAbilitySum() {
     const abilities = this.element.querySelector(".abilities");
     const inputs = abilities.querySelectorAll("input[type=number]");
-    const total = Array.from(inputs).reduce((t, input) => t + input.valueAsNumber, 0);
+    const total = Array.from(inputs).reduce((t, input) => {
+      const currValue = input.valueAsNumber;
+      const invalid = !!this.document.getFieldForProperty(input.name).validate(currValue);
+      input.parentElement.classList.toggle("invalid", invalid);
+      return t + currValue;
+    }, 0);
     const valid = total === 12;
     const icon = valid ? "fa-solid fa-check" : "fa-solid fa-times";
     const span = abilities.querySelector(".sum");

--- a/module/applications/sheets/item-taxonomy-sheet.mjs
+++ b/module/applications/sheets/item-taxonomy-sheet.mjs
@@ -88,7 +88,12 @@ export default class CrucibleTaxonomyItemSheet extends CrucibleActorDetailsItemS
   #updateAbilitySum() {
     const abilities = this.element.querySelector(".abilities");
     const inputs = abilities.querySelectorAll("input[type=number]");
-    const total = Array.from(inputs).reduce((t, input) => t + input.valueAsNumber, 0);
+    const total = Array.from(inputs).reduce((t, input) => {
+      const currValue = input.valueAsNumber;
+      const invalid = !!this.document.getFieldForProperty(input.name).validate(currValue);
+      input.parentElement.classList.toggle("invalid", invalid);
+      return t + currValue;
+    }, 0);
     const valid = total === 12;
     const icon = valid ? "fa-solid fa-check" : "fa-solid fa-times";
     const span = abilities.querySelector(".sum");
@@ -128,7 +133,12 @@ export default class CrucibleTaxonomyItemSheet extends CrucibleActorDetailsItemS
     const resistances = this.element.querySelector(".resistances");
     const inputs = resistances.querySelectorAll("input[type=number]");
     const immuneTotal = resistances.querySelector("[name='immunities']").value.length * 4;
-    const total = Array.from(inputs).reduce((t, input) => t + input.valueAsNumber, immuneTotal);
+    const total = Array.from(inputs).reduce((t, input) => {
+      const currValue = input.valueAsNumber;
+      const invalid = !!this.document.getFieldForProperty(input.name).validate(currValue);
+      input.parentElement.classList.toggle("invalid", invalid);
+      return t + currValue;
+    }, immuneTotal);
     const valid = total === 0;
     const icon = valid ? "fa-solid fa-check" : "fa-solid fa-times";
     const span = resistances.querySelector(".sum");

--- a/styles/item.less
+++ b/styles/item.less
@@ -180,6 +180,9 @@
         border: 1px solid var(--color-frame);
         border-radius: 6px;
         text-align: center;
+        &.invalid {
+          border-color: red;
+        }
       }
       input {
         --input-height: 24px;


### PR DESCRIPTION
Closes #986 
<img width="1102" height="517" alt="image" src="https://github.com/user-attachments/assets/ba2b9263-4f2d-44d2-86e7-d834d65de5ef" />
Wasn't sure whether to mark the "sum" area as invalid in the case of bad individual inputs. Settled on no.