### PR TITLE
[#1116] Ensure hazard & roll dialogs are properly styled in firefox

### DIFF
--- a/module/dice/hazard-dialog.mjs
+++ b/module/dice/hazard-dialog.mjs
@@ -241,7 +241,9 @@ export default class HazardDialog extends ActionUseDialog {
    */
   static async #onHazardConfigToggle(_event) {
     this.#configureHazard = !this.#configureHazard;
-    await this.render({window: {title: this.title}});
+    const remInPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const offset = (this.#configureHazard ? -1 : 1) * (remInPx + 240);
+    await this.render({window: {title: this.title}, position: {left: this.position.left + offset}});
   }
 
   /* -------------------------------------------- */

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -647,7 +647,9 @@ export default class StandardCheckDialog extends DialogV2 {
         this.#selectedSkills.set(currentSkill, null);
       }
     }
-    await this.render({window: {title: this.title}});
+    const remInPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const offset = (this.customizeSkills ? -1 : 1) * (remInPx + 240);
+    await this.render({window: {title: this.title}, position: {left: this.position.left + offset}});
   }
 
   /* -------------------------------------------- */

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -471,6 +471,7 @@
             }
           }
           .crucible-rank-pips {
+            flex-wrap: wrap;
             flex: 0 0 100px;
             justify-content: center;
             gap: 4px 2px;

--- a/styles/dice.less
+++ b/styles/dice.less
@@ -8,6 +8,7 @@
   .standard-check {
     padding: 1rem;
     gap: 1rem;
+    width: calc(360px + 2rem);
     .roll-form {
       width: 360px;
     }
@@ -20,6 +21,7 @@
   .standard-check.select-targets {
     flex-direction: row;
     flex-wrap: wrap;
+    width: calc(600px + 3rem);
     .roll-form {
       flex: none;
     }
@@ -29,11 +31,17 @@
     }
   }
 
+  .standard-check.roll-request.customize-skills,
+  .standard-check.configure-hazard.select-targets {
+    width: calc(840px + 4rem);
+  }
+
   /** Side panel shared layout */
   .standard-check .request-form,
   .standard-check .skills-form,
   .standard-check .hazard-config-form,
   .standard-check .hazard-targets-form {
+    width: 240px;
     flex: 0 0 240px;
     h3.divider {
       margin: 0 0 -0.5rem 0;

--- a/styles/theme.less
+++ b/styles/theme.less
@@ -432,6 +432,7 @@
 
   .crucible-rank-pips {
     justify-content: space-between;
+    flex-wrap: nowrap;
     --pip-size: 14px;
     --pip-border: 1px;
     --pip-dot-margin: 2px;


### PR DESCRIPTION
Closes #1116 
Three parts to this.
1. Unrelated to the issue, now when we toggle the left panel of the hazard or roll dialog, the rest of the dialog stays in the same relative spot (adjust `left` by what the width will change by).
2. The pips wrapping like crazy in firefox: Now by default `.crucible-rank-pips` have `flex-wrap: nowrap`, and we change it in the one spot that we actually want wrapping: the actor sheet styles.
3. The unexpected wrapping of paneled dialogs & unexpectedly _loooong_ hazard dialog: Hardcoded width for standard check without panels, standard check with at least one panel, standard check with both possible panels. I hate it, because it feels like it _should be automatic_, and indeed in chrome it is. I hate it, because if we ever change the base size of the panels, we need to change these styles too. But it is a solution to the firefox css issue, and it plays nice with font size scaling, so I think it's better than letting the bug exist.