### PR TITLE
[#1147] Ensure actor sheet cannot be resized by resizing browser window

### DIFF
--- a/styles/actor.less
+++ b/styles/actor.less
@@ -30,6 +30,11 @@
     }
   }
 
+  &:not(.minimized,.minimizing,.maximizing) {
+    min-width: 900px;
+    min-height: 760px;
+  }
+
   // Sheet body
   .sheet-body {
     display: flex;

--- a/styles/item.less
+++ b/styles/item.less
@@ -134,7 +134,7 @@
 }
 
 // Make item sheet body resizable
-.crucible.item:not(.minimized) {
+.crucible.item:not(.minimized,.minimizing,.maximizing) {
   min-width: 560px;
   min-height: 400px;
   .sheet-body {


### PR DESCRIPTION
Closes #1147 
Also amend similar logic already used for item sheet so that item sheets minimize & maximize more smoothly.
Perhaps in the future we can investigate resizability of the actor sheet, but for now I think a static size makes sense, and we just need to enforce that with css.