### PR TITLE
[#841, #1047] Add `.scrollable`-style padding, margin, & gutter to creation styles, limit max tooltip height to viewport height

### DIFF
--- a/styles/creation.less
+++ b/styles/creation.less
@@ -295,9 +295,6 @@
     height: 100%;
     overflow: hidden auto;
     gap: var(--gap);
-    padding-right: 0.75rem;
-    margin-right: -0.75rem;
-    scrollbar-gutter: stable;
 
     .step-header {
       margin: 0;

--- a/styles/creation.less
+++ b/styles/creation.less
@@ -295,6 +295,9 @@
     height: 100%;
     overflow: hidden auto;
     gap: var(--gap);
+    padding-right: 0.75rem;
+    margin-right: -0.75rem;
+    scrollbar-gutter: stable;
 
     .step-header {
       margin: 0;

--- a/styles/theme.less
+++ b/styles/theme.less
@@ -461,6 +461,7 @@
   border-image: url("../ui/frames/tooltip-frame.webp") 64 repeat;
   border-image-width: 32px;
   text-align: left; // always left, regardless of tooltip position
+  max-height: 100%;
 
   &.wide {
     max-width: unset;

--- a/templates/sheets/creation/ancestry.hbs
+++ b/templates/sheets/creation/ancestry.hbs
@@ -15,7 +15,7 @@
         </menu>
     </div>
 
-    <div id="ancestry-details" class="step-details flexcol">
+    <div id="ancestry-details" class="step-details scrollable flexcol">
     {{#if ancestry}}
         <h1 class="step-header">{{ancestry.name}}</h1>
         <article class="step-summary">

--- a/templates/sheets/creation/background.hbs
+++ b/templates/sheets/creation/background.hbs
@@ -15,7 +15,7 @@
         </menu>
     </div>
 
-    <div id="background-details" class="step-details flexcol">
+    <div id="background-details" class="step-details scrollable flexcol">
     {{#if background}}
         <h1 class="step-header">{{background.name}}</h1>
         <article class="step-summary">


### PR DESCRIPTION
Closes #841 
Closes #1047 
For 841, just set `max-height: 100%` on crucible tooltips. Could do something neat like what 5e does with a mutation observer on tooltips to ensure unlocked ones don't render a scrollbar, but instead somehow visually telegraph that there's more info there if you lock it, then if locked scrollbar is rendered. For now, simple solution.

For 1047, I checked how the 5e version in ember looks - it uses the `scrollable` class itself. We could do that too in theory, but at the risk of accidentally introducing sub-styles I just added the important bits to the existing `.step-details` selector.