### PR TITLE
[#1031] Represent unknown/unset DCs as `null` instead of `0`, and allow group check DCs to be modified after message post

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1482,6 +1482,7 @@
     "DCAdditionalPassive": "{dcLabel}, Passive",
     "DCAdditionalGroup": "{dcLabel}, Group",
     "DCSpecific": "DC {dc}",
+    "DCTargetSpecific": "{skill} DC Target",
     "DiceTotal": "Dice Total",
     "Enchantment": "Enchantment",
     "EnchantmentBonus": "Enchantment Bonus",

--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -23,30 +23,35 @@ export const TEMPLATES = {
 export function addChatMessageContextOptions(_app, options) {
   if ( !game.user.isGM ) return;
 
-  // Assign difficulty for skill checks
+  // Assign difficulty for skill or group checks
   options.push({
     label: _loc("DICE.SetDifficulty"),
     icon: '<i class="fas fa-bullseye"></i>',
     visible: li => {
       const message = game.messages.get(li.dataset.messageId);
       const flags = message.flags.crucible || {};
-      return message.isRoll && flags.skill;
+      return message.isRoll && (flags.skill || flags.groupCheck);
     },
     onClick: async (_e, li) => {
       const message = game.messages.get(li.dataset.messageId);
-      const roll = message.rolls[0];
+      const flags = message.flags.crucible;
+      const skills = new Set(message.rolls.map(r => r.data.type));
       const formData = await foundry.applications.api.DialogV2.input({
         window: {title: _loc("DICE.SetDifficulty")},
-        content: `\
+        content: Array.from(skills).map(skill => `\
         <div class="form-group slim">
-            <label>DC Target</label>
-            <div class="form-fields">
-                <input type="number" name="dc" value="${roll.data.dc || 15}" autofocus>
-            </div>
-        </div>`
+          <label>${_loc("DICE.DCTargetSpecific", {skill: SYSTEM.SKILLS[skill]?.label ?? skill})}</label>
+          <div class="form-fields">
+            <input type="number" name="${skill}" value="${message.rolls.find(r => r.data.type === skill).data.dc ?? 0}">
+          </div>
+        </div>`).join("")
       });
-      for ( const r of message.rolls ) r.data.dc = formData.dc;
-      await message.update({rolls: message.rolls}, {diff: false});
+      for ( const r of message.rolls ) r.data.dc = formData[r.data.type];
+      const update = {rolls: message.rolls};
+      if ( flags.groupCheck ) {
+        update.content = await crucible.api.dice.GroupCheck.renderGroupCheckCard(flags.groupCheck, message.rolls);
+      }
+      await message.update(update, {diff: false});
     }
   });
 

--- a/module/dice/group-check.mjs
+++ b/module/dice/group-check.mjs
@@ -45,7 +45,7 @@ import StandardCheck from "./standard-check.mjs";
  * @property {string} outcomeKey       Localization key for the aggregate outcome label
  * @property {string} classes          CSS classes describing the outcome (success/failure plus optional critical)
  * @property {string} detail           Pre-localized right-side label that contextualizes the hex score
- * @property {number} score            Weighted total: crit success +2, success +1, failure 0, crit failure -1
+ * @property {number|"???"} score      Weighted total: crit success +2, success +1, failure 0, crit failure -1
  * @property {number} total            Number of participants whose rolls counted toward the aggregate
  * @property {number} required         Score threshold needed to clear an aggregate success
  * @property {number} skippedCount     Number of participants excluded as skipped
@@ -258,7 +258,7 @@ export default class GroupCheck extends StandardCheck {
       actors
     };
 
-    const content = await this.#renderGroupCheckCard(groupCheckFlags);
+    const content = await GroupCheck.renderGroupCheckCard(groupCheckFlags);
     const skillIds = Object.keys(skills);
     const flavor = (skillIds.length === 1)
       ? _loc("ACTION.SkillCheck", {skill: SYSTEM.SKILLS[skillIds[0]].label})
@@ -426,7 +426,7 @@ export default class GroupCheck extends StandardCheck {
    * @param {Roll[]} [rolls=[]]         The message's canonical rolls array
    * @returns {Promise<string>}         The rendered HTML content
    */
-  async #renderGroupCheckCard(flags, rolls=[]) {
+  static async renderGroupCheckCard(flags, rolls=[]) {
     const actors = Object.values(flags.actors).map(entry => GroupCheck.#prepareActorTemplateData(entry, rolls));
     const aggregate = GroupCheck.#computeAggregate(flags, rolls);
     return foundry.applications.handlebars.renderTemplate(GroupCheck.#GROUP_CHECK_TEMPLATE, {actors, aggregate});
@@ -469,7 +469,12 @@ export default class GroupCheck extends StandardCheck {
 
     let outcomeKey = "ACTION.EFFECT_RESULT_TYPES.";
     let classes;
-    if ( score >= total ) {
+    if ( rolls.some(r => !Number.isNumeric(r.data.dc)) ) {
+      score = "???";
+      outcomeKey = "COMMON.Unknown";
+      classes = "unknown";
+    }
+    else if ( score >= total ) {
       outcomeKey += "CriticalSuccess";
       classes = "critical success";
     }
@@ -538,7 +543,7 @@ export default class GroupCheck extends StandardCheck {
       const updateData = foundry.utils.isPlainObject(result) ? result : {};
       const newRolls = updateData.rolls ?? [];
       const allRolls = [...current.rolls, ...newRolls];
-      const content = await this.#fromFlags(flags).#renderGroupCheckCard(flags, allRolls);
+      const content = await this.renderGroupCheckCard(flags, allRolls);
       if ( newRolls.length ) {
         const existingRolls = current.rolls.map(r => JSON.stringify(r.toJSON()));
         updateData.rolls = [...existingRolls, ...newRolls.map(r => JSON.stringify(r.toJSON()))];

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -22,7 +22,7 @@ import StandardCheckDialog from "./standard-check-dialog.mjs";
 /**
  * @typedef {DiceCheckBonuses} StandardCheckData
  * @property {string} actorId                 The ID of the actor rolling the check
- * @property {number} dc                      The target difficulty of the check
+ * @property {number|null} dc                      The target difficulty of the check
  * @property {string} type                    The type of check being performed
  * @property {number} totalBoons              The computed total number of boons applied to the roll
  * @property {number} totalBanes              The computed total number of banes applied to the roll
@@ -37,7 +37,7 @@ import StandardCheckDialog from "./standard-check-dialog.mjs";
  * @property {number} diceTotal                       The sum of the dice before bonuses.
  * @property {object|undefined} damage                The rendered damage breakdown, or undefined if not applicable.
  * @property {string} targetLabel                     Secondary text shown on the primary result line.
- * @property {number} dc                              The difficulty class the roll is checked against.
+ * @property {number|null} dc                              The difficulty class the roll is checked against.
  * @property {string} defenseType                     The defense type label shown alongside the target value.
  * @property {string} formula                         The rendered roll formula.
  * @property {string} cssClass                        CSS classes applied to the rendered dice check wrapper.
@@ -195,7 +195,7 @@ export default class StandardCheck extends Roll {
    * @param {object} data     The initially provided data object
    */
   static #configureData(data) {
-    data.dc = Math.max(data.dc, 0);
+    if ( Number.isNumeric(data.dc) ) data.dc = Math.max(data.dc, 0);
     data.totalBoons = StandardCheck.#prepareBoons(data.boons);
     data.totalBanes = StandardCheck.#prepareBoons(data.banes);
   }
@@ -282,7 +282,7 @@ export default class StandardCheck extends Roll {
    * @returns {{outcome: string, classes: string[]}}
    */
   prepareOutcome() {
-    if ( !this.data.dc ) return {outcome: "COMMON.Unknown", classes: ["unknown"]};
+    if ( !Number.isNumeric(this.data.dc) ) return {outcome: "COMMON.Unknown", classes: ["unknown"]};
     let outcome = "ACTION.EFFECT_RESULT_TYPES.";
     const classes = [];
     if ( this.isCriticalSuccess || this.isCriticalFailure ) {
@@ -315,7 +315,7 @@ export default class StandardCheck extends Roll {
     if ( targetLabel === undefined ) {
       const skill = SYSTEM.SKILLS[this.data.type];
       const label = skill?.label ?? defenseType;
-      const dcLabel = game.user.isGM ? (dc || "??") : "";
+      const dcLabel = game.user.isGM ? (`${dc}` ?? "??") : "";
       targetLabel = dcLabel ? `${label} ${dcLabel}` : label;
     }
     return {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -498,11 +498,11 @@ export default class CrucibleActor extends Actor {
    * @param {object} options
    * @param {number} [options.banes]
    * @param {number} [options.boons]
-   * @param {number} [options.dc]
+   * @param {number|null} [options.dc]
    * @param {boolean} [options.passive]
    * @returns {PassiveCheck|StandardCheck}
    */
-  getSkillCheck(skillId, {banes=0, boons=0, dc=0, passive=false}={}) {
+  getSkillCheck(skillId, {banes=0, boons=0, dc=null, passive=false}={}) {
     const skill = this.system.skills[skillId];
     if ( !skill ) throw new Error(`Invalid skill ID ${skillId}`);
     const {boons: systemBoons={}, banes: systemBanes={}} = this.system.rollBonuses;


### PR DESCRIPTION
Closes #1031 
0DC skill checks mean "show as unknown DC, and allow the GM to set via the chat message's context menu." 0DC attack rolls mean "the poor fella getting smacked somehow actually has 0 defense," and therefore should render as such.