### PR TITLE
[#1270] Localize default 'DC' label for unknown defense type

### DIFF
--- a/module/dice/attack-roll.mjs
+++ b/module/dice/attack-roll.mjs
@@ -148,7 +148,7 @@ export default class AttackRoll extends StandardCheck {
     const defense = SYSTEM.DEFENSES[dt];
     if ( defense ) cardData.defenseType = defense.shortLabel ?? defense.label;
     else if ( dt in SYSTEM.SKILLS ) cardData.defenseType = SYSTEM.SKILLS[dt].label;
-    else cardData.defenseType = this.constructor.DEFENSE_TYPE;
+    else cardData.defenseType = _loc("DICE.DC");
     if ( game.user.isGM ) cardData.targetLabel = `${cardData.defenseType} ${cardData.dc}`;
 
     // Roll result

--- a/module/dice/attack-roll.mjs
+++ b/module/dice/attack-roll.mjs
@@ -148,7 +148,7 @@ export default class AttackRoll extends StandardCheck {
     const defense = SYSTEM.DEFENSES[dt];
     if ( defense ) cardData.defenseType = defense.shortLabel ?? defense.label;
     else if ( dt in SYSTEM.SKILLS ) cardData.defenseType = SYSTEM.SKILLS[dt].label;
-    else cardData.defenseType = "DC";
+    else cardData.defenseType = this.constructor.DEFENSE_TYPE;
     if ( game.user.isGM ) cardData.targetLabel = `${cardData.defenseType} ${cardData.dc}`;
 
     // Roll result

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -100,10 +100,12 @@ export default class StandardCheck extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * The defense type label used when rendering this check.
+   * The localized defense type label used when rendering this check.
    * @type {string}
    */
-  static DEFENSE_TYPE = "DC";
+  static get DEFENSE_TYPE() {
+    return _loc("DICE.DC");
+  }
 
   /* -------------------------------------------- */
 

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -100,16 +100,6 @@ export default class StandardCheck extends Roll {
   /* -------------------------------------------- */
 
   /**
-   * The localized defense type label used when rendering this check.
-   * @type {string}
-   */
-  static get DEFENSE_TYPE() {
-    return _loc("DICE.DC");
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Default timeout for remote roll requests.
    * @type {number}
    */
@@ -324,7 +314,7 @@ export default class StandardCheck extends Roll {
   prepareDiceResultContext({targetLabel}={}) {
     const {outcome, classes} = this.prepareOutcome();
     const dc = this.data.dc;
-    const defenseType = this.constructor.DEFENSE_TYPE;
+    const defenseType = _loc("DICE.DC");
     const damage = this.prepareRenderedDamage();
     if ( damage?.display ) classes.push("damage");
     if ( targetLabel === undefined ) {


### PR DESCRIPTION
Closes #1270 
Had to make it a getter to be able to localize. Also, used it in the attack roll class instead of hardcoding the localization there again.