### PR TITLE
[#1072, #1073, #1074, #1110, #1112, #1113] Address a number of missing localizations

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2313,10 +2313,14 @@
       "RequiresRuneGesture": "You must know a spellcraft Rune in order to utilize a Gesture.",
       "RequiresRuneInflection": "You must know a spellcraft Rune in order to utilize an Inflection."
     },
+    "Banned": "Banned",
+    "Empty": "Empty",
     "GrantsSpells": "<strong>Iconic Spells:</strong>: {name} grants {spells} Iconic Spell slots.",
+    "Locked": "Locked",
     "NodeSpecific": "{nodeType} Node",
     "PointsAvailable": "Points Available",
-    "Prerequisites": "Prerequisites"
+    "Prerequisites": "Prerequisites",
+    "Tier": "Tier {tier}"
   },
   "TAXONOMY": {
     "CATEGORIES": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -593,7 +593,10 @@
         "Elite": "Elite",
         "Minion": "Minion",
         "Normal": "Normal"
-      }
+      },
+      "NoArchetype": "No Archetype",
+      "NoTaxonomy": "No Taxonomy",
+      "ThreatLevelSpecific": "Threat Level {threat}"
     },
     "CREATION": {
       "AbandonContent": "Discard creation progress and exit the creator?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2197,6 +2197,8 @@
       "PurchaseNodeReverse": "Remove point spent on empty node \"{node}\"?",
       "PurchaseNodeTitle": "Purchase Talent Node?",
       "PurchaseTitle": "Purchase Talent: {name}",
+      "Remove": "<p>Remove talent <strong>{name}</strong>, reclaiming 1 Talent Point?</p>",
+      "RemoveTitle": "Remove Talent: {name}",
       "Reset": "Reset"
     },
     "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -659,7 +659,7 @@
           "base": "Base Engagement",
           "label": "Engagement",
           "labelShort": "Engage",
-          "tooltip": "Number of Enemies Engaged<br>(Size - 2) + Engagement Bonus"
+          "tooltip": "Number of Enemies able to be Engaged<br>(Size - 2) + Engagement Bonus"
         },
         "engagementBonus": {
           "hint": "An additive modifier to base engagement.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1557,6 +1557,7 @@
       "Create": "Create Item",
       "Delete": "Delete Item",
       "Drop": "Drop Weapon",
+      "DropDetail": "Drop the {item}",
       "Edit": "Edit Item",
       "Equip": "Equip {typeLabel}",
       "EquipDetail": "Equip the {item}",
@@ -1564,7 +1565,8 @@
       "RecoverAllContent": "Pick up all of {actor}'s dropped items?",
       "RecoverAllTitle": "Recover Dropped Items",
       "RecoverDetail": "Recover the dropped {item}",
-      "UnEquip": "Un-equip {typeLabel}"
+      "UnEquip": "Un-equip {typeLabel}",
+      "UnEquipDetail": "Un-equip the {item}"
     },
     "COMPOSED_NAME": {
       "Prefix": "{prefixes} {name}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1530,6 +1530,10 @@
     "DefaultActor": "Environment",
     "DefaultName": "Environmental Hazard",
     "Hazard": "Hazard",
+    "Parenthetical": "{label} ({tags})",
+    "Rank": "Hazard {danger}",
+    "TooltipDamage": "{rank} vs. {defense} dealing {damage} damage to {resource}",
+    "TooltipRestoration": "{rank} vs. {defense} restoring {resource}",
     "UseHazard": "Use Hazard",
     "WindowTitle": "Hazard: {name}",
     "CONFIG": {

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -1112,7 +1112,8 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       bonusAttribute: "engagementBonus",
       minValue: 0,
       editLabel: "ACTOR.ACTIONS.EditEngagement",
-      baseLabel: "ACTOR.FIELDS.movement.engagement.base"
+      baseLabel: "ACTOR.FIELDS.movement.engagement.base",
+      baseHint: _loc("ACTOR.FIELDS.movement.engagement.tooltip").split("<br>")[0]
     });
   }
 
@@ -1129,7 +1130,8 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       bonusAttribute: "sizeBonus",
       minValue: 1,
       editLabel: "ACTOR.ACTIONS.EditSize",
-      baseLabel: "ACTOR.FIELDS.movement.size.base"
+      baseLabel: "ACTOR.FIELDS.movement.size.base",
+      baseHint: "ACTOR.FIELDS.movement.size.tooltip"
     });
   }
 
@@ -1146,7 +1148,8 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       bonusAttribute: "strideBonus",
       minValue: 0,
       editLabel: "ACTOR.ACTIONS.EditMovement",
-      baseLabel: "ACTOR.FIELDS.movement.stride.base"
+      baseLabel: "ACTOR.FIELDS.movement.stride.base",
+      baseHint: "ACTOR.FIELDS.movement.stride.tooltip"
     });
   }
 
@@ -1193,9 +1196,10 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
    * @param {number} [options.minValue]
    * @param {string} [options.editLabel]
    * @param {string} [options.baseLabel]
+   * @param {string} [options.baseHint]
    * @returns {Promise<void>}
    */
-  async #editMovementBonusDialog({baseAttribute, bonusAttribute, minValue, editLabel, baseLabel}={}) {
+  async #editMovementBonusDialog({baseAttribute, bonusAttribute, minValue, editLabel, baseLabel, baseHint}={}) {
     const bonusField = this.actor.system.schema.getField(`movement.${bonusAttribute}`);
     if ( !bonusField ) throw new Error(`Actor ${this.actor.name} does not have a movement.${bonusAttribute} field`);
     const baseValue = this.actor.system.movement[baseAttribute];
@@ -1203,7 +1207,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     const minBonus = minValue - baseValue;
 
     // Structure form content
-    const baseGroup = bonusField.toFormGroup({label: _loc(baseLabel), classes: ["slim"]},
+    const baseGroup = bonusField.toFormGroup({label: _loc(baseLabel), hint: _loc(baseHint), classes: ["slim"]},
       {name: "", value: baseValue, disabled: true});
     const bonusGroup = bonusField.toFormGroup({classes: ["slim"]}, {value: bonusValue, min: minBonus, step: 1});
     bonusGroup.querySelector("input").toggleAttribute("autofocus", true);

--- a/module/canvas/tree/talent-hud.mjs
+++ b/module/canvas/tree/talent-hud.mjs
@@ -68,10 +68,10 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
     const tagGroups = [];
 
     // Node tags
-    const nodeTags = [{label: `Tier ${node.tier}`}, {label: node.id}];
-    if ( state.banned ) nodeTags.push({label: "Banned", class: "unmet"});
-    else if ( !state.unlocked ) nodeTags.push({label: "Locked", class: "unmet"});
-    if ( !node.talents.size ) nodeTags.push({label: "Empty", class: "unmet"});
+    const nodeTags = [{label: _loc("TALENT.Tier", {tier: node.tier})}, {label: node.id}];
+    if ( state.banned ) nodeTags.push({label: _loc("TALENT.Banned"), class: "unmet"});
+    else if ( !state.unlocked ) nodeTags.push({label: _loc("TALENT.Locked"), class: "unmet"});
+    if ( !node.talents.size ) nodeTags.push({label: _loc("TALENT.Empty"), class: "unmet"});
     const nodeType = _loc(`TALENT.NODES.${node.type.capitalize()}`);
     tagGroups.push({
       id: node.type,

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -381,7 +381,7 @@ export const TAGS = {
   afterStrike: {
     tag: "afterStrike",
     label: "ACTION.TAG.AfterStrike",
-    tooltip: "ACTION.TAG.ActorStrikeTooltip",
+    tooltip: "ACTION.TAG.AfterStrikeTooltip",
     category: "requirements",
     canUse() {
       const lastAction = this.actor.lastConfirmedAction;

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -29,7 +29,7 @@ export function bleeding(actor, {ability="dexterity", amount, turns=3, damageTyp
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Bleeding"),
-    name: "Bleeding",
+    name: _loc(CONFIG.statusEffects.bleeding.name),
     img: "icons/skills/wounds/blood-spurt-spray-red.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -55,7 +55,7 @@ export function burning(actor, {ability="intellect", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Burning"),
-    name: "Burning",
+    name: _loc(CONFIG.statusEffects.burning.name),
     img: "icons/magic/fire/projectile-smoke-swirl-red.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -85,7 +85,7 @@ export function freezing(actor, {ability="wisdom", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Freezing"),
-    name: "Freezing",
+    name: _loc(CONFIG.statusEffects.freezing.name),
     img: "icons/magic/water/orb-ice-web.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -111,7 +111,7 @@ export function confused(actor, {ability="intellect", amount, turns=2}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Confused"),
-    name: "Confused",
+    name: _loc(CONFIG.statusEffects.confused.name),
     img: "icons/magic/air/air-burst-spiral-pink.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -137,7 +137,7 @@ export function corroding(actor, {ability="wisdom", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Corroding"),
-    name: "Corroding",
+    name: _loc(CONFIG.statusEffects.corroding.name),
     img: "icons/magic/earth/orb-stone-smoke-teal.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -161,7 +161,7 @@ export function decay(actor, {ability="wisdom", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Decaying"),
-    name: "Decaying",
+    name: _loc(CONFIG.statusEffects.decaying.name),
     img: "icons/magic/unholy/strike-beam-blood-red-purple.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -185,7 +185,7 @@ export function entropy(actor, {ability="presence", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Entropy"),
-    name: "Entropy",
+    name: _loc(CONFIG.statusEffects.entropy.name),
     img: "icons/magic/unholy/orb-swirling-teal.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -210,7 +210,7 @@ export function irradiated(actor, {ability="presence", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Irradiated"),
-    name: "Irradiated",
+    name: _loc(CONFIG.statusEffects.irradiated.name),
     img: "icons/magic/light/beams-rays-orange-purple-large.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -239,7 +239,7 @@ export function mending(actor, {ability="wisdom", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Mending"),
-    name: "Mending",
+    name: _loc(CONFIG.statusEffects.mending.name),
     img: "icons/magic/life/cross-beam-green.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -263,7 +263,7 @@ export function inspired(actor, {ability="presence", amount, turns=1}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Inspired"),
-    name: "Inspired",
+    name: _loc(CONFIG.statusEffects.inspired.name),
     img: "icons/magic/light/explosion-star-glow-silhouette.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -288,7 +288,7 @@ export function dominated(actor, {ability="wisdom", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Dominated"),
-    name: "Dominated",
+    name: _loc(CONFIG.statusEffects.dominated.name),
     img: "icons/magic/control/hypnosis-mesmerism-watch.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -314,7 +314,7 @@ export function poisoned(actor, {ability="toughness", amount, turns=6}={}) {
   amount ??= actor.getAbilityBonus(ability, 1);
   return {
     _id: getEffectId("Poisoned"),
-    name: "Poisoned",
+    name: _loc(CONFIG.statusEffects.poisoned.name),
     img: "icons/magic/unholy/orb-smoking-green.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -340,7 +340,7 @@ export function poisoned(actor, {ability="toughness", amount, turns=6}={}) {
 export function suffocating(actor, {amount=6, turns}={}) {
   return {
     _id: getEffectId("Suffocating"),
-    name: "Suffocating",
+    name: _loc(CONFIG.statusEffects.suffocating.name),
     img: "icons/magic/water/vortex-water-whirlpool.webp",
     duration: turns ? {value: turns, units: "rounds", expiry: "turnStart"} : {},
     origin: actor?.uuid,
@@ -370,7 +370,7 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
   amount ??= actor.getAbilityBonus(ability, 2);
   return {
     _id: getEffectId("Shocked"),
-    name: "Shocked",
+    name: _loc(CONFIG.statusEffects.shocked.name),
     img: "icons/magic/lightning/bolt-strike-forked-blue.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,
@@ -394,7 +394,7 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
 export function staggered(actor, {turns=1}={}) {
   return {
     _id: getEffectId("Staggered"),
-    name: "Staggered",
+    name: _loc(CONFIG.statusEffects.staggered.name),
     img: "icons/skills/melee/strike-hammer-destructive-orange.webp",
     duration: {value: turns, units: "rounds", expiry: "turnStart"},
     origin: actor?.uuid,

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -161,7 +161,7 @@ export default class StandardCheckDialog extends DialogV2 {
       buttons: this.#prepareButtons(),
       dice: this.roll.dice.map(d => `d${d.faces}`),
       difficulty: this._getDifficulty(data.dc),
-      difficulties: Object.entries(SYSTEM.DICE.checkDifficulties).map(d => ({dc: d[0], label: `${_loc(d[1])} (DC ${d[0]})`})),
+      difficulties: Object.entries(SYSTEM.DICE.checkDifficulties).map(d => ({dc: d[0], label: `${_loc(d[1])} (${_loc("DICE.DCSpecific", {dc: d[0]})})`})),
       configurable: this.configurable,
       isGM: game.user.isGM,
       request: this.#prepareRequest(),

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1854,8 +1854,8 @@ export default class CrucibleActor extends Actor {
     if ( !ownedTalent ) throw new Error(`Talent "${ownedTalent.id}" is not owned by Actor "${this.id}"`);
     if ( dialog ) {
       const confirm = await foundry.applications.api.DialogV2.confirm({
-        window: {title: `Remove Talent: ${ownedTalent.name}`},
-        content: `<p>Remove talent <strong>${ownedTalent.name}</strong>, reclaiming 1 Talent Point?</p>`,
+        window: {title: _loc("TALENT.ACTIONS.RemoveTitle", {name: ownedTalent.name})},
+        content: _loc("TALENT.ACTIONS.Remove", {name: ownedTalent.name}),
         yes: {default: true},
         no: {default: false}
       });

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2207,10 +2207,10 @@ export default class CrucibleActor extends Actor {
     const typeLabel = _loc(CONFIG.Item.typeLabels[item.type]);
     const action = new CrucibleAction({
       id: "equipItem",
-      name: dropped ? `Drop ${typeLabel}` : `Un-equip ${typeLabel}`,
+      name: _loc(`ITEM.ACTIONS.${dropped ? "Drop" : "UnEquip"}`, {typeLabel}),
       img: item.img,
       cost: {action: ap},
-      description: `${dropped ? "Drop" : "Un-equip"} the ${item.name}.`,
+      description: _loc(`ITEM.ACTIONS.${dropped ? "Drop" : "UnEquip"}Detail`, {item: item.name}),
       target: {type: "self", scope: 1}
     }, {actor: this});
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -500,21 +500,22 @@ function enrichHazard([_match, terms, name]) {
   const {damageType, defenseType, resource, restoration} = action.usage;
 
   // Prepare label
-  const hazardRank = `Hazard ${danger}`;
+  const hazardRank = _loc("HAZARD.Rank", {danger});
   const parenthetical = name ? [hazardRank] : [];
   for ( const t of tags ) {
     const cfg = SYSTEM.ACTION.TAGS[t];
     if ( cfg && cfg.label && !cfg.internal ) parenthetical.push(_loc(cfg.label));
   }
   let label = name || hazardRank;
-  if ( parenthetical.length ) label += ` (${parenthetical.join(", ")})`;
-
+  const listFormatter = new Intl.ListFormat(game.i18n.lang, {style: "short", type: "unit"});
+  if ( parenthetical.length ) label = _loc("HAZARD.Parenthetical", {label, tags: listFormatter.format(parenthetical)});
   // Prepare tooltip
   const defenseLabel = _loc(SYSTEM.DEFENSES[defenseType]?.label);
   const resourceLabel = _loc(SYSTEM.RESOURCES[resource]?.label);
   const damageLabel = _loc(SYSTEM.DAMAGE_TYPES[damageType]?.label) || "";
-  const tooltip = restoration ? `${hazardRank} vs. ${defenseLabel} restoring ${resourceLabel}`
-    : `${hazardRank} vs. ${defenseLabel} dealing ${damageLabel} damage to ${resourceLabel}`;
+  const tooltip = restoration
+    ? _loc("HAZARD.TooltipRestoration", {rank: hazardRank, defense: defenseLabel, resource: resourceLabel})
+    : _loc("HAZARD.TooltipDamage", {rank: hazardRank, defense: defenseLabel, damage: damageLabel, resource: resourceLabel});
 
   // Return the enriched content tag
   const tag = document.createElement("enriched-content");

--- a/module/models/actor-adversary.mjs
+++ b/module/models/actor-adversary.mjs
@@ -332,10 +332,10 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
    */
   getTags(scope="full") {
     const tags = {};
-    tags.level = `Threat Level ${this.advancement.threat}`;
+    tags.level = _loc("ACTOR.ADVERSARY.ThreatLevelSpecific", {threat: this.advancement.threat});
     if ( scope === "short" ) return tags;
-    tags.taxonomy = this.details.taxonomy?.name || "No Taxonomy";
-    tags.archetype = this.details.archetype?.name || "No Archetype";
+    tags.taxonomy = this.details.taxonomy?.name || _loc("ACTOR.ADVERSARY.NoTaxonomy");
+    tags.archetype = this.details.archetype?.name || _loc("ACTOR.ADVERSARY.NoArchetype");
     return tags;
   }
 

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -290,7 +290,7 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
    */
   getTags(scope="full") {
     const tags = {};
-    tags.level = `Level ${this.advancement.level}`;
+    tags.level = _loc("ACTOR.LevelSpecific", {level: this.advancement.level});
     if ( scope === "short" ) return tags;
     if ( this.details.signatureName ) tags.signatureName = this.details.signatureName;
     return tags;


### PR DESCRIPTION
Closes #1072 
Closes #1073 
Closes #1074 
All just spots where we didn't use existing localization. For the first one, instead of writing it out manually for each, I just grabbed the localization key from `CONFIG.statusEffects`.

Closes #1110 
Closes #1113
Added some new localization for this. Also added some for unequip/drop detail, and used existing for the unequip/drop action name.

Closes #1112
For the movement-field edit dialogs, now also pass a hint for the base. After strike tooltip had a typo in it (`ActorStrike`). Hazard localizations added & ListFormat used for parentheticals. Added localization for node tags.