### PR TITLE
[#1025] Un-disable module hook expand buttons, hide "add action" +, when in locked compendium

### DIFF
--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -251,6 +251,16 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
 
   /* -------------------------------------------- */
 
+  /** @inheritDoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    this.element.querySelectorAll(".module-hook, [data-action='hookToggleSource']").forEach(el => {
+      el.disabled = false;
+    });
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Prepare action groups for the actions tab, separating item-level actions from affix-provided actions.
    * @returns {Promise<object[]>}
@@ -269,7 +279,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
     const itemActionIds = new Set(sourceActions.map(a => a.id));
     const groups = [{
       legend: null,
-      canAdd: true,
+      canAdd: this.isEditable,
       isEditable: this.isEditable,
       actions: await Promise.all(
         this.document.system.actions.filter(a => itemActionIds.has(a.id)).map(enrichAction)


### PR DESCRIPTION
Closes #1025 
Fieldsets & their descendants will get disabled by core when `!isEditable` in `_onRender`, so undoing that explicitly for the `.module-hook` fieldsets and their `hookToggleSource` buttons. Also noticed while I was in there that the button _inside_ the Actions fieldset legend doesn't get disabled, so hide it if `!isEditable`.