### PR TITLE
Ensure pre-camel-cased inputs to `generateId` don't get lowercased

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -834,8 +834,8 @@ async function packageCompendium(documentName, packName, folder) {
  */
 function generateId(title, length) {
   const id = title.split(" ").map((w, i) => {
-    const p = w.slugify({replacement: "", lowercase: i === 0, strict: true});
-    return i ? p.titleCase() : p;
+    const p = w.slugify({replacement: "", lowercase: false, strict: true});
+    return i ? p.titleCase() : (p.charAt(0).toLowerCase() + p.slice(1));
   }).join("");
   return Number.isNumeric(length) ? id.slice(0, length).padEnd(length, "0") : id;
 }


### PR DESCRIPTION
Before & Afters of some examples:
| Input | Before | After |
| ----- | ------ | ----- |
| "Berserker Rage" | "berserkerRage" | "berserkerRage" |
| "berserkerRage" | "berserkerrage" | "berserkerRage" |
| "BERSERKERRAGE" | "berserkerrage" | "bERSERKERRAGE" |
| "BERSERKER RAGE" | "berserkerRage" | "bERSERKERRage" |

The last two rows are, imo, irrelevant edge cases. The important bit is the second row, since we frequently pass camelCase identifiers to `generateId` for the purposes of auto-generating effect IDs, and that shouldn't result in a meaningful change from the identifier.