### PR TITLE
add tooltip to weapon category

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2650,6 +2650,13 @@
       "ReloadTooltip": "This weapon requires reloading in order to strike. When the weapon is not loaded, any actions which use the weapon cost +1 Action Points.",
       "Returning": "Returning",
       "ReturningTooltip": "This weapon is magically or mechanically engineered to return to your hand after being thrown. Using the Throw Weapon action with this weapon does not result in it becoming Dropped.",
+      "TrainedTooltip": "This weapon uses {training} training and scales with {scaling}. This weapon needs {hands} to use.",
+      "TrainedTooltipHands": {
+        "one": "one hand",
+        "both": "both hands",
+        "main": "the main hand",
+        "offhand": "the offhand"
+      },
       "Thrown": "Thrown",
       "ThrownTooltip": "This weapon is designed to be suitable for throwing and does not suffer the Banes penalty that is usually applied to the Throw Weapon action.",
       "UntrainedTooltip": "Your character lacks {training} weapon training and suffers a -4 Skill penalty when attacking with this weapon.",

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -513,6 +513,25 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     if ( (item.type === "weapon") && config.equipped ) {
       const tooltip = item.system._getUntrainedTooltip(this.actor);
       if ( tooltip ) config.tags.category = {label: config.tags.category, unmet: true, tooltip};
+      else {
+        console.log(item);
+        const category = SYSTEM.WEAPON.CATEGORIES[item.system.category];
+        const trainingLabels = category.training.map(t => _loc(SYSTEM.WEAPON.TRAINING[t].label));
+        const training = game.i18n.getListFormatter({type: "disjunction"}).format(trainingLabels);
+        const scalingLabels = category.scaling.split(".").map(s => _loc(SYSTEM.ABILITIES[s].label));
+        const scaling = game.i18n.getListFormatter({type: "conjunction"}).format(scalingLabels);
+        let hands;
+        if (category.hands === 2) {
+          hands = _loc("WEAPON.TAGS.TrainedTooltipHands.both");
+        } else if (category.main && category.off) {
+          hands = _loc("WEAPON.TAGS.TrainedTooltipHands.one");
+        } else if (category.main) {
+          hands = _loc("WEAPON.TAGS.TrainedTooltipHands.main");
+        } else {
+          hands = _loc("WEAPON.TAGS.TrainedTooltipHands.offhand");
+        }
+        config.tags.category = {label: config.tags.category, tooltip: _loc("WEAPON.TAGS.TrainedTooltip", {training, scaling, hands})};
+      }
     }
   }
 


### PR DESCRIPTION
closes #1139 
example tooltips added by this PR:
<img width="315" height="143" alt="image" src="https://github.com/user-attachments/assets/810fbd96-583d-4a99-b470-f93a3146f31e" />
<img width="316" height="122" alt="image" src="https://github.com/user-attachments/assets/d3baf9c6-95a2-4abc-865c-7310082e462c" />
<img width="320" height="143" alt="image" src="https://github.com/user-attachments/assets/b1fdb040-f08a-476f-a14d-615acf854885" />
<img width="322" height="127" alt="image" src="https://github.com/user-attachments/assets/a5e8a39e-916b-468d-8249-ed3bd92377d8" />
