### PR TITLE
[#1029] Fix adversary sheet threat icon, i18n, i18n for hazards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1516,6 +1516,8 @@
     }
   },
   "HAZARD": {
+    "DefaultActor": "Environment",
+    "DefaultName": "Environmental Hazard",
     "Hazard": "Hazard",
     "UseHazard": "Use Hazard",
     "WindowTitle": "Hazard: {name}",

--- a/module/applications/sheets/adversary-sheet.mjs
+++ b/module/applications/sheets/adversary-sheet.mjs
@@ -28,7 +28,7 @@ export default class AdversarySheet extends CrucibleBaseActorSheet {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const {actor: a, source: s, incomplete: i} = context;
-    const {threat, level} = a.system.advancement;
+    const {rank, level} = a.system.advancement;
 
     // Expand Context
     Object.assign(context, {
@@ -36,7 +36,7 @@ export default class AdversarySheet extends CrucibleBaseActorSheet {
       taxonomyName: a.system.details.taxonomy?.name || _loc("TAXONOMY.SHEET.Choose"),
       canPurchaseTalents: false,
       threats: SYSTEM.THREAT_RANKS,
-      threat: SYSTEM.THREAT_RANKS[threat],
+      threat: SYSTEM.THREAT_RANKS[rank],
       levelDisplay: this.#getLevelDisplay(level),
       canLevelUp: level < 24,
       canLevelDown: level > -5

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -2687,7 +2687,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     // so fabricate a fresh placeholder when reconstituting one from chat
     let actor = fromUuidSync(actorUuid) || ChatMessage.getSpeakerActor(message.speaker);
     if ( !actor && actionData.tags?.includes("hazard") ) {
-      actor = new Actor.implementation({name: "Environment", type: "adversary"});
+      actor = new Actor.implementation({name: _loc("HAZARD.DefaultActor"), type: "adversary"});
     }
     const item = fromUuidSync(itemUuid);
     const token = fromUuidSync(tokenUuid);
@@ -2785,7 +2785,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     tags.unshift("hazard");
     return new this({
       id: "environmentAttack",
-      name: name || "Environmental Hazard",
+      name: name || _loc("HAZARD.DefaultName"),
       img: "icons/skills/wounds/injury-body-pain-gray.webp",
       description: description ?? "",
       target: {type: "single", scope: 4, self: true},

--- a/templates/sheets/actor/adversary-header.hbs
+++ b/templates/sheets/actor/adversary-header.hbs
@@ -2,7 +2,7 @@
     <header class="title flexrow">
         <input class="charname" name="name" type="text" value="{{source.name}}" placeholder="Actor Name">
         <div class="advancement flexrow">
-            <span><i class="threat-icon {{threat.icon}}"></i> Level</span>
+            <span><i class="threat-icon {{threat.icon}}"></i> {{localize "ADVANCEMENT.Level"}}</span>
             <div class="controls flexcol">
                 <button type="button" class="icon fa-solid fa-caret-up {{#unless canLevelUp}}inactive{{/unless}}"
                         data-tooltip aria-label="{{localize 'ACTOR.ADVERSARY.ACTIONS.IncreaseLevel'}}"


### PR DESCRIPTION
Closes #1029 
`system.advancement.threat` was the numerical value. `rank` is what we want to get the icon etc properly. Also added some missing i18n.