### PR TITLE
[#1056], [#1068] Don't unset targets on cancel action, ensure `usage.summons` is initialized empty if no set summon

### DIFF
--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -673,7 +673,6 @@ export default class ActionUseDialog extends StandardCheckDialog {
     if ( canvas.tokens._movementPlanningContext?.object?.document === token ) {
       canvas.tokens._cancelMovementPlanning();
     }
-    canvas.tokens.setTargets([]);
   }
 
   /* -------------------------------------------- */

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1028,9 +1028,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     }
 
     // Prepare Summons
-    if ( this.summon.actorUuid ) {
-      this.usage.summons = [{...this.summon}];
-    }
+    this.usage.summons = this.summon.actorUuid ? [{...this.summon}] : [];
 
     // Reset bonuses
     Object.assign(this.usage.bonuses, {


### PR DESCRIPTION
Closes #1056 
Closes #1068 