### PR TITLE
[#1003] Add Echolocation detection mode, clean up construction of others

### DIFF
--- a/_source/adversary-talents/Echolocation_echolocation0000.yml
+++ b/_source/adversary-talents/Echolocation_echolocation0000.yml
@@ -11,10 +11,7 @@ system:
     long as they are not behind total cover. If the creature is
     @Condition[deafened], this sense may not be used.</p><p>A creature detected
     using @ref[name] is treated as visible for the purposes of actions which
-    require you to see your target.</p><h3 class="divider">Under
-    Development</h3><p>This should eventually be handled with a
-    specialized<strong> Detection Mode</strong> added to tokens which have this
-    talent.</p>
+    require you to see your target.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -33,12 +30,12 @@ flags:
   ember:
     crucibleOverride: true
 _stats:
-  coreVersion: '14.360'
+  coreVersion: '14.361'
   systemId: crucible
-  systemVersion: 0.9.1
+  systemVersion: 0.9.3
   createdTime: 1776979376935
-  modifiedTime: 1776979376936
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1778698487262
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null
   duplicateSource: null

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -445,19 +445,11 @@ Hooks.once("init", async function() {
   CONFIG.Canvas.layers.grid.layerClass = canvas.grid.CrucibleGridLayer;
 
   // Crucible-specific detection modes
-  CONFIG.Canvas.detectionModes.thermalVision = new canvas.detectionModes.DetectionModeThermalVision({
-    id: "thermalVision",
-    label: "DETECTION_MODES.ThermalVision",
-    type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.SIGHT
+  Object.assign(CONFIG.Canvas.detectionModes, {
+    echolocation: new canvas.detectionModes.DetectionModeEcholocation(),
+    senseCreature: new canvas.detectionModes.DetectionModeSenseCreature(),
+    thermalVision: new canvas.detectionModes.DetectionModeThermalVision()
   });
-  CONFIG.Canvas.detectionModes.senseCreature = new canvas.detectionModes.DetectionModeSenseCreature({
-    id: "senseCreature",
-    label: "DETECTION_MODES.SenseCreature",
-    tokenConfig: false,
-    type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.OTHER,
-    walls: false,
-    angle: false
-  })
 });
 
 /* -------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -1405,6 +1405,7 @@
     "Wounds": "Healing Threshold"
   },
   "DETECTION_MODES": {
+    "Echolocation": "Echolocation",
     "SenseCreature": "Sense Creature",
     "ThermalVision": "Thermal Vision"
   },

--- a/module/canvas/detection-modes/_module.mjs
+++ b/module/canvas/detection-modes/_module.mjs
@@ -1,2 +1,3 @@
+export {default as DetectionModeEcholocation} from "./echolocation.mjs"
 export {default as DetectionModeSenseCreature} from "./sense-creature.mjs";
 export {default as DetectionModeThermalVision} from "./thermal-vision.mjs";

--- a/module/canvas/detection-modes/echolocation.mjs
+++ b/module/canvas/detection-modes/echolocation.mjs
@@ -1,0 +1,40 @@
+export default class DetectionModeEcholocation extends foundry.canvas.perception.DetectionMode {
+  constructor() {
+    super({
+      id: "echolocation",
+      label: "DETECTION_MODES.Echolocation",
+      type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.SOUND,
+      walls: true,
+      angle: false
+    });
+  }
+
+  /** @override */
+  static getDetectionFilter() {
+    return this._detectionFilter ??= foundry.canvas.rendering.filters.OutlineOverlayFilter.create({
+      outlineColor: [1, 1, 0, 1],
+      knockout: true,
+      wave: true
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canDetect(visionSource, target) {
+
+    // Echolocation only works on creatures
+    if ( !(target instanceof foundry.canvas.placeables.Token) ) return false;
+    const source = visionSource.object.document;
+
+    // Cannot use echolocation if deafened
+    if ( source.hasStatusEffect("deafened") ) return false;
+
+    // If constrained by walls, cannot see if either source or target is burrowing
+    if ( this.walls ) {
+      if ( source.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
+      if ( target.document.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
+    }
+    return true;
+  }
+}

--- a/module/canvas/detection-modes/sense-creature.mjs
+++ b/module/canvas/detection-modes/sense-creature.mjs
@@ -1,4 +1,14 @@
 export default class DetectionModeSenseCreature extends foundry.canvas.perception.DetectionMode {
+  constructor() {
+    super({
+      id: "senseCreature",
+      label: "DETECTION_MODES.SenseCreature",
+      tokenConfig: false,
+      type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.OTHER,
+      walls: false,
+      angle: false
+    });
+  }
 
   /**
    * Glow colors for each rune.

--- a/module/canvas/detection-modes/thermal-vision.mjs
+++ b/module/canvas/detection-modes/thermal-vision.mjs
@@ -2,6 +2,13 @@
  * A custom DetectionMode that is specialized in perceiving temperature changes from ambient equilibrium.
  */
 export default class DetectionModeThermalVision extends foundry.canvas.perception.DetectionMode {
+  constructor() {
+    super({
+      id: "thermalVision",
+      label: "DETECTION_MODES.ThermalVision",
+      type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.SIGHT
+    });
+  }
 
   /**
    * Glow colors for each detectable temperature tier. Hot tiers shade orange/red; cold tiers shade blue/purple.

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -369,6 +369,14 @@ HOOKS.dustbinder000000 = {
 
 /* -------------------------------------------- */
 
+HOOKS.echolocation0000 = {
+  prepareToken(_item, token) {
+    token.detectionModes.echolocation ??= {enabled: true, range: 60};
+  }
+};
+
+/* -------------------------------------------- */
+
 HOOKS.evasiveshot00000 = {
   prepareAttack(item, action, _target, _rollData) {
     if ( !action.tags.has("strike") ) return;


### PR DESCRIPTION
Closes #1003 
I offloaded the passing of detection mode constructor params to the detection modes themselves to make them more self-contained & clean up `crucible.mjs`

Did _not_ make it so that a `silenced` creature cannot use echolocation, as it was not specified that the sonic pulses are emitted via a mouth. Can change that if desired.