### PR TITLE
[#1174] Ensure creating an effect via the token HUD's status effect panel results in an effect whose icon matches that of the status clicked

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -39,6 +39,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
     if ( status?.generator ) {
       const generated = status.generator();
       delete generated._id; // Preserve toggled _id
+      delete generated.img; // Preserve toggled icon to avoid confusion
       foundry.utils.mergeObject(effectData, generated, {overwrite: true});
       effectData.duration = {}; // Toggled effects have unlimited duration
     }


### PR DESCRIPTION
Closes #1174 
Only really relevant for Staggered and Suffocating, as all the other generated statuses aren't available via the token hud. But for those two, when created that way, their icon should match what was just clicked.