### PR TITLE
[#771] Add "important" adversaries, which track Wounds & Madness

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -920,6 +920,8 @@
   },
   "ADVANCEMENT": {
     "ExpectedLevel": "Expected Level",
+    "Important": "Important",
+    "ImportantTooltip": "Important Adversaries track Wounds and Madness.",
     "Level": "Level",
     "MilestoneAward": "Award Milestones",
     "MilestoneTooltip": "{progress} of {required} milestones until next level",

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -1063,10 +1063,10 @@ export const TAGS = {
         const targetResources = event.target?.system?.resources;
         if ( !targetResources ) continue;
         const resource = event.roll.data.damage.resource ?? "health";
-        if ( (resource === "health") && ("wounds" in targetResources) ) {
+        if ( (resource === "health") && (event.target.system.usesReserveResources) ) {
           event.roll.data.damage.resource = "wounds";
         }
-        else if ( (resource === "morale") && ("madness" in targetResources) ) {
+        else if ( (resource === "morale") && (event.target.system.usesReserveResources) ) {
           event.roll.data.damage.resource = "madness";
         }
       }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1035,13 +1035,13 @@ export default class CrucibleActor extends Actor {
       const overflow = Math.min(uncapped, 0);
 
       // Health overflows into Wounds
-      if ( (resourceName === "health") && (overflow !== 0) && ("wounds" in r) ) {
+      if ( (resourceName === "health") && (overflow !== 0) && (this.system.usesReserveResources) ) {
         changes.wounds ||= {value: r.wounds.value};
         changes.wounds.value -= overflow;
       }
 
       // Morale overflows into Madness
-      else if ( (resourceName === "morale") && (overflow !== 0) && ("madness" in r) ) {
+      else if ( (resourceName === "morale") && (overflow !== 0) && (this.system.usesReserveResources) ) {
         changes.madness ||= {value: r.madness.value};
         changes.madness.value -= overflow;
       }

--- a/module/models/actor-adversary.mjs
+++ b/module/models/actor-adversary.mjs
@@ -20,7 +20,8 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
     // Advancement
     schema.advancement = new fields.SchemaField({
       level: new fields.NumberField({...requiredInteger, initial: 1, min: -5, max: 24, label: "ADVANCEMENT.Level"}),
-      rank: new fields.StringField({required: true, choices: SYSTEM.THREAT_RANKS, initial: "normal"})
+      rank: new fields.StringField({required: true, choices: SYSTEM.THREAT_RANKS, initial: "normal"}),
+      important: new fields.BooleanField({required: true, initial: false})
     });
 
     // Details
@@ -48,11 +49,6 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
       delete abilityField.fields.base;
       delete abilityField.fields.increases;
     }
-
-    // Adversaries only use active resource pools
-    for ( const resource of Object.values(SYSTEM.RESOURCES) ) {
-      if ( resource.type !== "active" ) delete schema.resources.fields[resource.id];
-    }
     return schema;
   }
 
@@ -66,13 +62,14 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
   /* -------------------------------------------- */
 
   /** @override */
-  get isDead() {
-    return (this.abilities.toughness.value > 0) && (this.resources.health.value === 0);
+  get usesReserveResources() {
+    return this.advancement.important;
   }
 
   /** @override */
-  get isWeakened() {
-    return false;
+  get isDead() {
+    if ( !this.abilities.toughness.value ) return false;
+    return super.isDead;
   }
 
   /** @override */
@@ -82,10 +79,6 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
   }
 
   /** @override */
-  get isInsane() {
-    return false;
-  }
-
   get isIncapacitated() {
     if ( !this.abilities.toughness.value && this.isBroken ) return true;
     return super.isIncapacitated;

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -199,7 +199,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
    * @type {boolean}
    */
   get isWeakened() {
-    return this.resources.health.value === 0;
+    return this.usesReserveResources && (this.resources.health.value === 0);
   }
 
   /**
@@ -215,7 +215,8 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
    * @type {boolean}
    */
   get isDead() {
-    return this.resources.wounds.value === this.resources.wounds.max;
+    if ( this.usesReserveResources ) return this.resources.wounds.value === this.resources.wounds.max;
+    else return this.resources.health.value === 0;
   }
 
   /**
@@ -232,7 +233,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
    * @type {boolean}
    */
   get isInsane() {
-    return this.resources.madness.value === this.resources.madness.max;
+    return this.usesReserveResources && (this.resources.madness.value === this.resources.madness.max);
   }
 
   /**
@@ -241,6 +242,14 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
    */
   get hasFreeMove() {
     return this.equipment.canFreeMove && !this.parent.status.hasMoved;
+  }
+
+  /**
+   * Does this Actor track Wounds & Madness?
+   * @returns {boolean}
+   */
+  get usesReserveResources() {
+    return true;
   }
 
   /* -------------------------------------------- */
@@ -839,12 +848,12 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     // Health and Wounds
     const healthBase = Math.max(level, 1) * p.healthPerLevel;
     rs.health.base = Math.ceil((healthBase + (4 * a.toughness.value) + (2 * a.strength.value)) * p.healthMultiplier);
-    if ( "wounds" in rs ) rs.wounds.base = Math.ceil(p.woundsMultiplier * rs.health.base);
+    rs.wounds.base = Math.ceil(p.woundsMultiplier * rs.health.base);
 
     // Morale and Madness
     const moraleBase = Math.max(level, 1) * p.moralePerLevel;
     rs.morale.base = Math.ceil((moraleBase + (4 * a.presence.value) + (2 * a.wisdom.value)) * p.moraleMultiplier);
-    if ( "madness" in rs ) rs.madness.base = Math.ceil(p.madnessMultiplier * rs.morale.base);
+    rs.madness.base = Math.ceil(p.madnessMultiplier * rs.morale.base);
 
     // Resources
     rs.action.base = p.actionMax;
@@ -961,8 +970,12 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     const {isIncapacitated, statuses} = this.parent;
 
     // Healing thresholds based on wounds and madness
-    const wounds = resources.wounds?.value ?? ((resources.health.max - resources.health.value) * 2);
-    const madness = resources.madness?.value ?? ((resources.morale.max - resources.morale.value) * 2);
+    const wounds = this.usesReserveResources
+      ? resources.wounds.value
+      : ((resources.health.max - resources.health.value) * 2);
+    const madness = this.usesReserveResources
+      ? resources.madness.value
+      : ((resources.morale.max - resources.morale.value) * 2);
     defenses.wounds.base += Math.floor(wounds / 10);
     defenses.madness.base += Math.floor(madness / 10);
 
@@ -1127,7 +1140,21 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
       delta = gain;
     }
     allocation[resource] = (allocation[resource] || 0) + delta;
-    return {[resource]: delta};
+    const deltas = {[resource]: delta};
+    if ( (amount >= 0) || !this.usesReserveResources ) return deltas;
+    const overflowName = {health: "wounds", morale: "madness"}[resource];
+    const overflow = overflowName ? this.resources[overflowName] : null;
+    if ( !overflow ) return deltas;
+    const primaryLoss = -(deltas[resource] || 0);
+    const remaining = -amount - primaryLoss;
+    if ( remaining <= 0 ) return deltas;
+    const overflowValue = Math.max(overflow.value + (allocation[overflowName] || 0), 0);
+    const gain = Math.min(overflow.max - overflowValue, remaining);
+    if ( gain > 0 ) {
+      deltas[overflowName] = gain;
+      allocation[overflowName] = (allocation[overflowName] || 0) + gain;
+    }
+    return deltas;
   }
 
   /* -------------------------------------------- */

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -297,27 +297,6 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
   }
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  allocateResourceChange(amount, resource, allocation) {
-    const deltas = super.allocateResourceChange(amount, resource, allocation);
-    if ( amount >= 0 ) return deltas;
-    const overflowName = {health: "wounds", morale: "madness"}[resource];
-    const overflow = overflowName ? this.resources[overflowName] : null;
-    if ( !overflow ) return deltas;
-    const primaryLoss = -(deltas[resource] || 0);
-    const remaining = -amount - primaryLoss;
-    if ( remaining <= 0 ) return deltas;
-    const overflowValue = Math.max(overflow.value + (allocation[overflowName] || 0), 0);
-    const gain = Math.min(overflow.max - overflowValue, remaining);
-    if ( gain > 0 ) {
-      deltas[overflowName] = gain;
-      allocation[overflowName] = (allocation[overflowName] || 0) + gain;
-    }
-    return deltas;
-  }
-
-  /* -------------------------------------------- */
   /*  Deprecations and Compatibility              */
   /* -------------------------------------------- */
 

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -175,6 +175,11 @@
       select {
         flex: 0 0 120px;
       }
+      div.important {
+        text-wrap: nowrap;
+        flex: 0;
+        flex-wrap: nowrap;
+      }
       div.size {
         flex: none;
         gap: 0.25rem;

--- a/templates/sheets/actor/adversary-attributes.hbs
+++ b/templates/sheets/actor/adversary-attributes.hbs
@@ -10,6 +10,14 @@
                 <span class="sep">/</span>
                 <span class="total value">{{resources.health.max}}</span>
             </div>
+            {{#if actor.system.advancement.important}}
+            <div class="pool long flexrow">
+                {{formInput fields.resources.fields.wounds.fields.value value=resources.wounds.value type="number"}}
+                <span class="sep">/</span>
+                <span class="total value">{{resources.wounds.max}}</span>
+            </div>
+            <h4 class="label below" data-tooltip="{{resources.wounds.tooltip}}">{{resources.wounds.label}}</h4>
+            {{/if}}
             <div class="threshold wounds" data-tooltip="{{defenses.wounds.tooltip}}">
                 <span class="value">{{defenses.wounds.total}}</span>
             </div>
@@ -65,6 +73,14 @@
                 <span class="sep">/</span>
                 <span class="total value">{{resources.morale.max}}</span>
             </div>
+            {{#if actor.system.advancement.important}}
+            <div class="pool long flexrow">
+                {{formInput fields.resources.fields.madness.fields.value value=resources.madness.value type="number"}}
+                <span class="sep">/</span>
+                <span class="total value">{{resources.madness.max}}</span>
+            </div>
+            <h4 class="label below" data-tooltip="{{resources.madness.tooltip}}">{{resources.madness.label}}</h4>
+            {{/if}}
             <div class="threshold madness" data-tooltip="{{defenses.madness.tooltip}}">
                 <span class="value">{{defenses.madness.total}}</span>
             </div>

--- a/templates/sheets/actor/adversary-header.hbs
+++ b/templates/sheets/actor/adversary-header.hbs
@@ -25,6 +25,10 @@
             <a>{{#if incomplete.archetype}}<i class="fa-solid fa-circle-plus"></i> {{/if}}{{archetypeName}}</a>
         </h2>
         <div class="metadata flexrow">
+            <div class="important flexrow" data-tooltip="ADVANCEMENT.ImportantTooltip">
+                <span class="label">{{localize "ADVANCEMENT.Important"}}</span>
+                {{formInput fields.advancement.fields.important value=source.system.advancement.important}}
+            </div>
             {{formInput fields.advancement.fields.rank value=source.system.advancement.rank labelAttr="label"}}
             <div class="size flexrow">
                 <span class="label" data-tooltip="TAXONOMY.FIELDS.movement.size.hint">{{localize "TAXONOMY.FIELDS.movement.size.label"}}</span>


### PR DESCRIPTION
Closes #771 
- Adds a checkbox to the header of adversary sheets for Important
- Adversaries no longer delete reserve resources from their schema
- Added a new `usesReserveResources` getter to `CrucibleBaseActor` (defaults to `true`, overridden in `CrucibleAdversaryActor`). This should be used everywhere we previously checked whether wounds/madness _existed_ on an actor
- Moved hero-specific override of `allocateResourceChanges` into parent implementation, with a check for the above getter
- Moved some adversary-specific getter overrides into parent implementation as well

One thing to consider is whether we want to set `woundsMultiplier` and `madnessMultiplier` to 0 for actors which don't use reserve resources. Or clobber bonus & base & max during prep. I think we can just leave it as-is, since having behind-the-scenes wounds values prepped doesn't actually make a difference anywhere with these changes.