### PR TITLE
Talent fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -416,6 +416,11 @@
           "AttackMissed": "You may only Interpose against an attack that hit or glanced your ally.",
           "RequiresStrike": "Interpose requires the most recent action to be a weapon Strike.",
           "SingleTarget": "Interpose can only be used against a single-target Strike."
+        },
+        "REPERCUSSIVE_BLOCK": {
+          "AlreadyConfirmed": "The attack against you has already been confirmed and can no longer be reacted to.",
+          "InvalidOutcome": "You may only use Repercussive Block after an attack against you is defended by Block.",
+          "MeleeOnly": "You may only use Repercussive Block against an incoming melee attack."
         }
       },
       "AuraNoToken": "You cannot use an Aura-target action without having a token on the scene!",

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -1093,22 +1093,6 @@ HOOKS.reload = {
 
 /* -------------------------------------------- */
 
-HOOKS.repercussiveBlock = {
-  postActivate() {
-    for ( const [target, events] of this.eventsByTarget ) {
-      if ( !events.allSuccess ) continue;
-      const {mainhand} = target.equipment.weapons; // TODO - react to the prior action?
-      if ( !mainhand?.id || mainhand.properties.has("natural") ) continue;
-      this.recordEvent({type: "actorUpdate", target,
-        actorUpdates: {items: [{_id: mainhand.id, system: {dropped: true, equipped: false}}]},
-        itemSnapshots: [mainhand.snapshot()],
-        statusText: [{text: "Disarmed!", fontSize: 64}]});
-    }
-  }
-};
-
-/* -------------------------------------------- */
-
 HOOKS.rest = {
   canUse() {
     if ( this.actor.system.isDead || this.actor.system.isInsane ) {

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -147,8 +147,6 @@ HOOKS.blastFlask = {
 HOOKS.bodyBlock = {
   canUse() {
     const targetAction = ChatMessage.implementation.getLastAction();
-    const myEvents = targetAction.eventsByActor.get(this.actor);
-    if ( !myEvents ) return;
     if ( !targetAction.tags.has("melee") ) {
       throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.BODY_BLOCK.MeleeOnly"));
     }
@@ -156,7 +154,8 @@ HOOKS.bodyBlock = {
       throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.BODY_BLOCK.AlreadyConfirmed"));
     }
     const results = game.system.api.dice.AttackRoll.RESULT_TYPES;
-    for ( const event of myEvents.roll ) {
+    const myEvents = targetAction.eventsByActor.get(this.actor);
+    for ( const event of myEvents?.roll || [] ) {
       if ( [results.ARMOR, results.GLANCE].includes(event.roll.data.result) ) {
         this.usage.targetAction = targetAction.message.id;
         return true;
@@ -1096,8 +1095,6 @@ HOOKS.reload = {
 HOOKS.repercussiveBlock = {
   canUse() {
     const targetAction = ChatMessage.implementation.getLastAction();
-    const myEvents = targetAction.eventsByActor.get(this.actor);
-    if ( !myEvents ) return;
     if ( !targetAction.tags.has("melee") ) {
       throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.REPERCUSSIVE_BLOCK.MeleeOnly"));
     }
@@ -1105,7 +1102,8 @@ HOOKS.repercussiveBlock = {
       throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.REPERCUSSIVE_BLOCK.AlreadyConfirmed"));
     }
     const results = game.system.api.dice.AttackRoll.RESULT_TYPES;
-    for ( const event of myEvents.roll ) {
+    const myEvents = targetAction.eventsByActor.get(this.actor);
+    for ( const event of myEvents?.roll || [] ) {
       if ( results.BLOCK === event.roll.data.result ) {
         this.usage.targetAction = targetAction.message.id;
         return true;

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -1093,6 +1093,30 @@ HOOKS.reload = {
 
 /* -------------------------------------------- */
 
+HOOKS.repercussiveBlock = {
+  canUse() {
+    const targetAction = ChatMessage.implementation.getLastAction();
+    const myEvents = targetAction.eventsByActor.get(this.actor);
+    if ( !myEvents ) return;
+    if ( !targetAction.tags.has("melee") ) {
+      throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.REPERCUSSIVE_BLOCK.MeleeOnly"));
+    }
+    if ( targetAction.message.flags.crucible.confirmed ) {
+      throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.REPERCUSSIVE_BLOCK.AlreadyConfirmed"));
+    }
+    const results = game.system.api.dice.AttackRoll.RESULT_TYPES;
+    for ( const event of myEvents.roll ) {
+      if ( results.BLOCK === event.roll.data.result ) {
+        this.usage.targetAction = targetAction.message.id;
+        return true;
+      }
+    }
+    throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.REPERCUSSIVE_BLOCK.InvalidOutcome"));
+  }
+};
+
+/* -------------------------------------------- */
+
 HOOKS.rest = {
   canUse() {
     if ( this.actor.system.isDead || this.actor.system.isInsane ) {


### PR DESCRIPTION
For now, this PR includes
- a fix for Repercussive Block (removing the hook that duplicated the disarm tag, and adding prerequisites checking).
- a small fix to the `canUse` hook of Body Block, making it correctly reject usage when the last action has no events, such as a move action.

Notes:
- Repercussive Block and Body Block have nearly identical `canUse` hooks and nearly identical error messages in those hooks. Perhaps the checks they perform can be standardized into a function that checks that the last action is unconfirmed and has specific tags and outcome, such as a blocked melee attack.