### PR TITLE
[#750] Enable locking talent descriptions in tree via middle-mouse

### DIFF
--- a/module/canvas/tree/talent-tree-node.mjs
+++ b/module/canvas/tree/talent-tree-node.mjs
@@ -116,7 +116,7 @@ export default class CrucibleTalentTreeNode extends CrucibleTalentIcon {
 
     // If a talent's description is locked, unlock it & pseudo-hover rather than (de)activating node
     if ( tree.hud.target?.isLocked ) {
-      tree.hud.target.toggleLock(false);
+      tree.hud.target.toggleLock();
       this._onPointerOver(event);
       return;
     }

--- a/module/canvas/tree/talent-tree-node.mjs
+++ b/module/canvas/tree/talent-tree-node.mjs
@@ -113,10 +113,17 @@ export default class CrucibleTalentTreeNode extends CrucibleTalentIcon {
     event.stopPropagation();
     if ( event.data.originalEvent.button !== 0 ) return; // Only support standard left-click
     const tree = game.system.tree;
-    const ownedTalents = tree.actor.system.talentNodes[this.node.id] || [];
-    const nodeTalents = new Set([...this.node.talents, ...ownedTalents]);
+
+    // If a talent's description is locked, unlock it & pseudo-hover rather than (de)activating node
+    if ( tree.hud.target?.isLocked ) {
+      tree.hud.target.toggleLock(false);
+      this._onPointerOver(event);
+      return;
+    }
 
     // Toggle node active state
+    const ownedTalents = tree.actor.system.talentNodes[this.node.id] || [];
+    const nodeTalents = new Set([...this.node.talents, ...ownedTalents]);
     if ( !nodeTalents.size ) return this.#onToggleEmptyNode();
     if ( this.isActive ) tree.deactivateNode({event, hover: false});
     else tree.activateNode(this, {event});
@@ -131,7 +138,9 @@ export default class CrucibleTalentTreeNode extends CrucibleTalentIcon {
    */
   _onPointerOver(event) {
     const tree = crucible.tree;
-    if ( !tree.rendering || (event.nativeEvent.target !== tree.canvas) ) return;
+
+    // Ignore pointerOver if tree not rendered, event not over tree, or a talent's description is locked
+    if ( !tree.rendering || (event.nativeEvent.target !== tree.canvas) || tree.hud.target?.isLocked ) return;
     tree.hud.activate(this);
     const s = (this.config.size + 8) / this.config.size;
     this.scale.set(s, s);
@@ -150,7 +159,9 @@ export default class CrucibleTalentTreeNode extends CrucibleTalentIcon {
    */
   _onPointerOut(event) {
     const tree = game.system.tree;
-    if ( !tree.rendering || (event.nativeEvent.target !== tree.canvas) ) return;
+
+    // Ignore pointerOut if tree not rendered, event not over tree, or a talent's description is locked
+    if ( !tree.rendering || (event.nativeEvent.target !== tree.canvas) || tree.hud.target?.isLocked ) return;
     tree.hud.clear();
     if ( this.isActive ) return; // Don't un-hover an active node
     this.scale.set(1.0, 1.0);

--- a/module/canvas/tree/talent-tree-talent.mjs
+++ b/module/canvas/tree/talent-tree-talent.mjs
@@ -11,6 +11,28 @@ export default class CrucibleTalentTreeTalent extends CrucibleTalentIcon {
 
   /* -------------------------------------------- */
 
+  /**
+   * Whether this talent's description should be locked
+   * @type {boolean}
+   */
+  #locked = false;
+
+  /**
+   * Whether this talent's description would be displayed if not locked
+   * @type {boolean}
+   */
+  #showIfUnlocked = false;
+
+  /**
+   * Whether this talent's description is locked
+   * @type {boolean}
+   */
+  get isLocked() {
+    return this.#locked;
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   _configure({active, accessible, ...config}={}) {
     config = super._configure(config);
@@ -77,14 +99,46 @@ export default class CrucibleTalentTreeTalent extends CrucibleTalentIcon {
 
   /* -------------------------------------------- */
 
+  /**
+   * Toggle description lock state. If unlocking & not still hovered, act as if hovered out
+   */
+  toggleLock() {
+    this.#locked = !this.#locked;
+    crucible.tree.hud.classList.toggle("locked", this.#locked);
+    if ( !this.#locked && !this.#showIfUnlocked ) {
+      this.scale.set(1.0, 1.0);
+      crucible.tree.hud.clear();
+    }
+  }
+
+  /* -------------------------------------------- */
+
   #activateInteraction() {
     this.removeAllListeners();
     this.on("pointerover", this.#onPointerOver.bind(this));
     this.on("pointerout", this.#onPointerOut.bind(this));
-    this.on("pointerdown", this.#onClickLeft.bind(this));
+    this.on("pointerdown", this.#onPointerDown.bind(this));
     this.on("rightdown", this.#onClickRight.bind(this));
     this.eventMode = "static";
     this.cursor = "pointer";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle left-click or middle-click events on a Talent icon to lock description or add talent to Actor.
+   * @param {PIXI.InteractionEvent} event
+   */
+  async #onPointerDown(event) {
+    event.stopPropagation();
+    switch ( event.data.originalEvent.button ) {
+      case 0:
+        this.#onClickLeft(event);
+        break;
+      case 1:
+        if ( crucible.tree.hud.target === this ) this.toggleLock();
+        break;
+    }
   }
 
   /* -------------------------------------------- */
@@ -95,9 +149,15 @@ export default class CrucibleTalentTreeTalent extends CrucibleTalentIcon {
    * @returns {Promise<void>}
    */
   async #onClickLeft(event) {
-    event.stopPropagation();
-    if ( event.data.originalEvent.button !== 0 ) return; // Only support standard left-click
     const tree = game.system.tree;
+
+    // If a talent description is locked, unlock it, and do nothing more if that talent isn't the clicked one
+    if ( tree.hud.target?.isLocked ) {
+      const lockedTalent = tree.hud.target;
+      lockedTalent.toggleLock();
+      this.#onPointerOver(event);
+      if ( lockedTalent !== this ) return;
+    }
     const actor = tree.actor;
     if ( !actor ) return;
     if ( !actor || actor.talentIds.has(this.talent.id) ) return;
@@ -129,8 +189,10 @@ export default class CrucibleTalentTreeTalent extends CrucibleTalentIcon {
    */
   #onPointerOver(event) {
     const tree = crucible.tree;
-    if ( event.nativeEvent.target !== tree.canvas ) return;
+    if ( (event.nativeEvent.target !== tree.canvas) ) return;
+    if ( tree.hud.target?.isLocked ) return;
     event.stopPropagation();
+    this.#showIfUnlocked = true;
     this.scale.set(1.2, 1.2);
     tree.hud.activate(this);
   }
@@ -143,6 +205,8 @@ export default class CrucibleTalentTreeTalent extends CrucibleTalentIcon {
    */
   #onPointerOut(event) {
     event.stopPropagation();
+    this.#showIfUnlocked = false;
+    if ( crucible.tree.hud.target?.isLocked ) return;
     this.scale.set(1.0, 1.0);
     game.system.tree.hud.clear();
   }

--- a/module/canvas/tree/talent-tree.mjs
+++ b/module/canvas/tree/talent-tree.mjs
@@ -612,12 +612,13 @@ export default class CrucibleTalentTree extends PIXI.Container {
   /* -------------------------------------------- */
 
   /**
-   * Handle left-click events on the talent tree
+   * Handle left-click events on the talent tree, unlocking a locked talent description or deactivating the active node
    * @param {PIXI.FederatedEvent}   event
    */
   #onClickLeft(event) {
     event.stopPropagation();
-    this.deactivateNode({event});
+    if ( this.hud.target?.isLocked ) this.hud.target.toggleLock();
+    else this.deactivateNode({event});
   }
 
   /* -------------------------------------------- */

--- a/styles/hud.less
+++ b/styles/hud.less
@@ -34,6 +34,10 @@
   border-image-width: 32px;
   box-sizing: content-box;
 
+  &.locked {
+    box-shadow: 0 0 2rem var(--color-border-highlight);
+  }
+
   .node header {
     gap: 0.5rem;
   }


### PR DESCRIPTION
Closes #750

I expect there may be some refinement of this mechanism & styling, but currently:
- Middle mouse locks the hovered talent's description
- Locked talent descriptions have a box shadow highlight
- While a talent is locked, hover events are skipped for other Talents or Nodes
- Left clicking any other talent, any other node, or any blank space on the tree unlocks, but does not perform the left click interaction
- Left clicking the locked talent unlocks & performs the left click interaction
- Right clicking does nothing, but right click dragging & scrolling is still possible with a description locked

I did _not_ implement locking _node_ tooltips, but maybe we should just for consistency.