### PR TITLE
[#1002] Add sense creature detection mode

### DIFF
--- a/_source/talent/Gesture__Sense_gestureSense0000.yml
+++ b/_source/talent/Gesture__Sense_gestureSense0000.yml
@@ -27,12 +27,7 @@ system:
     Monstrosities</p></li><li><p><strong>Life</strong>: Plants and
     Beasts</p></li><li><p><strong>Lightning</strong>: Constructs and Storm
     Elementals</p></li><li><p><strong>Oblivion</strong>:
-    Outsiders</p></li><li><p><strong>Soul</strong>: Humanoids</p></li></ul><h3
-    class="divider">Playtest Notes</h3><p>There is no automation for the sense
-    that is temporarily granted by this spell, but such automation can be
-    provided in the future via a Detection Mode which temporarily reveals
-    creatures of the appropriate type to the spellcaster while the spell is
-    maintained.</p>
+    Outsiders</p></li><li><p><strong>Soul</strong>: Humanoids</p></li></ul>
   actions: []
   rune: ''
   gesture: sense
@@ -51,12 +46,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.361'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.9.2
   createdTime: 1762828633395
-  modifiedTime: 1773514792579
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1778618197823
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: gestureSense0000
 sort: 0
 _key: '!items!gestureSense0000'

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -442,6 +442,14 @@ Hooks.once("init", async function() {
     label: "DETECTION_MODES.ThermalVision",
     type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.SIGHT
   });
+  CONFIG.Canvas.detectionModes.senseCreature = new canvas.detectionModes.DetectionModeSenseCreature({
+    id: "senseCreature",
+    label: "DETECTION_MODES.SenseCreature",
+    tokenConfig: false,
+    type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.OTHER,
+    walls: false,
+    angle: false
+  })
 });
 
 /* -------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -1396,6 +1396,7 @@
     "Wounds": "Healing Threshold"
   },
   "DETECTION_MODES": {
+    "SenseCreature": "Sense Creature",
     "ThermalVision": "Thermal Vision"
   },
   "DICE": {

--- a/module/canvas/detection-modes/_module.mjs
+++ b/module/canvas/detection-modes/_module.mjs
@@ -1,1 +1,2 @@
+export {default as DetectionModeSenseCreature} from "./sense-creature.mjs";
 export {default as DetectionModeThermalVision} from "./thermal-vision.mjs";

--- a/module/canvas/detection-modes/sense-creature.mjs
+++ b/module/canvas/detection-modes/sense-creature.mjs
@@ -1,0 +1,90 @@
+export default class DetectionModeSenseCreature extends foundry.canvas.perception.DetectionMode {
+
+  /**
+   * Glow colors for each rune.
+   * @type {Readonly<Record<string, [number, number, number, number]>>}
+   */
+  static #GLOW_COLORS = Object.freeze({
+    control: [0.588, 0.278, 1.0, 1],
+    death: [0.663, 1.0, 0.506, 1],
+    earth: [0.431, 0.796, 0.0, 1],
+    flame: [1.0, 0.424, 0.0, 1],
+    frost: [0.0, 0.98, 1.0, 1],
+    illumination: [1.0, 0.976, 0.749, 1],
+    illusion: [0.886, 0.063, 0.212, 1],
+    kinesis: [0.843, 0.843, 0.843, 1],
+    life: [1.0, 0.443, 0.565, 1],
+    lightning: [1.0, 0.725, 0.424, 1],
+    oblivion: [0.478, 0.043, 0.086, 1],
+    soul: [0.008, 0.608, 1.0, 1]
+  });
+
+  /**
+   * Cached glow filters keyed by rune id.
+   * @type {Map<string, foundry.canvas.rendering.filters.GlowOverlayFilter>}
+   */
+  static #filtersByRune = new Map();
+
+  /**
+   * The rune id of the most recently detected target. Set by `_canDetect` and consumed by `getDetectionFilter`,
+   * which the visibility loop calls immediately after a successful `testVisibility`.
+   * @type {string|null}
+   */
+  static #pendingRune = null;
+
+  /**
+   * Which creature categories can be seen by which rune id.
+   * TODO: Determine whether this should live elsewhere. Maybe a reverse association from creature category to rune
+   * @type {Record<string, string[]>}
+   */
+  static #creaturesByRune = {
+    control: ["fiend"],
+    death: ["undead"],
+    earth: ["ooze", "elementalEarth"],
+    flame: ["dragon", "elementalFire"],
+    frost: ["giant", "elementalFrost"],
+    illumination: ["celestial"],
+    illusion: ["fey"],
+    kinesis: ["monstrosity"],
+    life: ["plant", "beast"],
+    lightning: ["construct", "elementalStorm"],
+    oblivion: ["outsider"],
+    soul: ["humanoid"]
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static getDetectionFilter() {
+    const runeId = this.#pendingRune;
+    this.#pendingRune = null;
+    if ( !runeId ) return undefined;
+    let filter = this.#filtersByRune.get(runeId);
+    if ( !filter ) {
+      filter = foundry.canvas.rendering.filters.GlowOverlayFilter.create({glowColor: this.#GLOW_COLORS[runeId]});
+      this.#filtersByRune.set(runeId, filter);
+    }
+    return filter;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canDetect(visionSource, target) {
+
+    // Sense only works on creatures (for our purposes)
+    if ( !(target instanceof foundry.canvas.placeables.Token) ) return false;
+
+    // Check which rune is in use
+    // TODO: Determine the ideal way of storing this info
+    const source = visionSource.object.document;
+    const senseEffectId = SYSTEM.EFFECTS.getEffectId("sense");
+    const senseEffect = source.actor?.effects.get(senseEffectId);
+    const runeId = senseEffect?.flags.crucible?.senseRune ?? source.actor?.flags.crucible?.senseRune;
+    if ( !runeId ) return false;
+    const targetCategory = target.actor?.system.details?.taxonomy?.category ?? "humanoid";
+    if ( !DetectionModeSenseCreature.#creaturesByRune[runeId].includes(targetCategory) ) return false;
+    DetectionModeSenseCreature.#pendingRune = runeId;
+    return true;
+  }
+}

--- a/module/canvas/detection-modes/sense-creature.mjs
+++ b/module/canvas/detection-modes/sense-creature.mjs
@@ -2,21 +2,21 @@ export default class DetectionModeSenseCreature extends foundry.canvas.perceptio
 
   /**
    * Glow colors for each rune.
-   * @type {Readonly<Record<string, [number, number, number, number]>>}
+   * @type {Readonly<Record<string, string>>}
    */
   static #GLOW_COLORS = Object.freeze({
-    control: [0.588, 0.278, 1.0, 1],
-    death: [0.663, 1.0, 0.506, 1],
-    earth: [0.431, 0.796, 0.0, 1],
-    flame: [1.0, 0.424, 0.0, 1],
-    frost: [0.0, 0.98, 1.0, 1],
-    illumination: [1.0, 0.976, 0.749, 1],
-    illusion: [0.886, 0.063, 0.212, 1],
-    kinesis: [0.843, 0.843, 0.843, 1],
-    life: [1.0, 0.443, 0.565, 1],
-    lightning: [1.0, 0.725, 0.424, 1],
-    oblivion: [0.478, 0.043, 0.086, 1],
-    soul: [0.008, 0.608, 1.0, 1]
+    control: "#9647ff",
+    death: "#a9ff81",
+    earth: "#6ecb00",
+    flame: "#ff6c00",
+    frost: "#00faff",
+    illumination: "#fff9bf",
+    illusion: "#e21036",
+    kinesis: "#d7d7d7",
+    life: "#ff7190",
+    lightning: "#ffb96c",
+    oblivion: "#7a0b16",
+    soul: "#029bff"
   });
 
   /**
@@ -32,26 +32,6 @@ export default class DetectionModeSenseCreature extends foundry.canvas.perceptio
    */
   static #pendingRune = null;
 
-  /**
-   * Which creature categories can be seen by which rune id.
-   * TODO: Determine whether this should live elsewhere. Maybe a reverse association from creature category to rune
-   * @type {Record<string, string[]>}
-   */
-  static #creaturesByRune = {
-    control: ["fiend"],
-    death: ["undead"],
-    earth: ["ooze", "elementalEarth"],
-    flame: ["dragon", "elementalFire"],
-    frost: ["giant", "elementalFrost"],
-    illumination: ["celestial"],
-    illusion: ["fey"],
-    kinesis: ["monstrosity"],
-    life: ["plant", "beast"],
-    lightning: ["construct", "elementalStorm"],
-    oblivion: ["outsider"],
-    soul: ["humanoid"]
-  };
-
   /* -------------------------------------------- */
 
   /** @override */
@@ -61,7 +41,8 @@ export default class DetectionModeSenseCreature extends foundry.canvas.perceptio
     if ( !runeId ) return undefined;
     let filter = this.#filtersByRune.get(runeId);
     if ( !filter ) {
-      filter = foundry.canvas.rendering.filters.GlowOverlayFilter.create({glowColor: this.#GLOW_COLORS[runeId]});
+      const glowColor = [...Color.from(this.#GLOW_COLORS[runeId]).rgb, 1];
+      filter = foundry.canvas.rendering.filters.GlowOverlayFilter.create({glowColor});
       this.#filtersByRune.set(runeId, filter);
     }
     return filter;
@@ -76,15 +57,29 @@ export default class DetectionModeSenseCreature extends foundry.canvas.perceptio
     if ( !(target instanceof foundry.canvas.placeables.Token) ) return false;
 
     // Check which rune is in use
-    // TODO: Determine the ideal way of storing this info
     const source = visionSource.object.document;
-    const senseEffectId = SYSTEM.EFFECTS.getEffectId("sense");
-    const senseEffect = source.actor?.effects.get(senseEffectId);
-    const runeId = senseEffect?.flags.crucible?.senseRune ?? source.actor?.flags.crucible?.senseRune;
-    if ( !runeId ) return false;
-    const targetCategory = target.actor?.system.details?.taxonomy?.category ?? "humanoid";
-    if ( !DetectionModeSenseCreature.#creaturesByRune[runeId].includes(targetCategory) ) return false;
+    const senseEffect = source.actor?.effects.get(SYSTEM.EFFECTS.getEffectId("sense"));
+    const runeIds = senseEffect?.flags.crucible?.runes ?? source.actor?.flags.crucible?.senseRunes;
+    if ( !runeIds?.length ) return false;
+    const runeId = DetectionModeSenseCreature.#getTargetRune(target.actor);
+    if ( !runeIds.includes(runeId) ) return false;
     DetectionModeSenseCreature.#pendingRune = runeId;
     return true;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the proper rune required to sense a target actor.
+   * @param {CrucibleActor|null} actor
+   */
+  static #getTargetRune(actor) {
+    if ( !actor ) return null;
+
+    // TODO: Allow for overrides of rune per ancestry & taxonomy
+    if ( actor.type === "hero" ) return SYSTEM.ACTOR.CREATURE_CATEGORIES.humanoid.sense;
+    const taxonomy = actor.system.details?.taxonomy;
+    if ( !taxonomy ) return null;
+    return SYSTEM.ACTOR.CREATURE_CATEGORIES[taxonomy.category]?.sense;
   }
 }

--- a/module/const/actor.mjs
+++ b/module/const/actor.mjs
@@ -2,32 +2,36 @@ import {defineEnum} from "./enum.mjs";
 
 /**
  * Creature types supported by the system.
- * @type {Readonly<Record<string, {id: string, label: string, skill: string, knowledge: string, temperature: string}>>}
+ * @type {Readonly<Record<string, {id: string, label: string, skill: string, knowledge: string, temperature: string, sense?: string}>>}
  */
 export const CREATURE_CATEGORIES = defineEnum({
   beast: {
     label: "TAXONOMY.CATEGORIES.Beast",
     skill: "medicine",
     knowledge: "beasts",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "life"
   },
   celestial: {
     label: "TAXONOMY.CATEGORIES.Celestial",
     skill: "arcana",
     knowledge: "celestials",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "illumination"
   },
   construct: {
     label: "TAXONOMY.CATEGORIES.Construct",
     skill: "science",
     knowledge: "machines",
-    temperature: "neutral"
+    temperature: "neutral",
+    sense: "lightning"
   },
   dragon: {
     label: "TAXONOMY.CATEGORIES.Dragon",
     skill: "arcana",
     knowledge: "dragons",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "flame"
   },
   elemental: {
     label: "TAXONOMY.CATEGORIES.Elemental",
@@ -39,79 +43,92 @@ export const CREATURE_CATEGORIES = defineEnum({
     label: "TAXONOMY.CATEGORIES.ElementalEarth",
     skill: "arcana",
     knowledge: "elementals",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "earth"
   },
   elementalFire: {
     label: "TAXONOMY.CATEGORIES.ElementalFire",
     skill: "arcana",
     knowledge: "elementals",
-    temperature: "boiling"
+    temperature: "boiling",
+    sense: "flame"
   },
   elementalFrost: {
     label: "TAXONOMY.CATEGORIES.ElementalFrost",
     skill: "arcana",
     knowledge: "elementals",
-    temperature: "gelid"
+    temperature: "gelid",
+    sense: "frost"
   },
   elementalStorm: {
     label: "TAXONOMY.CATEGORIES.ElementalStorm",
     skill: "arcana",
     knowledge: "elementals",
-    temperature: "cool"
+    temperature: "cool",
+    sense: "lightning"
   },
   fey: {
     label: "TAXONOMY.CATEGORIES.Fey",
     skill: "arcana",
     knowledge: "fey",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "illusion"
   },
   fiend: {
     label: "TAXONOMY.CATEGORIES.Fiend",
     skill: "arcana",
     knowledge: "fiends",
-    temperature: "cool"
+    temperature: "cool",
+    sense: "control"
   },
   giant: {
     label: "TAXONOMY.CATEGORIES.Giant",
     skill: "society",
     knowledge: "legends",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "frost"
   },
   humanoid: {
     label: "TAXONOMY.CATEGORIES.Humanoid",
     skill: "society",
     knowledge: null,
-    temperature: "warm"
+    temperature: "warm",
+    sense: "soul"
   },
   monstrosity: {
     label: "TAXONOMY.CATEGORIES.Monstrosity",
     skill: "medicine",
     knowledge: "monsters",
-    temperature: "warm"
+    temperature: "warm",
+    sense: "kinesis"
   },
   ooze: {
     label: "TAXONOMY.CATEGORIES.Ooze",
     skill: "science",
     knowledge: null,
-    temperature: "neutral"
+    temperature: "neutral",
+    sense: "earth"
   },
   plant: {
     label: "TAXONOMY.CATEGORIES.Plant",
     skill: "wilderness",
     knowledge: null,
-    temperature: "neutral"
+    temperature: "neutral",
+    sense: "life"
   },
   outsider: {
     label: "TAXONOMY.CATEGORIES.Outsider",
     skill: "arcana",
     knowledge: "outsiders",
-    temperature: "cool"
+    temperature: "cool",
+    sense: "oblivion"
   },
   undead: {
     label: "TAXONOMY.CATEGORIES.Undead",
     skill: "arcana",
     knowledge: "undeath",
-    temperature: "cool"
+    temperature: "cool",
+    sense: "death"
   }
 });
 

--- a/module/const/spellcraft.mjs
+++ b/module/const/spellcraft.mjs
@@ -366,7 +366,7 @@ export const GESTURES = Object.seal({
     nameFormat: NAME_FORMATS.ADJ,
     scaling: "presence",
     target: {
-      type: "pulse", // TODO aura type
+      type: "aura",
       size: 30
     }
   },

--- a/module/hooks/spellcraft.mjs
+++ b/module/hooks/spellcraft.mjs
@@ -159,7 +159,7 @@ HOOKS.sense = {
       _id: SYSTEM.EFFECTS.getEffectId(this.gesture.id),
       img: this.img,
       name: this.name,
-      // TODO: If/when effects get hooks, move this into prepareToken rather than using changes
+      // TODO: Move this logic into token data prep
       system: {
         changes: [{
           key: "token.detectionModes.senseCreature",
@@ -172,7 +172,7 @@ HOOKS.sense = {
       },
       flags: {
         crucible: {
-          senseRune: this.rune.id
+          runes: [this.rune.id]
         }
       }
     }]});

--- a/module/hooks/spellcraft.mjs
+++ b/module/hooks/spellcraft.mjs
@@ -39,7 +39,8 @@ HOOKS.aspect = {
       this.range = {maximum: 1}; // Touch
       this.usage.hasDice = true;
       return;
-    } else this.usage.hasDice = false;
+    }
+    else this.usage.hasDice = false;
 
     // TODO enable aspect healing
     if ( this.damage.healing ) console.warn("Gesture: Aspect is not configured for healing Runes yet");
@@ -149,12 +150,31 @@ HOOKS.sense = {
   initialize() {
     this.tags.add("maintained");
   },
+  prepare() {
+    this.usage.hasDice = false;
+    this.usage.region.wallRestriction = false;
+  },
   postActivate() {
     this.recordEvent({type: "effect", effects: [{
       _id: SYSTEM.EFFECTS.getEffectId(this.gesture.id),
       img: this.img,
       name: this.name,
-      system: {}
+      // TODO: If/when effects get hooks, move this into prepareToken rather than using changes
+      system: {
+        changes: [{
+          key: "token.detectionModes.senseCreature",
+          type: "override",
+          value: {
+            enabled: true,
+            range: this.target.size
+          }
+        }]
+      },
+      flags: {
+        crucible: {
+          senseRune: this.rune.id
+        }
+      }
     }]});
   }
 };


### PR DESCRIPTION
#1002 
Currently, the main intended use is with the Sense gesture. In theory, one could be granted this detection mode _without_ that by using `flags.crucible.senseRune` directly on an actor. No support currently for sensing using multiple runes simultaneously, though that's something we could add.