### PR TITLE
[#1006] Add hazard region behavior

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -173,6 +173,14 @@ Hooks.once("init", async function() {
   };
   CONFIG.Item.compendiumIndexFields = ["system.identifier"];
 
+  // Region Behavior document configuration
+  Object.assign(CONFIG.RegionBehavior.dataModels, {
+    "crucible.hazard": models.CrucibleHazardRegionBehavior
+  });
+  Object.assign(CONFIG.RegionBehavior.typeIcons, {
+    "crucible.hazard": "fa-solid fa-triangle-exclamation"
+  });
+
   // Configure dynamic constants
   for ( const [type, model] of Object.entries(CONFIG.Item.dataModels) ) {
     if ( foundry.utils.isSubclass(model, models.CruciblePhysicalItem) ) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1728,6 +1728,34 @@
       "Treasure": "Treasure"
     }
   },
+  "REGION_BEHAVIORS": {
+    "HAZARD": {
+      "FIELDS": {
+        "danger": {
+          "label": "Danger Level"
+        },
+        "defenseType": {
+          "label": "Defense Type"
+        },
+        "damageType": {
+          "label": "Damage Type"
+        },
+        "resource": {
+          "label": "Targeted Resource"
+        },
+        "tags": {
+          "label": "Hazard Tags"
+        },
+        "name": {
+          "label": "Name"
+        },
+        "promptGM": {
+          "hint": "If true, the GM will receive a roll dialog, otherwise the hazard will automatically roll.",
+          "label": "Prompt GM"
+        }
+      }
+    }
+  },
   "RESOURCES": {
     "TOOLTIPS": {
       "Action": "6 + Action Bonus",
@@ -2434,6 +2462,9 @@
     },
     "JournalEntryPage": {
       "skill": "Crucible Skill"
+    },
+    "RegionBehavior": {
+      "crucible.hazard": "Crucible Hazard"
     }
   },
   "WALKTHROUGH": {

--- a/module/models/_module.mjs
+++ b/module/models/_module.mjs
@@ -38,6 +38,9 @@ export {default as CrucibleToolItem} from "./item-tool.mjs";
 export {default as CrucibleTaxonomyItem} from "./item-taxonomy.mjs";
 export {default as CrucibleWeaponItem} from "./item-weapon.mjs";
 
+// Region Behavior
+export {default as CrucibleHazardRegionBehavior} from "./behavior-hazard.mjs";
+
 // Spellcraft
 export {default as CrucibleSpellcraftRune} from "./spellcraft-rune.mjs";
 export {default as CrucibleSpellcraftGesture} from "./spellcraft-gesture.mjs";

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -2769,9 +2769,10 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
    * @param {string} [options.damageType]     The damage type inflicted by the hazard.
    * @param {string} [options.resource]       The resource the hazard damages (defaults to "health").
    * @param {string} [options.name]           A custom display name for the hazard.
+   * @param {string} [options.description]    A custom enrichable description.
    * @returns {CrucibleAction}              The resulting CrucibleAction that provides the configured hazard
    */
-  static createHazard({actor, danger=0, tags, defenseType, damageType, resource, name, ...actionData}={}) {
+  static createHazard({actor, danger=0, tags, defenseType, damageType, resource, name, description, ...actionData}={}) {
     actor ||= new Actor.implementation({name: "Environment", type: "adversary"});
     tags = Array.isArray(tags) ? tags.filter(t => t !== "hazard") : [];
     tags.unshift("hazard");
@@ -2779,7 +2780,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       id: "environmentAttack",
       name: name || "Environmental Hazard",
       img: "icons/skills/wounds/injury-body-pain-gray.webp",
-      description: "",
+      description: description ?? "",
       target: {type: "single", scope: 4, self: true},
       ...actionData,
       tags

--- a/module/models/behavior-hazard.mjs
+++ b/module/models/behavior-hazard.mjs
@@ -1,0 +1,60 @@
+export default class CrucibleHazardRegionBehavior extends foundry.data.regionBehaviors.RegionBehaviorType {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["REGION_BEHAVIORS.HAZARD"];
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const {TOKEN_ENTER, TOKEN_EXIT, TOKEN_MOVE_IN, TOKEN_MOVE_OUT, TOKEN_MOVE_WITHIN,
+      TOKEN_TURN_START, TOKEN_TURN_END, TOKEN_ROUND_START, TOKEN_ROUND_END} = CONST.REGION_EVENTS;
+    const validEvents = [TOKEN_ENTER, TOKEN_EXIT, TOKEN_MOVE_IN, TOKEN_MOVE_OUT, TOKEN_MOVE_WITHIN,
+      TOKEN_TURN_START, TOKEN_TURN_END, TOKEN_ROUND_START, TOKEN_ROUND_END];
+    const {armor, block, dodge, parry, ...defenseTypes} = foundry.utils.deepClone(SYSTEM.DEFENSES);
+    const {action, focus, heroism, ...resources} = foundry.utils.deepClone(SYSTEM.RESOURCES);
+    const tags = Object.values(SYSTEM.ACTION.TAGS).reduce((acc, t) => {
+      if ( t.internal || (t.category !== "modifiers") ) return acc;
+      const cat = SYSTEM.ACTION.TAG_CATEGORIES[t.category];
+      const group = cat?.label;
+      return {...acc, [t.tag]: {label: t.label, group}};
+    }, {});
+    return {
+      name: new fields.StringField(),
+      danger: new fields.NumberField({initial: 0, required: true, nullable: false, integer: true}),
+      defenseType: new fields.StringField({initial: "physical", choices: defenseTypes, required: true}),
+      damageType: new fields.StringField({initial: "void", required: true, choices: {
+        healing: {label: _loc("ACTION.TAG.Healing")},
+        rallying: {label: _loc("ACTION.TAG.Rallying")},
+        ...SYSTEM.DAMAGE_TYPES
+      }}),
+      resource: new fields.StringField({initial: "health", choices: resources, required: true}),
+      tags: new fields.SetField(new fields.StringField({required: true, choices: tags})),
+      promptGM: new fields.BooleanField({initial: false}),
+      events: this._createEventsField({events: validEvents, initial: ["tokenEnter"]})
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _handleRegionEvent(event) {
+    if ( this.promptGM && !game.user.isActiveGM ) return;
+    if ( !this.promptGM && !event.user.isSelf ) return;
+    const {token} = event.data;
+    const actor = token.actor;
+    if ( !actor ) return;
+    const tags = [...this.tags, this.damageType];
+    const hazardData = {
+      actor,
+      danger: this.danger,
+      tags,
+      defenseType: this.defenseType,
+      resource: this.resource,
+      name: this.name
+    };
+    const action = crucible.api.models.CrucibleAction.createHazard(hazardData);
+    await action.use({dialog: this.promptGM});
+  }
+}

--- a/module/models/behavior-hazard.mjs
+++ b/module/models/behavior-hazard.mjs
@@ -22,6 +22,7 @@ export default class CrucibleHazardRegionBehavior extends foundry.data.regionBeh
     }, {});
     return {
       name: new fields.StringField(),
+      description: new fields.HTMLField(),
       danger: new fields.NumberField({initial: 0, required: true, nullable: false, integer: true}),
       defenseType: new fields.StringField({initial: "physical", choices: defenseTypes, required: true}),
       damageType: new fields.StringField({initial: "void", required: true, choices: {
@@ -52,7 +53,8 @@ export default class CrucibleHazardRegionBehavior extends foundry.data.regionBeh
       tags,
       defenseType: this.defenseType,
       resource: this.resource,
-      name: this.name
+      name: this.name,
+      description: this.description
     };
     const action = crucible.api.models.CrucibleAction.createHazard(hazardData);
     await action.use({dialog: this.promptGM});

--- a/system.json
+++ b/system.json
@@ -251,7 +251,9 @@
       "skill": {}
     },
     "RegionBehavior": {
-      "crucible.hazard": {}
+      "crucible.hazard": {
+        "htmlFields": ["description"]
+      }
     }
   },
   "grid": {

--- a/system.json
+++ b/system.json
@@ -249,6 +249,9 @@
     },
     "JournalEntryPage": {
       "skill": {}
+    },
+    "RegionBehavior": {
+      "crucible.hazard": {}
     }
   },
   "grid": {


### PR DESCRIPTION
Closes #1006 

<img width="633" height="810" alt="image" src="https://github.com/user-attachments/assets/53ac759d-a643-458b-9e26-b7c562ed9a40" />

I limited selectable tags to only the modifier tags, since everything else doesn't really make sense when we've got dropdowns for defense type, damage type, and resource. Wasn't sure whether we'd want to show the GM a roll dialog to let them do ad-hoc boons/banes, so decided an option for that would be best.