### PR TITLE
[#1099] Don't clear ownership when importing summon from compendium

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -596,7 +596,7 @@ export const TAGS = {
         let worldActor = game.actors.get(sourceActor.id);
         if ( !worldActor ) {
           worldActor = await game.actors.importFromCompendium(sourceActor.collection, sourceActor.id, {ownership},
-            {keepId: true});
+            {keepId: true, clearOwnership: false});
         }
         else await worldActor.update({ownership});
 


### PR DESCRIPTION
Closes #1099 
Currently, the `ownership` in `updateData` gets nuked on import for an actor which doesn't already exist in the world collection.