### PR TITLE
[#999] Display physical item properties as tags in inventory, render tooltips

### DIFF
--- a/_source/rules/Equipment_e33DSvx0cfa7fey6.yml
+++ b/_source/rules/Equipment_e33DSvx0cfa7fey6.yml
@@ -100,21 +100,23 @@ pages:
         weapons.</p><h4>Engaging</h4><p>This weapon is designed to better allow
         you to combat multiple foes, increasing your Engagement by +1. The
         weapon's defensive design reduces its base damage by 1 for one-handed
-        weapons or 2 for two-handed weapons.</p><h4>Oversized</h4><p>This weapon
-        is large for its category and is unwieldy in combat without special
-        training. The weapon gains +1 base damage for one-handed weapons or +2
-        for two-handed weapons, but is slow and provides +2 Banes to Initiative
-        rolls.</p><h4>Parrying</h4><p>This weapon provides +1 to Parry defense
-        while equipped and not Broken. The weapon's defensive balance increases
-        the critical hit threshold for Strikes made with this weapon by +1,
-        making critical hits harder to achieve.</p><h4>Versatile</h4><p>This
-        normally one-handed weapon can be used effectively with two hands. While
-        equipped without any item in the off-hand its base damage is increased
-        by +2 and Action cost is increased by +1.</p><h4>Thrown</h4><p>This
-        weapon can be used to Strike at range up to a distance of 20 feet. When
-        used to Strike a target that is not within melee range, the Weapon
-        becomes unequipped and must be retrieved before it can be used
-        again.</p>
+        weapons or 2 for two-handed weapons.</p><h4>Intuitive</h4><p>This weapon
+        is intuitive enough to be used untrained. The Skill penalty when using
+        this weapon untrained is only -1 instead of
+        -4.</p><h4>Oversized</h4><p>This weapon is large for its category and is
+        unwieldy in combat without special training. The weapon gains +1 base
+        damage for one-handed weapons or +2 for two-handed weapons, but is slow
+        and provides +2 Banes to Initiative rolls.</p><h4>Parrying</h4><p>This
+        weapon provides +1 to Parry defense while equipped and not Broken. The
+        weapon's defensive balance increases the critical hit threshold for
+        Strikes made with this weapon by +1, making critical hits harder to
+        achieve.</p><h4>Versatile</h4><p>This normally one-handed weapon can be
+        used effectively with two hands. While equipped without any item in the
+        off-hand its base damage is increased by +2 and Action cost is increased
+        by +1.</p><h4>Thrown</h4><p>This weapon can be used to Strike at range
+        up to a distance of 20 feet. When used to Strike a target that is not
+        within melee range, the Weapon becomes unequipped and must be retrieved
+        before it can be used again.</p>
       markdown: ''
     video:
       controls: true
@@ -127,10 +129,10 @@ pages:
     _stats:
       systemId: crucible
       systemVersion: 0.9.0
-      coreVersion: '14.359'
+      coreVersion: '14.361'
       createdTime: 1775568473272
-      modifiedTime: 1775572791370
-      lastModifiedBy: WRGzDgYAt3ZuX6TU
+      modifiedTime: 1778521450514
+      lastModifiedBy: ZXJsFnFZuf21WDAk
       compendiumSource: null
       duplicateSource: null
       exportSource: null

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -525,11 +525,11 @@ function preLocalizeConfig() {
 
   // Armor
   localizeConfigObject(SYSTEM.ARMOR.CATEGORIES);
-  localizeConfigObject(SYSTEM.ARMOR.PROPERTIES);
+  localizeConfigObject(SYSTEM.ARMOR.PROPERTIES, ["label", "tooltip"]);
 
   // Consumable
   localizeConfigObject(SYSTEM.CONSUMABLE.CATEGORIES);
-  localizeConfigObject(SYSTEM.CONSUMABLE.PROPERTIES);
+  localizeConfigObject(SYSTEM.CONSUMABLE.PROPERTIES, ["label", "tooltip"]);
 
   // Crafting
   localizeConfigObject(SYSTEM.CRAFTING.TRAINING);
@@ -558,7 +558,7 @@ function preLocalizeConfig() {
 
   // Weapon
   localizeConfigObject(SYSTEM.WEAPON.CATEGORIES);
-  localizeConfigObject(SYSTEM.WEAPON.PROPERTIES);
+  localizeConfigObject(SYSTEM.WEAPON.PROPERTIES, ["label", "tooltip"]);
   localizeConfigObject(SYSTEM.WEAPON.SLOTS);
   localizeConfigObject(SYSTEM.WEAPON.TRAINING);
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1063,8 +1063,11 @@
     },
     "PROPERTIES": {
       "Bulky": "Bulky",
+      "BulkyTooltip": "Armor that is <strong>Bulky</strong> is cumbersome to wield and conveys a penalty of +2 Banes to all Initiative rolls.",
       "Natural": "Natural",
-      "Noisy": "Noisy"
+      "NaturalTooltip": "Natural armor is a feature of the being 'wearing' it. It cannot typically be unequipped.",
+      "Noisy": "Noisy",
+      "NoisyTooltip": "Armor that is <strong>Noisy</strong> makes it difficult to move quietly."
     },
     "SHEET": {
       "ArmorBonus": "Armor Bonus",
@@ -1279,6 +1282,10 @@
         "max.label": "Maximum",
         "value.label": "Value"
       }
+    },
+    "PROPERTIES": {
+      "Thrown": "Thrown",
+      "ThrownTooltip":"This consumable is designed to be thrown."
     },
     "SCROLL": {
       "ComponentBudget": "This scroll may provide up to {budget} spellcraft component(s). Select which components this scroll provides.",

--- a/module/const/armor.mjs
+++ b/module/const/armor.mjs
@@ -52,13 +52,16 @@ export const CATEGORIES = defineEnum({
 export const PROPERTIES = defineEnum({
   ...foundry.utils.deepClone(ITEM_PROPERTIES),
   bulky: {
-    label: "ARMOR.PROPERTIES.Bulky"
+    label: "ARMOR.PROPERTIES.Bulky",
+    tooltip: "ARMOR.PROPERTIES.BulkyTooltip"
   },
   natural: {
-    label: "ARMOR.PROPERTIES.Natural"
+    label: "ARMOR.PROPERTIES.Natural",
+    tooltip: "ARMOR.PROPERTIES.NaturalTooltip"
   },
   noisy: {
-    label: "ARMOR.PROPERTIES.Noisy"
+    label: "ARMOR.PROPERTIES.Noisy",
+    tooltip: "ARMOR.PROPERTIES.NoisyTooltip"
   }
 });
 

--- a/module/const/consumable.mjs
+++ b/module/const/consumable.mjs
@@ -40,8 +40,8 @@ export const CATEGORIES = defineEnum({
 export const PROPERTIES = defineEnum({
   ...COMMON_PROPERTIES,
   thrown: {
-    label: "WEAPON.TAGS.Thrown",
-    tooltip: "WEAPON.TAGS.ThrownTooltip"
+    label: "CONSUMABLE.PROPERTIES.Thrown",
+    tooltip: "CONSUMABLE.PROPERTIES.ThrownTooltip"
   }
 });
 

--- a/module/models/item-armor.mjs
+++ b/module/models/item-armor.mjs
@@ -103,11 +103,7 @@ export default class CrucibleArmorItem extends CruciblePhysicalItem {
     }
 
     // Armor Properties
-    for ( const p of this.properties ) {
-      if ( p === "investment" ) continue;
-      if ( (p === "natural") && (this.config.category.id === "natural") ) continue;
-      tags[p] = ARMOR.PROPERTIES[p].label;
-    }
+    if ( (this.config.category.id === "natural") && tags.natural ) delete tags.natural;
 
     return scope === "short" ? {armor: tags.armor, dodge: tags.dodge} : tags;
   }

--- a/module/models/item-physical.mjs
+++ b/module/models/item-physical.mjs
@@ -353,6 +353,12 @@ export default class CruciblePhysicalItem extends foundry.abstract.TypeDataModel
     if ( this.dropped ) tags.dropped = this.schema.fields.dropped.label;
     if ( this.requiresInvestment ) tags.invested = this.invested ? this.schema.fields.invested.label
       : _loc("ITEM.PROPERTIES.NotInvested");
+
+    // Properties
+    for ( const prop of this.properties ) {
+      if ( ["investment", "stackable"].includes(prop) ) continue;
+      tags[prop] = this.constructor.ITEM_PROPERTIES[prop];
+    }
     return tags;
   }
 

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -122,12 +122,11 @@
       border: 1px solid var(--color-cool-5);
       border-radius: 4px;
       object-fit: contain;
+      align-self: start;
     }
     .name {
-      height: var(--sheet-header-height);
       gap: var(--sheet-header-gap);
       justify-content: center;
-
     }
     .title {
       border: none;

--- a/templates/sheets/actor/inventory.hbs
+++ b/templates/sheets/actor/inventory.hbs
@@ -13,11 +13,7 @@
                             {{#if item.showStack}}<span class="stack">({{item.stackLabel}}) </span>{{/if}}
                             {{~item.name~}}
                         </h4>
-                        <div class="tags">
-                            {{#each item.tags}}
-                            {{#if this}}<span class="tag">{{this}}</span>{{/if}}
-                            {{/each}}
-                        </div>
+                        {{crucibleTags item.tags}}
                     </div>
                     <div class="controls">
                         {{#each item.actions as |button|}}


### PR DESCRIPTION
Closes #999

- All physical items will now render all their properties as tags in inventory/item header. "Investment" and "Stackable" are exceptions.
- Added "Intuitive" to the equipment rules journal, using the existing tooltip text for it.
- Ensured property tooltips were being prelocalized.
- Added property tooltips for Armor: Bulky (using rules text), Natural (made it up), Noisy (made it up). Needed to add Natural, otherwise it'd try to intelligently render a tooltip and end up using the _action_ tooltip. And at that point felt silly not to add Noisy.
- Gave consumables their own Thrown localization, since the weapon version's tooltip made no sense for a consumable.
- Fixed an issue where a second (or worse, third) row of tags on an item could mess up the header. Before & After:

<img width="556" height="398" alt="image" src="https://github.com/user-attachments/assets/330365e9-97e8-4b84-8be2-3907f8db6e39" />
<img width="559" height="398" alt="image" src="https://github.com/user-attachments/assets/046158cc-85cb-4969-8151-614d2124cff6" />
