### PR TITLE
Replace blend curve with exposure curve and custom shader

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -476,6 +476,7 @@ Hooks.once("init", async function() {
 
 Hooks.once("canvasConfig", () => {
   canvas.grid.CrucibleHitBoxShader.registerPlugin();
+  canvas.particles.CrucibleParticleShader.registerPlugin();
 });
 
 /* -------------------------------------------- */

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -7,6 +7,7 @@ import {registerComponents} from "./vfx/components/_module.mjs";
 export * as detectionModes from "./detection-modes/_module.mjs";
 export * as tree from "./tree/_module.mjs";
 export * as grid from "./grid/_module.mjs";
+export * as particles from "./particles/_module.mjs";
 export * as vfx from "./vfx/_module.mjs";
 export * as movement from "./movement.mjs";
 export {default as CrucibleMovementPolygon} from "./movement-polygon.mjs";

--- a/module/canvas/particles/_module.mjs
+++ b/module/canvas/particles/_module.mjs
@@ -1,0 +1,1 @@
+export {default as CrucibleParticleShader} from "./particle-shader.mjs";

--- a/module/canvas/particles/particle-shader.mjs
+++ b/module/canvas/particles/particle-shader.mjs
@@ -1,0 +1,119 @@
+/**
+ * Batch shader for Crucible particles with exposure.
+ */
+export default class CrucibleParticleShader extends foundry.canvas.rendering.shaders.BaseSamplerShader {
+
+  /** @override */
+  static classPluginName = "batchCrucibleParticle";
+
+  /** @override */
+  static batchGeometry = [
+    {id: "aVertexPosition", size: 2, normalized: false, type: PIXI.TYPES.FLOAT},
+    {id: "aTextureCoord", size: 2, normalized: false, type: PIXI.TYPES.FLOAT},
+    {id: "aColor", size: 4, normalized: true, type: PIXI.TYPES.UNSIGNED_BYTE},
+    {id: "aTextureId", size: 1, normalized: false, type: PIXI.TYPES.FLOAT},
+    {id: "aExposure", size: 1, normalized: false, type: PIXI.TYPES.FLOAT}
+  ];
+
+  /** @override */
+  static batchVertexSize = 7;
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static _packInterleavedGeometry(element, attributeBuffer, indexBuffer, aIndex, iIndex) {
+    const {float32View, uint32View} = attributeBuffer;
+
+    // Write indices into buffer
+    const packedVertices = aIndex / this.vertexSize;
+    const indices = element.indices;
+    for ( let i = 0; i < indices.length; i++ ) {
+      indexBuffer[iIndex++] = packedVertices + indices[i];
+    }
+
+    // Prepare attributes
+    const vertexData = element.vertexData;
+    const uvs = element.uvs;
+    const baseTexture = element._texture.baseTexture;
+    const alpha = Math.min(element.worldAlpha, 1.0);
+    const argb = PIXI.Color.shared.setValue(element._tintRGB).toPremultiplied(alpha, baseTexture.alphaMode > 0);
+    const textureId = baseTexture._batchLocation;
+    const exposure = Math.clamp(element.object?.exposure ?? 0, -1, 1);
+
+    // Write attributes into buffer
+    const vertexSize = this.vertexSize;
+    for ( let i = 0, j = 0; i < vertexData.length; i += 2, j += vertexSize ) {
+      let k = aIndex + j;
+      float32View[k++] = vertexData[i];
+      float32View[k++] = vertexData[i + 1];
+      float32View[k++] = uvs[i];
+      float32View[k++] = uvs[i + 1];
+      uint32View[k++] = argb;
+      float32View[k++] = textureId;
+      float32View[k++] = exposure;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static get batchVertexShader() {
+    return `
+    #version 300 es
+    precision ${PIXI.Program.defaultVertexPrecision} float;
+    
+    in vec2 aVertexPosition;
+    in vec2 aTextureCoord;
+    in vec4 aColor;
+    in float aTextureId;
+    in float aExposure;
+    
+    uniform mat3 projectionMatrix;
+    uniform mat3 translationMatrix;
+    uniform vec4 tint;
+    
+    out vec2 vTextureCoord;
+    flat out vec4 vColor;
+    flat out float vTextureId;
+    flat out float vExposure;
+    
+    void main() {
+      gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
+      vTextureCoord = aTextureCoord;
+      vColor = aColor * tint;
+      vTextureId = aTextureId;
+      vExposure = aExposure;
+    }
+    `;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static get batchFragmentShader() {
+    return `
+    #version 300 es
+    
+    ${this.GLSL1_COMPATIBILITY_FRAGMENT}
+    
+    precision ${PIXI.Program.defaultFragmentPrecision} float;
+    
+    in vec2 vTextureCoord;
+    flat in vec4 vColor;
+    flat in float vTextureId;
+    flat in float vExposure;
+    
+    uniform sampler2D uSamplers[%count%];
+    
+    out vec4 fragColor;
+    
+    void main() {
+      vec4 color;
+      %forloop%
+      color *= vColor;
+      color.rgb *= 1.0 + vExposure;
+      fragColor = color;
+    }
+    `;
+  }
+}

--- a/module/canvas/vfx/animations/particle.mjs
+++ b/module/canvas/vfx/animations/particle.mjs
@@ -3,30 +3,6 @@
  * @import {default as CrucibleVFXComponent} from "../components/vfx-component.mjs";
  */
 
-let _blendCurvesSupported = null;
-
-/**
- * FIXME: Pre-14.364 fallback for blend mode curves. ParticleGenerator does not accept
- * `{curve: [...]}` blend descriptors until 14.364; on older versions, degrade to the curve's first
- * value (a static blend mode) so the spell still plays. On 14.364+, pass the curve through unchanged.
- * Remove this shim once 14.364 is publicly released.
- *
- * Feature-detected by scanning the ParticleGenerator class source for the curve-validator's literal
- * error string ("blend.curve must end with time 1.") - more reliable than `isNewerVersion` for dev
- * builds that still report a pre-release version number even with the curve code already merged.
- * @param {number|{curve: Array}} blend  Blend mode literal or curve descriptor.
- * @param {number} fallback              Default blend mode if `blend` is null/undefined.
- * @returns {number|{curve: Array}}
- */
-function _resolveBlend(blend, fallback) {
-  if ( _blendCurvesSupported === null ) {
-    const src = foundry.canvas.animation.ParticleGenerator?.toString() ?? "";
-    _blendCurvesSupported = /#compileBlendValue/.test(src);
-  }
-  if ( _blendCurvesSupported ) return blend ?? fallback;
-  return blend?.curve?.[0]?.value ?? blend ?? fallback;
-}
-
 /**
  * A particle generator layer config. The optional generic parameter describes the shape of `params`.
  * @template [TParams=object]
@@ -56,6 +32,7 @@ function _resolveBlend(blend, fallback) {
  * @typedef CircleParticleGatherParams
  * @property {number} chargeRadius
  * @property {number|{min: number, max: number}} [lifetime]
+ * @property {number} [blend]  Defaults to ADD.
  */
 
 /**
@@ -78,6 +55,7 @@ const circleParticleGather = {
         innerWidth: bandWidth, outerWidth: bandWidth},
       rotation: {alignVelocity: true, spread: 0.2},
       velocity: {speed: [0, 0], angle: [0, 360]},
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD,
       onSpawn: (p, {generator}) => {
         const sceneX = p.x + generator.bounds.x;
         const sceneY = p.y + generator.bounds.y;
@@ -97,15 +75,13 @@ const circleParticleGather = {
  * @property {number} chargeRadius
  * @property {number} [swirlSpeed]    Orbital angular velocity (rad/sec); default 3.
  * @property {number} [spinSpeed]     Self-rotation angular velocity (rad/sec); defaults to swirl.
- * @property {number} [blendOut]      Blend mode to swap to at `blendOutTime` (per-particle mid-life ramp).
- * @property {number} [blendOutTime]  Age (0..1) at which to swap to `blendOut` (default 0.5).
  * @property {{in: number, out: number}} [fade]
+ * @property {number} [blend]  Defaults to ADD.
  */
 
 /**
  * Imploding spiral. Motes orbit the anchor while their radius collapses toward center, spinning on
  * their own axis and fading as they arrive. A small whirlpool drawing energy to a focal point.
- * Optional `blendOut` swaps blend mode at `blendOutTime` for a build-up-to-hot effect.
  * @type {CrucibleParticleBehavior<CircleParticleVortexParams>}
  */
 const circleParticleVortex = {
@@ -116,8 +92,6 @@ const circleParticleVortex = {
     const bandWidth = Math.max(2, chargeRadius * 0.15);
     const swirl = params.swirlSpeed ?? 3;
     const spin = params.spinSpeed ?? swirl;
-    const blendOut = (typeof params.blendOut === "number") ? params.blendOut : null;
-    const blendOutTime = params.blendOutTime ?? 0.5;
 
     // Drive position/rotation parametrically from age so motion continues after the generator soft-stops
     const place = (p, generator) => {
@@ -129,23 +103,19 @@ const circleParticleVortex = {
       p.x = ox + (Math.cos(a) * r);
       p.y = oy + (Math.sin(a) * r);
       p.rotation = p._vortexSpin + (spin * p.elapsedTime * 0.001);
-      if ( !p._vortexSwapped && (blendOut !== null) && (age >= blendOutTime) ) {
-        p.blendMode = blendOut;
-        p._vortexSwapped = true;
-      }
     };
     return {
       area: {type: "ring", x: anchor.x, y: anchor.y, radius: chargeRadius,
         innerWidth: bandWidth, outerWidth: bandWidth},
       velocity: {speed: [0, 0], angle: [0, 360]},
       fade: params.fade ?? {in: 0.15, out: 0.45},
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD,
       onSpawn: (p, {generator}) => {
         const sx = p.x + generator.bounds.x;
         const sy = p.y + generator.bounds.y;
         p._vortexAngle = Math.atan2(sy - anchor.y, sx - anchor.x);
         p._vortexRadius = Math.hypot(sx - anchor.x, sy - anchor.y);
         p._vortexSpin = Math.random() * Math.PI * 2;
-        p._vortexSwapped = false;
         place(p, generator);
       },
       onUpdate: (p, {generator}) => place(p, generator)
@@ -238,7 +208,7 @@ const circleParticleResidue = {
     return {
       area: {type: "circle", x: anchor.x, y: anchor.y, radius},
       velocity: {speed: [speed.min * gridScale, speed.max * gridScale], angle: [0, 360]},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.ADD),
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD,
       drift: {enabled: true, intensity: 0.5}
     };
   }
@@ -306,7 +276,7 @@ const circleParticleBurst = {
       velocity: {speed: [speed.min * gridScale, speed.max * gridScale], angle: [0, 360]},
       rotation: {alignVelocity: false, spread: Math.PI},
       drift: {enabled: true, intensity: 0.5},
-      blend: _resolveBlend(params.blend, 0)
+      blend: params.blend ?? 0
     };
   }
 };
@@ -323,7 +293,7 @@ const circleParticleBurst = {
  * @property {{min: number, max: number}} [rotationSpeed]  Per-particle tumbling (rad/sec).
  * @property {{min: number, max: number}} [lifetime]       Override the reach-derived lifetime.
  * @property {{in: number, out: number}} [fade]
- * @property {number} [blend]
+ * @property {number} [blend]           Defaults to ADD.
  */
 
 /**
@@ -360,7 +330,7 @@ const rayParticleBeam = {
       },
       lifetime: params.lifetime ?? {min: Math.round(reach * 0.85), max: reach},
       fade: params.fade ?? {in: 30, out: 150},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.ADD)
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD
     };
   }
 };
@@ -385,8 +355,7 @@ const rayParticleBeam = {
  *                                          head's march dissipate around the same moment, rather than
  *                                          late-spawning particles outliving early-spawning ones.
  * @property {{in: number, out: number}} [fade]
- * @property {PIXI.BLEND_MODES|ParticleGeneratorBlendValue} [blend]  Static blend mode or over-lifetime
- *   step-curve transition; resolved by the upstream ParticleGenerator.
+ * @property {number} [blend]
  */
 
 /**
@@ -395,8 +364,7 @@ const rayParticleBeam = {
  * passing jet, sparks falling off the front of a beam, or debris jettisoned from a charging line of
  * force. The head position is `origin + heading * headDist`, where `headDist` advances at `headSpeed`
  * (defaulting to "traverse `length` over the layer duration"). Pair with the main beam's BEAM_SPEED to
- * keep the cast-off head visually locked to the jet's leading edge. Pass a `blend` curve to make the
- * leading edge arrive bright (ADD) and cool to NORMAL as particles trail behind.
+ * keep the cast-off head visually locked to the jet's leading edge.
  * @type {CrucibleParticleBehavior<RayParticleHeadCastoffParams>}
  */
 const rayParticleHeadCastoff = {
@@ -427,7 +395,7 @@ const rayParticleHeadCastoff = {
       rotation: rotationCfg,
       ...(params.lifetime ? {lifetime: params.lifetime} : {}),
       fade: params.fade ?? {in: 40, out: 250},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL),
+      blend: params.blend ?? PIXI.BLEND_MODES.NORMAL,
       onTick: (dt, generator) => {
         if ( headDist >= length ) return;
         elapsed += dt;
@@ -481,7 +449,7 @@ const rayParticleRootCastoff = {
       rotation: {alignVelocity: true, spread: params.rotationSpread ?? 0.3},
       lifetime: params.lifetime ? {min: params.lifetime.min, max: params.lifetime.max} : {min: 200, max: 400},
       fade: params.fade ?? {in: 0, out: 150},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.ADD)
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD
     };
   }
 };
@@ -547,7 +515,7 @@ const rayParticleGroundCascade = {
       rotation: {initial: rotation, spread: params.rotationSpread ?? 0.3},
       lifetime,
       fade: params.fade ?? {in: 0, out: 800},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL),
+      blend: params.blend ?? PIXI.BLEND_MODES.NORMAL,
       onTick: dt => {
         elapsed += dt;
         frontDist = Math.clamp(elapsed / duration, 0, 1) * length;
@@ -619,7 +587,7 @@ const shapeParticleCombustion = {
       scale: {min: baseScale.min * gridScale, max: baseScale.max * gridScale, curve: scaleCurve},
       lifetime: params.lifetime ?? {min: 600, max: 1100},
       fade: params.fade ?? {in: 30, out: 350},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.ADD)
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD
     };
   }
 };
@@ -671,7 +639,7 @@ const shapeParticleResidue = {
       scale: {min: baseScale.min * gridScale, max: baseScale.max * gridScale, curve: scaleCurve},
       lifetime: params.lifetime ?? {min: 1800, max: 3000},
       fade: params.fade ?? {in: 200, out: 1200},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL)
+      blend: params.blend ?? PIXI.BLEND_MODES.NORMAL
     };
   }
 };
@@ -724,7 +692,7 @@ const fanParticleSweep = {
       rotation: {alignVelocity: true, spread: 0.1},
       lifetime: (typeof lifetime === "object") ? lifetime : {min: Math.round(lifetime * 0.5), max: lifetime},
       fade: params.fade ?? {in: 30, out: Math.round(reach * 0.4)},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.ADD),
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD,
       onTick: dt => {
         elapsed += dt;
         const t = Math.clamp(elapsed / duration, 0, 1);
@@ -786,7 +754,7 @@ const fanParticleCascade = {
       rotation: {initial: rotation, spread: 0.2},
       lifetime: params.lifetime ?? {min: 400, max: 700},
       fade: params.fade ?? {in: 20, out: 400},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL),
+      blend: params.blend ?? PIXI.BLEND_MODES.NORMAL,
       onTick: (dt, generator) => {
         elapsed += dt;
         const t = Math.clamp(elapsed / duration, 0, 1);
@@ -858,7 +826,7 @@ const fanParticleArcDeposit = {
       velocity: {speed: [0, 0], angle: [0, 360]},
       rotation: {alignVelocity: false, spread: Math.PI},
       fade: params.fade ?? {in: 0, out: 2000},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL),
+      blend: params.blend ?? PIXI.BLEND_MODES.NORMAL,
       onTick: dt => {
         elapsed += dt;
         const t = Math.clamp(elapsed / duration, 0, 1);
@@ -884,10 +852,8 @@ const fanParticleArcDeposit = {
  * @property {number} [reach]           Peak radial extension in px (default state.radius).
  * @property {number} [armSpread]       Per-wisp angular jitter (rad) around its assigned angle (default 0).
  * @property {number} [rotationSpeed]   Per-particle spin (rad/sec); 0 to disable (default 0).
- * @property {number} [blendOut]        Blend mode to swap to at `blendOutTime` for the return trip.
- * @property {number} [blendOutTime]    Age (0..1) at which to swap to `blendOut` (default 0.5).
  * @property {{in: number, out: number}} [fade]
- * @property {number} [blend]
+ * @property {number} [blend]           Defaults to ADD.
  */
 
 /**
@@ -895,8 +861,7 @@ const fanParticleArcDeposit = {
  * Angles are evenly distributed across the cone arc; each particle's radial distance follows
  * `reach * sin(PI * age)`, so all wisps reach peak extension at mid-life and return at end-of-life.
  * Pair with `count: N` + `initial: 1` + `spawnRate: 0` + a fixed `lifetime` to fire one volley with
- * no follow-on spawns. Optional `rotationSpeed` spins each wisp on its own axis; optional `blendOut`
- * swaps blend mode at peak extension for a "hot outbound, cool inbound" look.
+ * no follow-on spawns. Optional `rotationSpeed` spins each wisp on its own axis.
  * @type {CrucibleParticleBehavior<FanParticleYoyoParams>}
  */
 const fanParticleYoyo = {
@@ -907,8 +872,6 @@ const fanParticleYoyo = {
     const reach = params.reach ?? radius;
     const armSpread = params.armSpread ?? 0;
     const rotationSpeed = params.rotationSpeed ?? 0;
-    const blendOut = (typeof params.blendOut === "number") ? params.blendOut : null;
-    const blendOutTime = params.blendOutTime ?? 0.5;
     const angles = [];
     for ( let i = 0; i < count; i++ ) {
       const t = (count === 1) ? 0.5 : (i / (count - 1));
@@ -920,14 +883,13 @@ const fanParticleYoyo = {
       velocity: {speed: [0, 0], angle: [0, 360]},
       rotation: {alignVelocity: false, spread: 0},
       fade: params.fade ?? {in: 0.1, out: 0.2},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL),
+      blend: params.blend ?? PIXI.BLEND_MODES.ADD,
       onSpawn: (p, {generator}) => {
         const base = angles[nextIndex % angles.length];
         nextIndex++;
         const jitter = armSpread ? (((Math.random() - 0.5) * 2) * armSpread) : 0;
         p._yoyoAngle = base + jitter;
         p._yoyoSpin = Math.random() * Math.PI * 2;
-        p._yoyoSwapped = false;
         p.x = origin.x - generator.bounds.x;
         p.y = origin.y - generator.bounds.y;
       },
@@ -937,10 +899,6 @@ const fanParticleYoyo = {
         p.x = (origin.x + (Math.cos(p._yoyoAngle) * r)) - generator.bounds.x;
         p.y = (origin.y + (Math.sin(p._yoyoAngle) * r)) - generator.bounds.y;
         p.rotation = p._yoyoSpin + ((rotationSpeed * p.elapsedTime) / 1000);
-        if ( !p._yoyoSwapped && (blendOut !== null) && (age >= blendOutTime) ) {
-          p.blendMode = blendOut;
-          p._yoyoSwapped = true;
-        }
       }
     };
   }
@@ -987,7 +945,7 @@ const blastParticleFallingDebris = {
       rotation: {spread: params.rotationSpread ?? Math.PI},
       lifetime: params.lifetime ?? {min: 2500, max: 3100},
       fade: params.fade ?? {in: 30, out: 600},
-      blend: _resolveBlend(params.blend, PIXI.BLEND_MODES.NORMAL),
+      blend: params.blend ?? PIXI.BLEND_MODES.NORMAL,
       onSpawn: p => {
         p._baseScale = p.scale.x;
         p.scale.set(p._baseScale * startScale, p._baseScale * startScale);

--- a/module/canvas/vfx/components/vfx-component.mjs
+++ b/module/canvas/vfx/components/vfx-component.mjs
@@ -1,4 +1,5 @@
 import VFXResolvedReferenceField from "../fields/vfx-resolved-reference-field.mjs";
+import CrucibleParticleShader from "../../particles/particle-shader.mjs";
 
 const {ArrayField, BooleanField, ColorField, NumberField, ObjectField, SchemaField, StringField} = foundry.data.fields;
 const {SOUND_ALIGNMENT} = foundry.canvas.vfx.constants;
@@ -554,6 +555,7 @@ export default class CrucibleVFXComponent extends foundry.canvas.vfx.VFXComponen
         const gridScale = this.state.gridScale;
         const config = {
           textures, manual: false, mode: "effect",
+          shaderClass: params.shaderClass ?? CrucibleParticleShader,
           count: params.count ?? null, initial: params.initial ?? 0,
           blend: params.blend ?? 0, tint: params.tint ?? 0xFFFFFF, fade: params.fade,
           spawnRate: params.spawnRate ?? 240,
@@ -565,6 +567,7 @@ export default class CrucibleVFXComponent extends foundry.canvas.vfx.VFXComponen
           pointSourceMask: layer.mask ? (this.mask ?? null) : null,
           ...behavior.setup.call(this, phase, layer)
         };
+        this.#configureParticleExposure(config, params.exposure);
 
         // Apply particle density multipliers to total count, spawn rate, and initial spawn values
         if ( config.count != null ) config.count = Math.max(0, Math.round(config.count * density));
@@ -587,6 +590,89 @@ export default class CrucibleVFXComponent extends foundry.canvas.vfx.VFXComponen
         this._registerTearDown(() => behavior.tearDown.call(this, phase, layer));
       }
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add exposure handling to a particle generator config.
+   * @param {ParticleGeneratorConfiguration} config   Particle generator configuration.
+   * @param {number|object|null} exposure             Exposure config. A value of 0 renders normally.
+   */
+  #configureParticleExposure(config, exposure) {
+    if ( exposure == null ) return;
+
+    const onSpawn = config.onSpawn;
+    const onUpdate = config.onUpdate;
+    const compute = this.#compileParticleExposure(exposure);
+    config.onSpawn = (particle, context) => {
+      onSpawn?.(particle, context);
+      particle.exposure = compute(particle, context);
+    };
+    if ( compute.dynamic || onUpdate ) {
+      config.onUpdate = (particle, context) => {
+        onUpdate?.(particle, context);
+        particle.exposure = compute(particle, context);
+      };
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Compile a particle exposure config into a runtime function.
+   * @param {number|object} exposure  The exposure config.
+   * @returns {function}
+   */
+  #compileParticleExposure(exposure) {
+    if ( typeof exposure === "number" ) {
+      const value = Math.clamp(exposure, -1, 1);
+      const compute = () => value;
+      compute.dynamic = false;
+      return compute;
+    }
+
+    const {min=0, max=min, curve, fn} = exposure;
+    const hasRange = ("min" in exposure) || ("max" in exposure);
+    const compute = (particle, context) => {
+      if ( fn ) return Math.clamp(fn(particle, context), -1, 1);
+      let value = particle._crucibleExposure;
+      if ( value == null ) {
+        value = Math.clamp(min + (this.rng() * (max - min)), -1, 1);
+        particle._crucibleExposure = value;
+      }
+      if ( curve ) {
+        const curveValue = this.#evaluateParticleExposureCurve(curve, particle);
+        value = hasRange ? value * curveValue : curveValue;
+      }
+      return Math.clamp(value, -1, 1);
+    };
+    compute.dynamic = !!(curve || fn);
+    return compute;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Evaluate an exposure curve at the particle's normalized age.
+   * @param {object[]} curve       Exposure curve points.
+   * @param {ParticleMesh} particle
+   * @returns {number}
+   */
+  #evaluateParticleExposureCurve(curve, particle) {
+    const age = particle.lifetime > 0 ? Math.clamp(particle.elapsedTime / particle.lifetime, 0, 1) : 1;
+    let previous = curve[0];
+    for ( let i = 1; i < curve.length; i++ ) {
+      const point = curve[i];
+      if ( age > point.time ) {
+        previous = point;
+        continue;
+      }
+      const span = point.time - previous.time;
+      const t = span > 0 ? Math.clamp((age - previous.time) / span, 0, 1) : 0;
+      return previous.value + ((point.value - previous.value) * t);
+    }
+    return previous.value;
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/vfx/spells.mjs
+++ b/module/canvas/vfx/spells.mjs
@@ -988,17 +988,18 @@ function _buildRayChargeAndDelivery(action, ctx) {
 /* -------------------------------------------- */
 
 /**
- * Helper function to create a blend mode transition curve.
- * @param {number} t    Normalized time [0, 1] when the blend mode cools from ADD to NORMAL
+ * Build a particle exposure curve that starts hot and settles back to normal.
+ * @param {number} t    Normalized time [0, 1] when the particle cools to normal exposure
  * @param {object} [options]
- * @param {number} [options.mode=PIXI.BLEND_MODES.ADD]          The "hot" blend mode
- * @param {boolean} [options.reverse=false]                     Start cool and become "hot" after t
+ * @param {boolean} [options.reverse=false]  Start normal and become hot after t
+ * @param {number} [options.normal=0]        The normal exposure value
+ * @param {number} [options.hot=1]           The hot exposure value
  * @returns {{curve: Array<{time: number, value: number}>}}
  */
-function _blendInHot(t, {mode=PIXI.BLEND_MODES.ADD, reverse=false}={}) {
+function _exposureInHot(t, {reverse=false, normal=0, hot=1.0}={}) {
   const curve = reverse
-    ? [{time: 0, value: PIXI.BLEND_MODES.NORMAL}, {time: t, value: mode}]
-    : [{time: 0, value: mode}, {time: t, value: PIXI.BLEND_MODES.NORMAL}];
+    ? [{time: 0, value: normal}, {time: t, value: hot}]
+    : [{time: 0, value: hot}, {time: t, value: normal}];
   if ( t < 1 ) curve.push({time: 1, value: curve[1].value});
   return {curve};
 }
@@ -1024,7 +1025,8 @@ const _CHARGE_FROST_ICICLES = {
   chargeLayers: [
     {categories: ["spray"], above: true, radiusFactor: 2.0,
       params: {lifetime: 350, spawnRate: 480,
-        alpha: {min: 0.5, max: 1.0}, scale: {min: 0.5, max: 1.0}, blend: _blendInHot(0.5, {reverse: true})}},
+        alpha: {min: 0.5, max: 1.0}, scale: {min: 0.5, max: 1.0},
+        exposure: _exposureInHot(0.5, {reverse: true})}},
     {categories: ["air"], above: false, animation: "circleParticleResidue", radiusFactor: 1.5,
       params: {lifetime: {min: 1500, max: 2200}, spawnRate: 120, count: 30, initial: 0.3,
         alpha: {min: 0.08, max: 0.22}, scale: {min: 0.8, max: 1.4},
@@ -1043,7 +1045,7 @@ const _CHARGE_LIFE_BLOOMS = {
       params: {sort: 0, lifetime: {min: 2000, max: 4000}, spawnRate: 10, scale: {min: 1.0, max: 1.5}}},
     {categories: ["spray"], above: true, radiusFactor: 2.5,
       params: {lifetime: {min: 900, max: 1500}, spawnRate: 80, scale: {min: 0.5, max: 0.8},
-        blend: _blendInHot(0.5)}}
+        exposure: _exposureInHot(0.5)}}
   ]
 };
 
@@ -1522,7 +1524,8 @@ const BLAST_VFX_PROPS = {
             scale: {min: 0.7, max: 1.3}, alpha: {min: 0.4, max: 0.7},
             scaleCurve: [{time: 0, value: 1.0}, {time: 1, value: 1.0}],
             fade: {in: 200, out: 2500},
-            blend: _blendInHot(0.2, {mode: PIXI.BLEND_MODES.MULTIPLY}),
+            blend: PIXI.BLEND_MODES.MULTIPLY,
+            exposure: _exposureInHot(0.2),
             elevation: 0}
         },
         { // Air smoke residue: brown-tinted smoke drifting upward from the explosion
@@ -1556,7 +1559,7 @@ const BLAST_VFX_PROPS = {
     deliverySound: {fade: 500, offset: -300, release: 800},
     impactTiming: "fromCenter",
     buildDelivery(ctx) {
-      const {action, textures, origin, radius, particleElevation, casterElevation} = ctx;
+      const {action, origin, radius, particleElevation, casterElevation} = ctx;
       const runeId = action.rune.id;
       const MAELSTROM_DURATION = this.deliveryDuration;
       return [
@@ -1592,7 +1595,7 @@ const BLAST_VFX_PROPS = {
             spawnRate: 220, lifetime: {min: 1800, max: 2600},
             scale: {min: 0.6, max: 1.1}, alpha: {min: 0.6, max: 0.95},
             fade: {in: 0.1, out: 0.4},
-            blend: _blendInHot(0.7, {reverse: true}),
+            exposure: _exposureInHot(0.7, {reverse: true}),
             elevation: casterElevation + 1}
         },
         { // Drifting bubble residue lingering above as the energy dissipates
@@ -1727,7 +1730,8 @@ const FAN_VFX_PROPS = {
             alpha: {min: 0.25, max: 0.5}, scale: {min: 0.75, max: 1.25},
             lifetime: {min: 5000, max: 7000}, spawnRate: 70, elevation: 0,
             fade: {in: 0, out: 2500},
-            blend: _blendInHot(0.2, {mode: PIXI.BLEND_MODES.MULTIPLY})
+            blend: PIXI.BLEND_MODES.MULTIPLY,
+            exposure: _exposureInHot(0.2)
           }
         },
         { // Sustained SprayEmbers stoking the area with ADD-blend sparks throughout the delivery
@@ -1745,7 +1749,7 @@ const FAN_VFX_PROPS = {
             fade: {in: 30, out: 500}}
         }
       ];
-    },
+    }
   },
 
   // Fan+Life
@@ -1768,7 +1772,7 @@ const FAN_VFX_PROPS = {
           scale: {min: 0.6, max: 1.1}, alpha: {min: 0.6, max: 0.95},
           elevation: casterElevation + 1,
           blend: PIXI.BLEND_MODES.NORMAL,
-          blendOut: PIXI.BLEND_MODES.ADD, blendOutTime: 0.6,
+          exposure: _exposureInHot(0.6, {reverse: true}),
           fade: {in: 0.15, out: 0.45}}
       }];
     },
@@ -1784,8 +1788,7 @@ const FAN_VFX_PROPS = {
             reach: Math.round(radius * 0.9),
             lifetime: {min: sweepDuration, max: sweepDuration},
             rotationSpeed: 5,
-            blend: PIXI.BLEND_MODES.ADD,
-            blendOut: PIXI.BLEND_MODES.NORMAL, blendOutTime: 0.5,
+            exposure: _exposureInHot(0.5),
             alpha: {min: 0.85, max: 1.0}, scale: {min: 1.0, max: 1.3},
             elevation: casterElevation + 1,
             fade: {in: 0.05, out: 0.15}


### PR DESCRIPTION
## Summary

Adds a custom batched particle shader for Crucible with per-particle exposure support. This replaces the old dynamic blend-mode behavior with a cleaner model: blend mode stays static, while exposure controls how hot or dim particles appear over time.

## What Changed

- Added `CrucibleParticleShader` with per-particle `exposure`.
- Uses Foundry-style exposure values: `-1` dark, `0` normal, `1` hot.
- Added support for exposure values, ranges, curves, and callbacks in VFX particles.
- Replaced `_blendInHot` with `_exposureInHot`.
- Removed dynamic blend-mode compatibility code and obsolete swap flags.
- Kept `NORMAL` and `MULTIPLY` blends explicit where needed. Otherwise particles use their behavior defaults => `ADD`