### PR TITLE
Update various action hooks to properly iterate over `this.targets`

### DIFF
--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -22,7 +22,7 @@ HOOKS.antitoxin = {
   postActivate() {
     const tiers = {shoddy: 3, standard: 5, fine: 7, superior: 9, masterwork: 11};
     const neutralizeAmount = tiers[this.item.system.quality];
-    for ( const target of this.targets.keys() ) {
+    for ( const [target] of this.targets ) {
       const effects = [];
       for ( const effect of target.effects ) {
         if ( !effect.statuses.has("poisoned") || !effect.system.dot?.length ) continue;
@@ -468,7 +468,7 @@ HOOKS.healingElixir = {
     const quality = this.usage.consumable.config.quality;
     let amount = 6;
     for ( let i = 1; i <= (quality.bonus + 1); i++ ) amount *= 2;
-    for ( const target of this.targets ) {
+    for ( const [target] of this.targets ) {
       this.recordEvent({target, resources: [{resource: "health", delta: amount}]});
     }
   }
@@ -616,7 +616,7 @@ HOOKS.executionersStrike = {
 HOOKS.extollDeeds = {
   postActivate() {
     const morale = Math.ceil(this.actor.system.abilities.presence.value / 2);
-    for ( const target of this.targets ) {
+    for ( const [target] of this.targets ) {
       this.recordEvent({target, resources: [{resource: "morale", delta: morale}]});
     }
   }
@@ -938,7 +938,7 @@ HOOKS.poisonIngest = {
 HOOKS.rallyingCry = {
   postActivate() {
     const amount = this.actor.abilities.presence.value;
-    for ( const target of this.targets ) {
+    for ( const [target] of this.targets ) {
       this.recordEvent({target, resources: [{resource: "morale", delta: amount}]});
     }
   }
@@ -951,7 +951,7 @@ HOOKS.rallyingElixir = {
     const quality = this.usage.consumable.config.quality;
     let amount = 6;
     for ( let i = 1; i <= (quality.bonus + 1); i++ ) amount *= 2;
-    for ( const target of this.targets ) {
+    for ( const [target] of this.targets ) {
       this.recordEvent({target, resources: [{resource: "morale", delta: amount}]});
     }
   }


### PR DESCRIPTION
Some remnant `for ( const target of this.targets )` when `this.targets` is now a `Map`. Affects Healing & Rallying Elixirs, Extoll Deeds, Rallying Cry.