### PR TITLE
Align sheet `TABS` with core `ApplicationV2` spec

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -219,11 +219,11 @@
       "Title": "Aktion"
     },
     "TABS": {
-      "Description": "Beschreibung",
-      "Effects": "Effekte",
-      "Hooks": "Hooks",
-      "Target": "Ziel",
-      "Usage": "Verwendung"
+      "description": "Beschreibung",
+      "effects": "Effekte",
+      "hooks": "Hooks",
+      "target": "Ziel",
+      "usage": "Verwendung"
     },
     "TAG": {
       "Accurate": "Präzise",
@@ -807,14 +807,14 @@
       "Resources": "Ressourcen"
     },
     "TABS": {
-      "Actions": "Aktionen",
-      "Attributes": "Attribute",
-      "Biography": "Biografie",
-      "Effects": "Effekte",
-      "Inventory": "Inventar",
-      "Skills": "Fertigkeiten",
-      "Spells": "Zauber",
-      "Talents": "Talente"
+      "actions": "Aktionen",
+      "attributes": "Attribute",
+      "biography": "Biografie",
+      "effects": "Effekte",
+      "inventory": "Inventar",
+      "skills": "Fertigkeiten",
+      "spells": "Zauber",
+      "talents": "Talente"
     },
     "WARNINGS": {
       "InsufficientCurrency": "Nicht genügend Währung, um {delta} {denom} abzuziehen.",
@@ -1554,15 +1554,15 @@
       "Type": "Ausrüstungstyp"
     },
     "TABS": {
-      "Actions": "Aktionen",
-      "Affixes": "Affixe",
-      "Configuration": "Konfiguration",
-      "Description": "Beschreibung",
-      "Equipment": "Ausrüstung",
-      "Hooks": "Hooks",
-      "Secrets": "Geheimnisse",
-      "Spells": "Zauber",
-      "Talents": "Talente"
+      "actions": "Aktionen",
+      "affixes": "Affixe",
+      "config": "Konfiguration",
+      "description": "Beschreibung",
+      "equipment": "Ausrüstung",
+      "hooks": "Hooks",
+      "secrets": "Geheimnisse",
+      "spells": "Zauber",
+      "talents": "Talente"
     },
     "WARNINGS": {
       "HookAlreadyExists": "{item} deklariert bereits eine Funktion für den Hook \"{hook}\".",

--- a/lang/en.json
+++ b/lang/en.json
@@ -241,11 +241,11 @@
       "ItemDivested": "Divested"
     },
     "TABS": {
-      "Description": "Description",
-      "Effects": "Effects",
-      "Hooks": "Hooks",
-      "Target": "Target",
-      "Usage": "Usage"
+      "description": "Description",
+      "effects": "Effects",
+      "hooks": "Hooks",
+      "target": "Target",
+      "usage": "Usage"
     },
     "TAG": {
       "Accurate": "Accurate",
@@ -943,14 +943,14 @@
       "Resources": "Resources"
     },
     "TABS": {
-      "Actions": "Actions",
-      "Attributes": "Attributes",
-      "Biography": "Biography",
-      "Effects": "Effects",
-      "Inventory": "Inventory",
-      "Skills": "Skills",
-      "Spells": "Spells",
-      "Talents": "Talents"
+      "actions": "Actions",
+      "attributes": "Attributes",
+      "biography": "Biography",
+      "effects": "Effects",
+      "inventory": "Inventory",
+      "skills": "Skills",
+      "spells": "Spells",
+      "talents": "Talents"
     },
     "WARNINGS": {
       "InsufficientCurrency": "Insufficient currency to deduct {delta} {denom}",
@@ -1789,15 +1789,15 @@
       "Type": "Equipment Type"
     },
     "TABS": {
-      "Actions": "Actions",
-      "Affixes": "Affixes",
-      "Configuration": "Configuration",
-      "Description": "Description",
-      "Equipment": "Equipment",
-      "Hooks": "Hooks",
-      "Secrets": "Secrets",
-      "Spells": "Spells",
-      "Talents": "Talents"
+      "actions": "Actions",
+      "affixes": "Affixes",
+      "config": "Configuration",
+      "description": "Description",
+      "equipment": "Equipment",
+      "hooks": "Hooks",
+      "secrets": "Secrets",
+      "spells": "Spells",
+      "talents": "Talents"
     },
     "WARNINGS": {
       "CombineDifferent": "{item} cannot be combined with {target} because the items are not identical.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -241,11 +241,11 @@
       "ItemDivested": "Zbycie"
     },
     "TABS": {
-      "Description": "Opis",
-      "Effects": "Efekty",
-      "Hooks": "Uchwyty",
-      "Target": "Cel",
-      "Usage": "Użycie"
+      "description": "Opis",
+      "effects": "Efekty",
+      "hooks": "Uchwyty",
+      "target": "Cel",
+      "usage": "Użycie"
     },
     "TAG": {
       "Accurate": "Dokładny",
@@ -943,14 +943,14 @@
       "Resources": "Zasoby"
     },
     "TABS": {
-      "Actions": "Akcje",
-      "Attributes": "Atrybuty",
-      "Biography": "Biografia",
-      "Effects": "Efekty",
-      "Inventory": "Wyposażenie",
-      "Skills": "Umiejętności",
-      "Spells": "Zaklęcia",
-      "Talents": "Talenty"
+      "actions": "Akcje",
+      "attributes": "Atrybuty",
+      "biography": "Biografia",
+      "effects": "Efekty",
+      "inventory": "Wyposażenie",
+      "skills": "Umiejętności",
+      "spells": "Zaklęcia",
+      "talents": "Talenty"
     },
     "WARNINGS": {
       "InsufficientCurrency": "Brak wystarczającej kwoty do obciążenia {delta} {denom}",
@@ -1789,15 +1789,15 @@
       "Type": "Typ wyposażenia"
     },
     "TABS": {
-      "Actions": "Akcje",
-      "Affixes": "Afiksy",
-      "Configuration": "Konfiguracja",
-      "Description": "Opis",
-      "Equipment": "Wyposażenie",
-      "Hooks": "Uchwyty",
-      "Secrets": "Sekrety",
-      "Spells": "Zaklęcia",
-      "Talents": "Talenty"
+      "actions": "Akcje",
+      "affixes": "Afiksy",
+      "config": "Konfiguracja",
+      "description": "Opis",
+      "equipment": "Wyposażenie",
+      "hooks": "Uchwyty",
+      "secrets": "Sekrety",
+      "spells": "Zaklęcia",
+      "talents": "Talenty"
     },
     "WARNINGS": {
       "CombineDifferent": "{item} nie można połączyć z {target}, ponieważ przedmioty te nie są identyczne.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -228,11 +228,11 @@
       "ItemDivested": "Изъят"
     },
     "TABS": {
-      "Description": "Описание",
-      "Effects": "Эффекты",
-      "Hooks": "Хуки",
-      "Target": "Цель",
-      "Usage": "использование"
+      "description": "Описание",
+      "effects": "Эффекты",
+      "hooks": "Хуки",
+      "target": "Цель",
+      "usage": "использование"
     },
     "TAG": {
       "Accurate": "Точный",
@@ -842,14 +842,14 @@
       "Resources": "Ресурсы"
     },
     "TABS": {
-      "Actions": "Действия",
-      "Attributes": "Атрибуты",
-      "Biography": "Биография",
-      "Effects": "Эффекты",
-      "Inventory": "Инвентарь",
-      "Skills": "Навыки",
-      "Spells": "Заклинания",
-      "Talents": "Таланты"
+      "actions": "Действия",
+      "attributes": "Атрибуты",
+      "biography": "Биография",
+      "effects": "Эффекты",
+      "inventory": "Инвентарь",
+      "skills": "Навыки",
+      "spells": "Заклинания",
+      "talents": "Таланты"
     },
     "WARNINGS": {
       "InsufficientCurrency": "Недостаточно валюты для вычета {delta} {denom}",
@@ -1648,15 +1648,15 @@
       "Type": "Тип снаряжения"
     },
     "TABS": {
-      "Actions": "Действия",
-      "Affixes": "Аффиксы",
-      "Configuration": "Конфигурация",
-      "Description": "Описание",
-      "Equipment": "Снаряжение",
-      "Hooks": "Хуки",
-      "Secrets": "Секреты",
-      "Spells": "Заклинания",
-      "Talents": "Таланты"
+      "actions": "Действия",
+      "affixes": "Аффиксы",
+      "config": "Конфигурация",
+      "description": "Описание",
+      "equipment": "Снаряжение",
+      "hooks": "Хуки",
+      "secrets": "Секреты",
+      "spells": "Заклинания",
+      "talents": "Таланты"
     },
     "WARNINGS": {
       "HookAlreadyExists": "{item} уже объявляет функцию для хука \"{hook}\".",

--- a/module/applications/config/action-config.mjs
+++ b/module/applications/config/action-config.mjs
@@ -81,23 +81,19 @@ export default class CrucibleActionConfig extends HandlebarsApplicationMixin(Doc
     }
   };
 
-  /**
-   * Define the structure of tabs used by this Action Sheet.
-   * @type {Record<string, Array<Record<string, ApplicationTab>>>}
-   */
-  static TABS = {
-    sheet: [
-      {id: "description", group: "sheet", icon: "fa-solid fa-book", label: "ACTION.TABS.Description"},
-      {id: "usage", group: "sheet", icon: "fa-solid fa-cogs", label: "ACTION.TABS.Usage"},
-      {id: "target", group: "sheet", icon: "fa-solid fa-bullseye", label: "ACTION.TABS.Target"},
-      {id: "effects", group: "sheet", icon: "fa-solid fa-hourglass-clock", label: "ACTION.TABS.Effects"},
-      {id: "hooks", group: "sheet", icon: "fa-solid fa-code", label: "ACTION.TABS.Hooks"}
-    ]
-  };
-
   /** @override */
-  tabGroups = {
-    sheet: "description"
+  static TABS = {
+    sheet: {
+      tabs: [
+        {id: "description", icon: "fa-solid fa-book"},
+        {id: "usage", icon: "fa-solid fa-cogs"},
+        {id: "target", icon: "fa-solid fa-bullseye"},
+        {id: "effects", icon: "fa-solid fa-hourglass-clock"},
+        {id: "hooks", icon: "fa-solid fa-code"}
+      ],
+      initial: "description",
+      labelPrefix: "ACTION.TABS"
+    }
   };
 
   /**
@@ -136,7 +132,7 @@ export default class CrucibleActionConfig extends HandlebarsApplicationMixin(Doc
         return acc;
       }, {}),
       isSummon: action.target.type === "summon",
-      tabs: this.#prepareTabs().sheet,
+      tabs: this._prepareTabs("sheet"),
       tags: this.#prepareTags(),
       targetScopes: SYSTEM.ACTION.TARGET_SCOPES.choices,
       targetTypes: SYSTEM.ACTION.TARGET_TYPES,
@@ -160,25 +156,6 @@ export default class CrucibleActionConfig extends HandlebarsApplicationMixin(Doc
       effect.fieldPath = `effects.${i}`;
     }
     return effects;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Configure the tabs used by this sheet.
-   * @returns {Record<string, Record<string, ApplicationTab>>}
-   */
-  #prepareTabs() {
-    const tabs = {};
-    for ( const [groupId, config] of Object.entries(this.constructor.TABS) ) {
-      const group = {};
-      for ( const t of config ) {
-        const active = this.tabGroups[t.group] === t.id;
-        group[t.id] = Object.assign({active, cssClass: active ? "active" : ""}, t);
-      }
-      tabs[groupId] = group;
-    }
-    return tabs;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -97,21 +97,22 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     }
   };
 
-  /**
-   * Define the structure of tabs used by this Item Sheet.
-   * @type {Record<string, Record<string, ApplicationTab>>}
-   */
+  /** @override */
   static TABS = {
-    sheet: [
-      {id: "attributes", group: "sheet", label: "ACTOR.TABS.Attributes"},
-      {id: "actions", group: "sheet", label: "ACTOR.TABS.Actions"},
-      {id: "inventory", group: "sheet", label: "ACTOR.TABS.Inventory"},
-      {id: "talents", group: "sheet", label: "ACTOR.TABS.Talents"},
-      {id: "skills", group: "sheet", label: "ACTOR.TABS.Skills"},
-      {id: "spells", group: "sheet", label: "ACTOR.TABS.Spells"},
-      {id: "effects", group: "sheet", label: "ACTOR.TABS.Effects"},
-      {id: "biography", group: "sheet", label: "ACTOR.TABS.Biography"}
-    ]
+    sheet: {
+      tabs: [
+        {id: "attributes", icon: "systems/crucible/ui/tabs/attributes.webp"},
+        {id: "actions", icon: "systems/crucible/ui/tabs/actions.webp"},
+        {id: "inventory", icon: "systems/crucible/ui/tabs/inventory.webp"},
+        {id: "talents", icon: "systems/crucible/ui/tabs/talents.webp"},
+        {id: "skills", icon: "systems/crucible/ui/tabs/skills.webp"},
+        {id: "spells", icon: "systems/crucible/ui/tabs/spells.webp"},
+        {id: "effects", icon: "systems/crucible/ui/tabs/effects.webp"},
+        {id: "biography", icon: "systems/crucible/ui/tabs/biography.webp"}
+      ],
+      initial: "attributes",
+      labelPrefix: "ACTOR.TABS"
+    }
   };
 
   /**
@@ -124,11 +125,6 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     accessory: "accessory",
     consumable: "toolbelt",
     tool: "toolbelt"
-  };
-
-  /** @override */
-  tabGroups = {
-    sheet: "attributes"
   };
 
   /**
@@ -163,7 +159,6 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
 
   /** @override */
   async _prepareContext(options) {
-    const tabGroups = this.#getTabs();
     const {inventory, talents, iconicSpells} = this.#prepareItems();
     const {sections: actions, favorites: favoriteActions} = this.#prepareActions();
     return {
@@ -190,8 +185,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       skillCategories: this.#prepareSkills(),
       source: this.document.toObject(),
       spells: this.#prepareSpells(iconicSpells),
-      tabGroups,
-      tabs: tabGroups.sheet,
+      tabs: this._prepareTabs("sheet"),
       talents
     };
   }
@@ -202,26 +196,6 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
   _attachFrameListeners() {
     super._attachFrameListeners();
     this.element.addEventListener("focusin", this.#onFocusIn.bind(this));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Configure the tabs used by this sheet.
-   * @returns {Record<string, Record<string, ApplicationTab>>}
-   */
-  #getTabs() {
-    const tabs = {};
-    for ( const [groupId, config] of Object.entries(this.constructor.TABS) ) {
-      const group = {};
-      for ( const t of config ) {
-        const active = this.tabGroups[t.group] === t.id;
-        const icon = `systems/crucible/ui/tabs/${t.id}.webp`;
-        group[t.id] = Object.assign({active, cssClass: active ? "active" : "", icon}, t);
-      }
-      tabs[groupId] = group;
-    }
-    return tabs;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/sheets/effect-affix-sheet.mjs
+++ b/module/applications/sheets/effect-affix-sheet.mjs
@@ -72,12 +72,13 @@ export default class CrucibleAffixEffectSheet extends api.HandlebarsApplicationM
   static TABS = {
     sheet: {
       tabs: [
-        {id: "description", icon: "fa-solid fa-book", label: "ITEM.TABS.Description"},
-        {id: "config", icon: "fa-solid fa-cogs", label: "ITEM.TABS.Configuration"},
-        {id: "actions", icon: "fa-solid fa-bolt", label: "ITEM.TABS.Actions"},
-        {id: "hooks", icon: "fa-solid fa-code", label: "ITEM.TABS.Hooks"}
+        {id: "description", icon: "fa-solid fa-book"},
+        {id: "config", icon: "fa-solid fa-cogs"},
+        {id: "actions", icon: "fa-solid fa-bolt"},
+        {id: "hooks", icon: "fa-solid fa-code"}
       ],
-      initial: "description"
+      initial: "description",
+      labelPrefix: "ITEM.TABS"
     }
   };
 

--- a/module/applications/sheets/effect-sheet.mjs
+++ b/module/applications/sheets/effect-sheet.mjs
@@ -29,12 +29,13 @@ export default class CrucibleActiveEffectSheet extends sheets.ActiveEffectConfig
   static TABS = {
     sheet: {
       tabs: [
-        {id: "description", icon: "fa-solid fa-book", label: "ITEM.TABS.Description"},
-        {id: "config", icon: "fa-solid fa-cogs", label: "ITEM.TABS.Configuration"},
-        {id: "duration", icon: "fa-solid fa-clock", label: "EFFECT.TABS.duration"},
-        {id: "changes", icon: "fa-solid fa-gears", label: "EFFECT.TABS.changes"}
+        {id: "description", icon: "fa-solid fa-book", label: "ITEM.TABS.description"},
+        {id: "config", icon: "fa-solid fa-cogs", label: "ITEM.TABS.config"},
+        {id: "duration", icon: "fa-solid fa-clock"},
+        {id: "changes", icon: "fa-solid fa-gears"}
       ],
-      initial: "description"
+      initial: "description",
+      labelPrefix: "EFFECT.TABS"
     }
   };
 

--- a/module/applications/sheets/item-actor-details-sheet.mjs
+++ b/module/applications/sheets/item-actor-details-sheet.mjs
@@ -29,14 +29,11 @@ export default class CrucibleActorDetailsItemSheet extends CrucibleBaseItemSheet
     }
   };
 
-  /**
-   * Define the structure of tabs used by this Item Sheet.
-   * @type {Record<string, Array<Record<string, ApplicationTab>>>}
-   */
+  /** @override */
   static TABS = foundry.utils.deepClone(super.TABS);
 
   static {
-    this.TABS.sheet.push({id: "talents", group: "sheet", icon: "fa-solid fa-bookmark", label: "ITEM.TABS.Talents"});
+    this.TABS.sheet.tabs.push({id: "talents", icon: "fa-solid fa-bookmark"});
   }
 
   /* -------------------------------------------- */

--- a/module/applications/sheets/item-archetype-sheet.mjs
+++ b/module/applications/sheets/item-archetype-sheet.mjs
@@ -23,12 +23,12 @@ export default class CrucibleArchetypeItemSheet extends CrucibleBackgroundItemSh
     }
   };
 
-  /** @inheritDoc */
+  /** @override */
   static TABS = foundry.utils.deepClone(super.TABS);
 
   static {
     this._initializeItemSheetClass();
-    this.TABS.sheet.push({id: "spells", group: "sheet", icon: "fa-solid fa-wand-magic-sparkles", label: "ITEM.TABS.Spells"});
+    this.TABS.sheet.tabs.push({id: "spells", icon: "fa-solid fa-wand-magic-sparkles"});
   }
 
   /* -------------------------------------------- */

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -72,20 +72,16 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
     }
   };
 
-  /**
-   * Define the structure of tabs used by this Item Sheet.
-   * @type {Record<string, Array<Record<string, ApplicationTab>>>}
-   */
-  static TABS = {
-    sheet: [
-      {id: "description", group: "sheet", icon: "fa-solid fa-book", label: "ITEM.TABS.Description"},
-      {id: "config", group: "sheet", icon: "fa-solid fa-cogs", label: "ITEM.TABS.Configuration"}
-    ]
-  };
-
   /** @override */
-  tabGroups = {
-    sheet: "description"
+  static TABS = {
+    sheet: {
+      tabs: [
+        {id: "description", icon: "fa-solid fa-book"},
+        {id: "config", icon: "fa-solid fa-cogs"}
+      ],
+      initial: "description",
+      labelPrefix: "ITEM.TABS"
+    }
   };
 
   /**
@@ -117,8 +113,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         templates: [this.AFFIX_PARTIAL],
         scrollable: [""]
       };
-      this.TABS.sheet.push({id: "affixes", group: "sheet", icon: "fa-solid fa-sparkles",
-        label: "ITEM.TABS.Affixes"});
+      this.TABS.sheet.tabs.push({id: "affixes", icon: "fa-solid fa-sparkles"});
     }
 
     // Includes Actions
@@ -129,7 +124,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         templates: [this.ACTION_PARTIAL],
         scrollable: [""]
       };
-      this.TABS.sheet.push({id: "actions", group: "sheet", icon: "fa-solid fa-bullseye", label: "ITEM.TABS.Actions"});
+      this.TABS.sheet.tabs.push({id: "actions", icon: "fa-solid fa-bullseye"});
     }
 
     // Includes Hooks
@@ -140,7 +135,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         templates: [HOOK_PARTIAL],
         scrollable: [""]
       };
-      this.TABS.sheet.push({id: "hooks", group: "sheet", icon: "fa-solid fa-cogs", label: "ITEM.TABS.Hooks"});
+      this.TABS.sheet.tabs.push({id: "hooks", icon: "fa-solid fa-cogs"});
     }
 
     // Includes Equipment
@@ -150,8 +145,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         template: "systems/crucible/templates/sheets/item/item-equipment.hbs",
         scrollable: [".equipment-list"]
       };
-      this.TABS.sheet.push({id: "equipment", group: "sheet", icon: "fa-solid fa-suitcase",
-        label: "ITEM.TABS.Equipment"});
+      this.TABS.sheet.tabs.push({id: "equipment", icon: "fa-solid fa-suitcase"});
     }
   }
 
@@ -166,7 +160,6 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
 
   /** @override */
   async _prepareContext(options) {
-    const tabGroups = this._getTabs();
     const source = this.document.toObject();
     const context = {
       item: this.document,
@@ -176,8 +169,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
       fieldDisabled: this.isEditable ? "" : "disabled",
       fields: this.document.system.schema.fields,
       hasAdvancedDescription: this.options.item.hasAdvancedDescription,
-      tabGroups,
-      tabs: tabGroups.sheet,
+      tabs: this._prepareTabs("sheet"),
       tabsPartial: this.constructor.PARTS.tabs.template,
       tags: this.document.getTags()
     };
@@ -398,33 +390,21 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
 
   /* -------------------------------------------- */
 
-  /**
-   * Configure the tabs used by this sheet.
-   * @returns {Record<string, Record<string, ApplicationTab>>}
-   * @protected
-   */
-  _getTabs() {
-    const tabs = {};
-    for ( const [groupId, config] of Object.entries(this.constructor.TABS) ) {
-      const group = {};
-      for ( const t of config ) {
-        const active = this.tabGroups[t.group] === t.id;
-        group[t.id] = Object.assign({active, cssClass: active ? "active" : ""}, t);
-      }
-      tabs[groupId] = group;
-    }
+  /** @inheritDoc */
+  _prepareTabs(group) {
+    const tabs = super._prepareTabs(group);
 
     // Description style
     const adv = this.options.item.hasAdvancedDescription;
-    tabs.sheet.description.cssClass = [
-      tabs.sheet.description.cssClass,
+    tabs.description.cssClass = [
+      tabs.description.cssClass,
       "biography",
       "description",
       adv ? "description-advanced" : ""
     ].filterJoin(" ");
 
     // Restrict access to hooks
-    if ( !game.user.isGM ) delete tabs.sheet.hooks;
+    if ( !game.user.isGM ) delete tabs.hooks;
     return tabs;
   }
 

--- a/module/applications/sheets/item-schematic-sheet.mjs
+++ b/module/applications/sheets/item-schematic-sheet.mjs
@@ -37,9 +37,8 @@ export default class CrucibleSchematicItemSheet extends CrucibleBaseItemSheet {
       template: "systems/crucible/templates/sheets/item/schematic-components.hbs",
       templates: [this.INPUT_PARTIAL, this.OUTPUT_PARTIAL]
     };
-    this.TABS.sheet.push({
+    this.TABS.sheet.tabs.push({
       id: "components",
-      group: "sheet",
       icon: "fa-solid fa-list-ol",
       label: "SCHEMATIC.SHEET.Components"
     });

--- a/module/applications/sheets/item-spell-sheet.mjs
+++ b/module/applications/sheets/item-spell-sheet.mjs
@@ -22,9 +22,9 @@ export default class CrucibleSpellItemSheet extends CrucibleBaseItemSheet {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _getTabs() {
-    const tabs = super._getTabs();
-    if ( !this.document.system.isConfigured ) delete tabs.sheet.actions;
+  _prepareTabs(group) {
+    const tabs = super._prepareTabs(group);
+    if ( !this.document.system.isConfigured ) delete tabs.actions;
     return tabs;
   }
 

--- a/templates/sheets/item/item-actions.hbs
+++ b/templates/sheets/item/item-actions.hbs
@@ -3,7 +3,7 @@
     {{#each actionGroups}}
     <fieldset>
         <legend>
-            <span>{{#if this.legend}}{{this.legend}}{{else}}{{localize "ITEM.TABS.Actions"}}{{/if}}</span>
+            <span>{{#if this.legend}}{{this.legend}}{{else}}{{localize "ITEM.TABS.actions"}}{{/if}}</span>
             {{#if this.canAdd}}
             <a class="button icon" data-action="actionAdd" aria-label="{{localize "TALENT.ACTIONS.ActionAdd"}}" data-tooltip>
                 <i class="fa-solid fa-plus"></i>

--- a/templates/sheets/item/spell-summary.hbs
+++ b/templates/sheets/item/spell-summary.hbs
@@ -4,7 +4,7 @@
 
 {{#if actions.length}}
 <section class="actions">
-    <h3 class="divider">{{localize "ITEM.TABS.Actions"}}</h3>
+    <h3 class="divider">{{localize "ITEM.TABS.actions"}}</h3>
     {{#each actions as |action|}}
     <div class="action line-item full" data-action-id="{{this.id}}">
         <header class="action-header">

--- a/templates/sheets/item/talent-summary.hbs
+++ b/templates/sheets/item/talent-summary.hbs
@@ -10,7 +10,7 @@
 
 {{#if actions.length}}
 <section class="actions">
-    <h3 class="divider" data-no-toc>{{localize "ITEM.TABS.Actions"}}</h3>
+    <h3 class="divider" data-no-toc>{{localize "ITEM.TABS.actions"}}</h3>
     {{#each actions as |action|}}
     <div class="action line-item full" data-action-id="{{this.id}}">
         <header class="action-header">

--- a/templates/tooltips/tooltip-physical.hbs
+++ b/templates/tooltips/tooltip-physical.hbs
@@ -15,7 +15,7 @@
 
     {{#if actions.length}}
     <section class="actions">
-        <h3 class="divider">{{localize "ITEM.TABS.Actions"}}</h3>
+        <h3 class="divider">{{localize "ITEM.TABS.actions"}}</h3>
         {{#each actions as |action|}}
         <div class="action line-item full" data-action-id="{{this.id}}">
             <header class="action-header">


### PR DESCRIPTION
Everywhere we define `static TABS`, move away from our custom `Record<string, Array<Record<string, ApplicationTab>>>` handling to the standard `Record<string, ApplicationTabsConfiguration>` handling. Doing so gives us inferred `group`s (since all of our apps only have one tab group), lets us make use of `labelPrefix` to save writing out labels in most cases, lets us remove what is effectively duplication of `ApplicationSheetV2#_prepareTabs`'s logic, and (perhaps most importantly) gives ChaosOS something pretty to point at as an example.

One change worth calling out: `CrucibleBaseItemSheet#_prepareTabs` now exists as an extension. It assumes `tabs.description` exists (in other words: It assumes `group` will always be `"sheet"`. This is a safe assumption because `SomeSheet#_prepareTabs` is only called in `SomeSheet#_prepareContext`, and in our case we never call `super._prepareContext`; rather, we _directly_ call `_prepareTabs("sheet")`.