### PR TITLE
revert erroneous usage of the Condition enricher

### DIFF
--- a/_source/equipment/Alchemist_s_Fire_alchemistsFire00.yml
+++ b/_source/equipment/Alchemist_s_Fire_alchemistsFire00.yml
@@ -26,7 +26,7 @@ system:
       img: icons/consumables/potions/bottle-round-corked-yellow.webp
       condition: ''
       description: >-
-        <p>You hurl the @ref[name], dealing @Condition[weakened] immediate
+        <p>You hurl the @ref[name], dealing <strong>Weakened</strong> immediate
         damage but causing the @Condition[burning] condition to all enemies in a
         4 foot radius <strong>Blast</strong> who fail to avoid the
         attack.</p><p>The amount of burning damage and its duration is dependent
@@ -61,6 +61,7 @@ system:
             value: 3
             units: rounds
             expiry: turnEnd
+            expired: false
           result:
             type: success
             all: false
@@ -70,6 +71,8 @@ system:
             regions: []
             summons: []
             changes: []
+            dc: null
+            properties: []
       tags:
         - consume
         - weakened
@@ -96,11 +99,11 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.9.5
   createdTime: 1772307157757
-  modifiedTime: 1776980754314
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1781394998737
+  lastModifiedBy: fzBjA63BB4hW4rQb
 sort: 500000
 _key: '!items!alchemistsFire00'

--- a/_source/equipment/Caustic_Phial_causticPhial0000.yml
+++ b/_source/equipment/Caustic_Phial_causticPhial0000.yml
@@ -26,7 +26,7 @@ system:
       img: icons/consumables/potions/bottle-conical-fumes-green.webp
       condition: ''
       description: >-
-        <p>You fling the @ref[name], dealing @Condition[weakened] immediate
+        <p>You fling the @ref[name], dealing <strong>Weakened</strong> immediate
         damage but causing the @Condition[corroding] condition to all enemies in
         a 4 foot radius <strong>Blast</strong> who fail to avoid the
         attack.</p><p>The amount of burning damage and its duration is dependent
@@ -61,6 +61,7 @@ system:
             value: 3
             units: rounds
             expiry: turnEnd
+            expired: false
           result:
             type: success
             all: false
@@ -70,6 +71,8 @@ system:
             regions: []
             summons: []
             changes: []
+            dc: null
+            properties: []
       tags:
         - consume
         - weakened
@@ -96,12 +99,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.9.5
   createdTime: 1772307157760
-  modifiedTime: 1776980754313
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1781395012898
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: causticPhial0000
 sort: 100000
 _key: '!items!causticPhial0000'

--- a/_source/talent/Headbutt_headbutt00000000.yml
+++ b/_source/talent/Headbutt_headbutt00000000.yml
@@ -15,8 +15,8 @@ system:
         <strong>Fortitude</strong> defense of an adjacent enemy. If your
         <strong>Initiative</strong> is superior to that of your target, you gain
         <strong>+1 Boon</strong> to this attack.</p><p>The attack is
-        <strong>Difficult</strong> and only deals @Condition[weakened] damage,
-        but if successful it inflicts the @Condition[staggered] for one
+        <strong>Difficult</strong> and only deals <strong>Weakened</strong>
+        damage, but if successful it inflicts the @Condition[staggered] for one
         round.</p><p>This action always uses an Unarmed weapon, even if your
         weapon slots are otherwise occupied.</p>
       cost:
@@ -53,6 +53,8 @@ system:
             maintenance: null
             regions: []
             summons: []
+            dc: null
+            properties: []
       tags:
         - melee
         - difficult
@@ -77,12 +79,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.9.5
   createdTime: 1776117265442
-  modifiedTime: 1776117522179
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1781395064389
+  lastModifiedBy: fzBjA63BB4hW4rQb
 ownership:
   default: 0
   AnoypGxxNIMOS0XY: 3


### PR DESCRIPTION
addresses the erroneous usage of @Condition[weakened] mentioned in https://github.com/foundryvtt/crucible/issues/1166
there also were some changes to the formatting of the yamls after building and then exporting. I could remove those from the PR, but they don't affect anything and will appear whenever we try to export descriptions.