### PR TITLE
[#1050] Allow multi-actor skill checks to not show aggregate result

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1431,6 +1431,7 @@
     },
     "GROUP_CHECK": {
       "Title": "Group Skill Check",
+      "TitleSpecific": "Group {skill} Skill Check",
       "DialogTitle": "{skill} Check: {name}",
       "NoUserForActor": "No active user found for: {name}",
       "STATUSES": {
@@ -1452,6 +1453,7 @@
       "AnyActorHint": "Choose any world Actors.",
       "ChooseTarget": "Choose Target",
       "ClearRequest": "Clear Request",
+      "GroupCheck": "Group Check",
       "Request": "Request",
       "RequestRolls": "Request Rolls",
       "SpecificActors": "Specific Actors",

--- a/module/dice/group-check.mjs
+++ b/module/dice/group-check.mjs
@@ -7,12 +7,13 @@ import StandardCheck from "./standard-check.mjs";
 
 /**
  * @typedef GroupCheckFlags
- * @property {string} checkId                        Unique group check ID
- * @property {Record<string, GroupCheckSkillConfig>} skills  Skill ID → config (DC per skill)
- * @property {number} sharedBoons                    GM-assigned shared boons
- * @property {number} sharedBanes                    GM-assigned shared banes
- * @property {string} [messageMode]                  The chat message visibility mode
- * @property {Record<string, GroupCheckActorEntry>} actors   Actor ID → entry
+ * @property {string} checkId                               Unique group check ID
+ * @property {Record<string, GroupCheckSkillConfig>} skills Skill ID → config (DC per skill)
+ * @property {number} sharedBoons                           GM-assigned shared boons
+ * @property {number} sharedBanes                           GM-assigned shared banes
+ * @property {string} [messageMode]                         The chat message visibility mode
+ * @property {Record<string, GroupCheckActorEntry>} actors  Actor ID → entry
+ * @property {boolean} aggregate                            Whether to show an aggregate result
  */
 
 /**
@@ -45,8 +46,8 @@ import StandardCheck from "./standard-check.mjs";
  * @property {string} outcomeKey       Localization key for the aggregate outcome label
  * @property {string} classes          CSS classes describing the outcome (success/failure plus optional critical)
  * @property {string} detail           Pre-localized right-side label that contextualizes the hex score
- * @property {number|string} score    Weighted total (crit success +2, success +1, failure 0, crit failure -1), or
- *                                    {@link StandardCheck.UNKNOWN_SCORE} when any participating roll has no DC set
+ * @property {number|string} score     Weighted total (crit success +2, success +1, failure 0, crit failure -1), or
+ *                                     {@link StandardCheck.UNKNOWN_SCORE} when any participating roll has no DC set
  * @property {number} total            Number of participants whose rolls counted toward the aggregate
  * @property {number} required         Score threshold needed to clear an aggregate success
  * @property {number} skippedCount     Number of participants excluded as skipped
@@ -138,9 +139,10 @@ export default class GroupCheck extends StandardCheck {
    * @param {Record<string, GroupCheckSkillConfig>} [options.skills]  Skill configs. Defaults to single skill from roll data.
    * @param {boolean} [options.local=false]  If true, the GM rolls for all actors locally without dispatching queries.
    * @param {string} [options.messageMode]   The chat message visibility mode chosen by the GM.
+   * @param {boolean} [options.aggregate]    Whether to show an aggregate result
    * @returns {Promise<void>}
    */
-  async requestSubmit({requestedActors, skills, local=false, messageMode}={}) {
+  async requestSubmit({requestedActors, skills, local=false, messageMode, aggregate=true}={}) {
     if ( !requestedActors?.size && !requestedActors?.length ) return;
 
     // Default to single skill from the roll data
@@ -170,13 +172,16 @@ export default class GroupCheck extends StandardCheck {
       sharedBoons: this.data.totalBoons,
       sharedBanes: this.data.totalBanes,
       messageMode,
-      actors
+      actors,
+      aggregate
     };
 
     const content = await GroupCheck.renderGroupCheckCard(groupCheckFlags);
     const skillIds = Object.keys(skills);
     const flavor = (skillIds.length === 1)
-      ? _loc("ACTION.SkillCheck", {skill: SYSTEM.SKILLS[skillIds[0]].label})
+      ? aggregate
+        ? _loc("DICE.GROUP_CHECK.TitleSpecific", {skill: SYSTEM.SKILLS[skillIds[0]].label})
+        : _loc("ACTION.SkillCheck", {skill: SYSTEM.SKILLS[skillIds[0]].label})
       : _loc("DICE.GROUP_CHECK.Title");
     const messageData = {
       content,
@@ -343,7 +348,7 @@ export default class GroupCheck extends StandardCheck {
    */
   static async renderGroupCheckCard(flags, rolls=[]) {
     const actors = Object.values(flags.actors).map(entry => GroupCheck.#prepareActorTemplateData(entry, rolls));
-    const aggregate = GroupCheck.#computeAggregate(flags, rolls);
+    const aggregate = flags.aggregate ? GroupCheck.#computeAggregate(flags, rolls) : null;
     return foundry.applications.handlebars.renderTemplate(GroupCheck.#GROUP_CHECK_TEMPLATE, {actors, aggregate});
   }
 

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -79,6 +79,12 @@ export default class StandardCheckDialog extends DialogV2 {
   request;
 
   /**
+   * Is this a group check which should result in an aggregate result?
+   * @type {boolean}
+   */
+  isGroupCheck;
+
+  /**
    * Display the skills customization panel.
    * @type {boolean}
    */
@@ -164,6 +170,7 @@ export default class StandardCheckDialog extends DialogV2 {
       difficulties: Object.entries(SYSTEM.DICE.checkDifficulties).map(d => ({dc: d[0], label: `${_loc(d[1])} (DC ${d[0]})`})),
       configurable: this.configurable,
       isGM: game.user.isGM,
+      isGroupCheck: this.isGroupCheck,
       request: this.#prepareRequest(),
       customizeSkills: this.#prepareCustomizeSkills(),
       skillSelector: this.#prepareSkillSelector(),
@@ -190,8 +197,8 @@ export default class StandardCheckDialog extends DialogV2 {
     const hasSkills = !this.customizeSkills || (this.#selectedSkills.size > 0);
     const canSubmitGroup = (this.#requestActors.size > 0) && hasSkills;
 
-    // Left toggle: Customize Skills (group checks only)
-    if ( this.isGroupCheck && isConfigurable ) {
+    // Left toggle: Customize Skills (configurable only)
+    if ( isConfigurable ) {
       const chevron = this.customizeSkills ? "fa-chevrons-right" : "fa-chevrons-left";
       buttons.push({type: "button", action: "skillsToggle", cssClass: `icon fa-solid ${chevron}`, tooltip: _loc("DICE.SKILLS.CustomizeSkills"), position: "left"});
     }
@@ -207,8 +214,8 @@ export default class StandardCheckDialog extends DialogV2 {
       {type: "button", action: "requestParty", cssClass: "icon fa-solid fa-users", tooltip: _loc("DICE.REQUESTS.AddParty")}
     );
 
-    // Right toggle: Request Rolls (group checks only)
-    if ( this.isGroupCheck && isConfigurable ) {
+    // Right toggle: Request Rolls (configurable only)
+    if ( isConfigurable ) {
       const chevron = this.request ? "fa-chevrons-left" : "fa-chevrons-right";
       buttons.push({type: "button", action: "requestToggle", cssClass: `icon fa-solid ${chevron}`, tooltip: _loc("DICE.REQUESTS.RequestRolls")});
     }
@@ -387,7 +394,8 @@ export default class StandardCheckDialog extends DialogV2 {
     const defaultDc = this.roll.data.dc;
     const skills = {};
     for ( const [id, customDc] of this.#selectedSkills ) skills[id] = {dc: customDc ?? defaultDc};
-    const options = {requestedActors: this.#requestActors, local: true, messageMode: this.messageMode};
+    const aggregate = this.isGroupCheck && this.#requestActors.size > 1;
+    const options = {requestedActors: this.#requestActors, local: true, messageMode: this.messageMode, aggregate};
     if ( Object.keys(skills).length ) options.skills = skills;
     const groupCheckInstance = new crucible.api.dice.GroupCheck(foundry.utils.deepClone(this.roll.data));
     await groupCheckInstance.requestSubmit(options);
@@ -448,6 +456,12 @@ export default class StandardCheckDialog extends DialogV2 {
       this.roll = actor.getSkillCheck(skillId, {dc, boons: this.roll.data.totalBoons,
         banes: this.roll.data.totalBanes});
       return this.render({window: {title: this.title}});
+    }
+
+    // Toggle group check
+    else if ( event.target.name === "isGroupCheck" ) {
+      this.isGroupCheck = event.target.checked;
+      return this.render();
     }
     super._onChangeForm(formConfig, event);
   }
@@ -528,6 +542,7 @@ export default class StandardCheckDialog extends DialogV2 {
   /**
    * Toggle the request actors panel.
    * @this {StandardCheckDialog}
+   * @param {PointerEvent} _event
    */
   static async #onRequestToggle(_event) {
     this.request = !this.request && game.user.isGM;
@@ -593,7 +608,8 @@ export default class StandardCheckDialog extends DialogV2 {
     const defaultDc = this.roll.data.dc;
     const skills = {};
     for ( const [id, customDc] of this.#selectedSkills ) skills[id] = {dc: customDc ?? defaultDc};
-    const options = {requestedActors: this.#requestActors, messageMode: this.messageMode};
+    const aggregate = this.isGroupCheck && this.#requestActors.size > 1;
+    const options = {requestedActors: this.#requestActors, messageMode: this.messageMode, aggregate};
     if ( Object.keys(skills).length ) options.skills = skills;
     await this.roll.requestGroupCheck(options);
     await this.close();

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -405,11 +405,12 @@ export default class StandardCheck extends Roll {
    * @param {Iterable<CrucibleActor>} [options.requestedActors] Actors to include in the group check
    * @param {Record<string, GroupCheckSkillConfig>} [options.skills] Skill configurations with per-skill DCs
    * @param {string} [options.messageMode] The chat message visibility mode
+   * @param {boolean} [options.aggregate] Whether to show an aggregate result
    * @returns {Promise<void>}
    */
-  async requestGroupCheck({requestedActors, skills, messageMode}={}) {
+  async requestGroupCheck({requestedActors, skills, messageMode, aggregate}={}) {
     const groupCheckInstance = new crucible.api.dice.GroupCheck(foundry.utils.deepClone(this.data));
-    return groupCheckInstance.requestSubmit({requestedActors, skills, messageMode});
+    return groupCheckInstance.requestSubmit({requestedActors, skills, messageMode, aggregate});
   }
 
   /* -------------------------------------------- */

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -813,12 +813,13 @@ function getPartyActors() {
  * @returns {{actor: CrucibleActor|null, check: StandardCheck}}
  */
 function prepareSkillCheck(event) {
-  const {skillId, dc: dcStr} = event.currentTarget.dataset;
+  const {skillId, dc: dcStr, group} = event.currentTarget.dataset;
   const parsedDc = Number(dcStr);
   const dc = Number.isNaN(parsedDc) ? 15 : parsedDc;
   const checkData = {type: skillId, dc};
   const actor = inferEnricherActors(true);
-  const check = actor ? actor.getSkillCheck(skillId, checkData) : new crucible.api.dice.StandardCheck(checkData);
+  const rollCls = group ? crucible.api.dice.GroupCheck : crucible.api.dice.StandardCheck;
+  const check = actor ? actor.getSkillCheck(skillId, checkData) : new rollCls(checkData);
   return {actor, check};
 }
 

--- a/templates/dice/standard-check-dialog.hbs
+++ b/templates/dice/standard-check-dialog.hbs
@@ -83,6 +83,12 @@
         <p class="hint">{{localize "ACTION.RequestActorsHint"}}</p>
         {{/each}}
     </div>
+    {{#if (gt request.actors.length 1)}}
+    <div class="form-fields">
+        <input type="checkbox" id="isGroupCheck" name="isGroupCheck" {{checked isGroupCheck}}/>
+        <label for="isGroupCheck">{{localize "DICE.REQUESTS.GroupCheck"}}</label>
+    </div>
+    {{/if}}
 </aside>
 {{/if}}
 


### PR DESCRIPTION
Closes #1050 
Changes:
- `GroupCheck#requestSubmit` now accepts an `options.aggregate` (default `true`) parameter. If `true`, chat card will include aggregate result. If false, will not.
- Single-skill aggregate group checks now flavor their chat cards with "Group {skill} Skill Check."
- `StandardCheckDialog` now includes a checkbox for "Group Check" which defaults to checked for `group` skill check enrichers or programmatically invoked `GroupCheck` dialogs. The checkbox only appears of the Request panel is open and there are at least 2 actors in the list. The checkbox controls whether an aggregate result is displayed.
- `StandardCheckDialog`'s toggles for the Skill Configuration & Request panels are now tied only to configurability, not `isGroupCheck`. This means that a GM can always (unless responding to a requested roll) access these panels, regardless of how the dialog was invoked.