### PR TITLE
[#1089] Ensure flanking & action-applied status-conveying effects show icon

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1151,6 +1151,7 @@ export default class CrucibleActor extends Actor {
       const forceUpdate = effectData._action === "update";
       const shouldUpdate = existing && (reverse ? forceUpdate : !forceDelete);
       const shouldDelete = existing && (reverse ? !forceUpdate : forceDelete);
+      if ( effectData.statuses.length ) effectData.showIcon ??= CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS;
       if ( shouldUpdate ) toUpdate.push(effectData);
       else if ( shouldDelete ) toDelete.push(effectData._id);
       else if ( !reverse ) toCreate.push(effectData);
@@ -2404,6 +2405,7 @@ export default class CrucibleActor extends Actor {
         description: _loc("ACTIVE_EFFECT.STATUSES.FlankedDescription"),
         img: "systems/crucible/icons/statuses/flanked.svg",
         statuses: ["flanked"],
+        showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS,
         system: {
           enemies: engagement.enemies.size,
           allies: engagement.allies.size,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1151,7 +1151,7 @@ export default class CrucibleActor extends Actor {
       const forceUpdate = effectData._action === "update";
       const shouldUpdate = existing && (reverse ? forceUpdate : !forceDelete);
       const shouldDelete = existing && (reverse ? !forceUpdate : forceDelete);
-      if ( effectData.statuses.length ) effectData.showIcon ??= CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS;
+      if ( effectData.statuses?.length ) effectData.showIcon ??= CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS;
       if ( shouldUpdate ) toUpdate.push(effectData);
       else if ( shouldDelete ) toDelete.push(effectData._id);
       else if ( !reverse ) toCreate.push(effectData);


### PR DESCRIPTION
Closes #1089 
Truthfully, I think the "best" solution might actually be to override `Token#_drawEffects` - but that's not ideal because we'd have to copy all the code over. Barring implementation of a core `ActiveEffect#shouldBeVisible` getter we can override, this does the job well enough I think.