### PR TITLE
[#1208] Allow editing non-embedded affix identifier, disable field on embedded affixes to prevent accidental no-op "updates"

### DIFF
--- a/module/applications/sheets/effect-affix-sheet.mjs
+++ b/module/applications/sheets/effect-affix-sheet.mjs
@@ -114,6 +114,7 @@ export default class CrucibleAffixEffectSheet extends api.HandlebarsApplicationM
         context.fields = effect.system.schema.fields;
         context.isEditable = this.isEditable;
         context.fieldDisabled = this.isEditable ? "" : "disabled";
+        context.identifierLocked = !!this.document.parent;
         context.itemTypeOptions = Array.from(SYSTEM.ITEM.AFFIXABLE_ITEM_TYPES).map(t => ({
           value: t, label: _loc(CONFIG.Item.typeLabels[t] ?? t)
         }));

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -148,12 +148,14 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
 
     // Affix effects specifically
     if ( this.type === "affix" ) {
-      if ( ("system" in changes) && ("identifier" in changes.system)
+      if ( "duration" in changes ) changes.duration = {value: null};
+
+      // Disallow changing identifier for embedded affixes
+      if ( this.parent && ("system" in changes) && ("identifier" in changes.system)
         && (changes.system.identifier !== this.system.identifier) ) {
         console.warn("The identifier of an existing affix cannot be changed.");
         return false;
       }
-      if ( "duration" in changes ) changes.duration = {value: null};
     }
   }
 

--- a/templates/sheets/effect/affix-config.hbs
+++ b/templates/sheets/effect/affix-config.hbs
@@ -2,7 +2,7 @@
          data-tab="{{tab.id}}" data-group="{{tab.group}}">
     <fieldset {{fieldDisabled}}>
         <legend>{{localize "AFFIX.ConfigIdentity"}}</legend>
-        {{formGroup fields.identifier value=source.system.identifier}}
+        {{formGroup fields.identifier value=source.system.identifier disabled=identifierLocked}}
         {{formGroup fields.affixType value=source.system.affixType localize=true}}
         {{formGroup fields.adjective value=source.system.adjective}}
         {{formGroup fields.itemTypes value=source.system.itemTypes type="checkboxes" stacked=true options=itemTypeOptions}}


### PR DESCRIPTION
Closes #1208 
Now affix identifiers can be changed in an AE Compendium context, and the UI won't even allow such changes in an embedded context.