### PR TITLE
fix physical defense calculation

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -712,7 +712,7 @@ export default class CrucibleActor extends Actor {
       if ( r <= parry ) return results.PARRY;
 
       // Block
-      const block = dodge + d.block.total;
+      const block = parry + d.block.total;
       if ( r <= block ) return results.BLOCK;
 
       // Armor


### PR DESCRIPTION
usage of `dodge` instead of `parry` in the calculation of `block` constant resulted in the a portion of Block up to the value of Parry essentially being converted to Armor