### PR TITLE
[#1019, #1020] Re-render favorites on action CRUD, fix various counterspell bugs, add automation for Horrific Critical

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -439,7 +439,7 @@
       "InvalidTarget": "You must designate at least one {type} target for {action}!",
       "InvalidTargetsGeneric": "Invalid targets for this action!",
       "LastCriticallyMissed": "You may only perform {action} after a basic Strike which did not critically miss.",
-      "LastNotMeleeCrit": "You may only perform {action} immediately after a Strike which critically succeeded.",
+      "LastNotMeleeCrit": "You may only perform {action} immediately after a melee Strike which critically succeeded.",
       "MaximumRange": "A selected target is further than the maximum range of {max} feet.",
       "MinimumRange": "A selected target is closer than the minimum range of {min} feet.",
       "MinimumSize": "You must be at least size {size} to use {action}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -439,6 +439,7 @@
       "InvalidTarget": "You must designate at least one {type} target for {action}!",
       "InvalidTargetsGeneric": "Invalid targets for this action!",
       "LastCriticallyMissed": "You may only perform {action} after a basic Strike which did not critically miss.",
+      "LastNotMeleeCrit": "You may only perform {action} immediately after a Strike which critically succeeded.",
       "MaximumRange": "A selected target is further than the maximum range of {max} feet.",
       "MinimumRange": "A selected target is closer than the minimum range of {min} feet.",
       "MinimumSize": "You must be at least size {size} to use {action}",

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -14,6 +14,7 @@ export default class CrucibleChatMessage extends ChatMessage {
   /** @inheritDoc */
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
+    if ( foundry.utils.hasProperty(data, "flags.crucible.action") ) CrucibleChatMessage.#renderAllSheetSidebars();
     this.#autoConfirmMessage();
   }
 
@@ -23,7 +24,32 @@ export default class CrucibleChatMessage extends ChatMessage {
   _onUpdate(data, options, userId) {
     super._onUpdate(data, options, userId);
     const flags = this.flags.crucible || {};
+    if ( foundry.utils.hasProperty(data, "flags.crucible.confirmed") ) CrucibleChatMessage.#renderAllSheetSidebars();
     if ( flags.action && flags.vfxConfig && (data.flags.crucible.confirmed === true) ) this.#playVFXEffect();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if ( foundry.utils.hasProperty(this, "flags.crucible.action") ) CrucibleChatMessage.#renderAllSheetSidebars();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Re-render all currently-rendered actor sheet sidebars
+   * @returns {Promise<void>}
+   */
+  // TODO: Find a better place for this to live
+  static #renderAllSheetSidebars() {
+    const promises = [];
+    for ( const app of foundry.applications.instances.values() ) {
+      if ( !(app instanceof crucible.api.applications.CrucibleBaseActorSheet) ) continue;
+      promises.push(app.render({parts: ["sidebar"]}));
+    }
+    return Promise.allSettled(promises);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -42,11 +42,9 @@ export default class CrucibleChatMessage extends ChatMessage {
    * Re-render all currently-rendered actor sheet sidebars
    * @returns {Promise<void>}
    */
-  // TODO: Find a better place for this to live
   static #renderAllSheetSidebars() {
     const promises = [];
-    for ( const app of foundry.applications.instances.values() ) {
-      if ( !(app instanceof crucible.api.applications.CrucibleBaseActorSheet) ) continue;
+    for ( const app of crucible.api.applications.CrucibleBaseActorSheet.instances() ) {
       promises.push(app.render({parts: ["sidebar"]}));
     }
     return Promise.allSettled(promises);

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -247,8 +247,15 @@ HOOKS.counterspell = {
     this.usage.context.tags.rune = _loc("SPELL.COMPONENTS.RuneSpecific", {rune: this.rune?.name ?? none});
     this.usage.context.tags.gesture = _loc("SPELL.COMPONENTS.GestureSpecific", {gesture: this.gesture?.name ?? none});
   },
+  canUse() {
+    if ( this.tags.has("noncombat") ) return;
+    const lastAction = ChatMessage.implementation.getLastAction();
+    const wasSpell = lastAction && (lastAction.tags.has("composed") || lastAction.tags.has("iconicSpell"));
+    if ( !wasSpell ) return false;
+  },
   async roll(target) {
     if ( this.usage.targetAction.message ) return;
+    this.events.findSplice(e => e.type === "spell");
     const dc = this.usage.dc;
     const rollData = {
       actorId: this.actor.id,
@@ -397,6 +404,20 @@ HOOKS.frostFlask = {
 
 /* -------------------------------------------- */
 
+HOOKS.fontOfLife = {
+  postActivate() {
+    const amount = this.actor.abilities.wisdom.value;
+    for ( const [target, events] of this.eventsByTarget ) {
+      const effectEvent = events.all.find(e => e.effects.length);
+      if ( !effectEvent ) continue;
+      effectEvent.effects[0].system.dot = [{amount, resource: "health", restoration: true}];
+      effectEvent.resources.push({resource: "health", delta: amount});
+    }
+  }
+};
+
+/* -------------------------------------------- */
+
 // TODO: Mote and Wanderer flame elemental tiers do not yet exist; remap Standard quality to Sprite and Masterwork
 //  quality to Visitor until those creatures are authored.
 HOOKS.gemOfConjuredFlame = {
@@ -432,20 +453,6 @@ HOOKS.gemOfConjuredFlame = {
 
 /* -------------------------------------------- */
 
-HOOKS.fontOfLife = {
-  postActivate() {
-    const amount = this.actor.abilities.wisdom.value;
-    for ( const [target, events] of this.eventsByTarget ) {
-      const effectEvent = events.all.find(e => e.effects.length);
-      if ( !effectEvent ) continue;
-      effectEvent.effects[0].system.dot = [{amount, resource: "health", restoration: true}];
-      effectEvent.resources.push({resource: "health", delta: amount});
-    }
-  }
-};
-
-/* -------------------------------------------- */
-
 HOOKS.healingElixir = {
   postActivate() {
     const quality = this.usage.consumable.config.quality;
@@ -470,6 +477,17 @@ HOOKS.healingTonic = {
       effectEvent.effects[0]._id = SYSTEM.EFFECTS.getEffectId(this.id);
       effectEvent.effects[0].system.dot = [{amount, resource: "health", restoration: true}];
       effectEvent.resources.push({resource: "health", delta: amount});
+    }
+  }
+};
+
+/* -------------------------------------------- */
+
+HOOKS.horrificCritical = {
+  canUse() {
+    const lastAction = this.actor.lastConfirmedAction;
+    if ( !lastAction?.tags.has("melee") || !lastAction?.events.some(e => (e.type === "strike") && e.isCriticalSuccess) ) {
+      throw new Error(_loc("ACTION.WARNINGS.LastNotMeleeCrit", {action: this.name}));
     }
   }
 };

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -251,10 +251,12 @@ HOOKS.counterspell = {
     if ( this.tags.has("noncombat") ) return;
     const lastAction = ChatMessage.implementation.getLastAction();
     const wasSpell = lastAction && (lastAction.tags.has("composed") || lastAction.tags.has("iconicSpell"));
-    if ( !wasSpell ) return false;
+    if ( !wasSpell ) throw new Error(_loc("SPELL.COUNTERSPELL.WARNINGS.BadTarget"));
   },
   async roll(target) {
     if ( this.usage.targetAction.message ) return;
+
+    // Must remove the spell attack added by the `spell` tag's _roll hook in the case of a non-combat counterspell
     this.events.findSplice(e => e.type === "spell");
     const dc = this.usage.dc;
     const rollData = {

--- a/module/models/counterspell-action.mjs
+++ b/module/models/counterspell-action.mjs
@@ -37,10 +37,15 @@ export default class CrucibleCounterspellAction extends CrucibleSpellAction {
   /** @inheritDoc */
   acquireTargets(options={}) {
     if ( this.usage.targetAction?.message === null ) {
-      return [{token: null, actor: this.actor, name: this.actor.name, uuid: this.actor.uuid}];
+      return this.targets = new Map([[this.actor, {
+        token: null,
+        actor: this.actor,
+        name: this.actor.name,
+        uuid: this.actor.uuid
+      }]]);
     }
     const targets = super.acquireTargets(options);
-    const target = targets[0];
+    const target = Array.from(targets.values())[0];
     const lastAction = ChatMessage.implementation.getLastAction({actor: target?.actor});
     const wasSpell = lastAction && (lastAction.tags.has("composed") || lastAction.tags.has("iconicSpell"));
     if ( !wasSpell ) {
@@ -113,7 +118,8 @@ export default class CrucibleCounterspellAction extends CrucibleSpellAction {
     if ( !(actor instanceof Actor) ) throw new Error("CounterspellAction.prompt requires an Actor instance");
     const counterspellAction = actor?.actions.counterspell;
     if ( !counterspellAction ) return;
-    const tags = actor.inCombat ? counterspellAction.tags : Array.from(counterspellAction.tags).findSplice(t => t === "reaction", "noncombat");
+    const tags = Array.from(counterspellAction.tags);
+    if ( !actor.inCombat ) tags.findSplice(t => t === "reaction", "noncombat");
     const action = counterspellAction.clone({tags});
     action.usage.dc = dc;
     action.usage.targetAction = new crucible.api.models.CrucibleSpellAction({rune, gesture, inflection, tags: ["composed"]});


### PR DESCRIPTION
Closes #1019 
Closes #1020 
New stuff:
- On message create & delete if `flags.crucible.action` exists, and on update if `flags.crucible.confirmed` is being changed, re-render all actor sheet sidebars, ensuring accurate favorites
- Horrific Critical usage is blocked if your previous action was not a critically successful melee strike
- Combat-based counterspell is now blocked not only if it's your turn or you're out of combat, but also if there is no possible valid target. (In the future, we could make it even stricter; right now it'll let you use it on someone who's confirmed the action, though it'll yell at you if you try to confirm the counterspell afterwards)

Fixed stuff:
- Counterspell never got updated to use the new `targets` Map instead of array. Now it has. It also wasn't setting `this.targets` previously, now it is.
- `fontOfLife` hook moved before `gemOfConjuredFlame` because alphabets are cool.