### PR TITLE
Use more enrichers

### DIFF
--- a/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
+++ b/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
@@ -7798,8 +7798,9 @@ actors:
             - id: devourThoughts
               description: >-
                 <p>Lash onto a single enemy with multiple tendrils, dealing
-                Weakened Psychic damage and inflicting the Stunned condition on
-                a success.</p>
+                @Rule[action.weakened] <strong>Psychic</strong> damage and
+                inflicting the @Rule[condition.stunned] condition on a
+                success.</p>
               tags:
                 - melee
                 - natural
@@ -7827,17 +7828,17 @@ actors:
                     - stunned
                   duration:
                     value: 1
-                    units: turns
+                    units: ''
                     expiry: null
                     expired: false
                   system:
-                    dot: []
-                    maintenance: null
-                    regions: []
-                    summons: []
                     changes: []
                     dc: null
+                    dot: []
+                    maintenance: null
                     properties: []
+                    regions: []
+                    summons: []
               name: Devour Thoughts
               img: icons/creatures/magical/spirit-fear-energy-pink.webp
               condition: ''
@@ -7963,7 +7964,7 @@ actors:
       modifiedTime: null
       lastModifiedBy: null
       compendiumSource: null
-      duplicateSource: null
+      duplicateSource: Actor.CTpEm0WlmFAAosBD
       exportSource: null
     ownership:
       default: 0
@@ -10010,7 +10011,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
+            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -15488,7 +15489,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
+            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -17130,7 +17131,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
+            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -25934,7 +25935,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
+            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -31080,8 +31081,8 @@ _stats:
   systemId: crucible
   systemVersion: 0.8.6
   coreVersion: '14.364'
-  modifiedTime: 1781451933240
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1781990217998
+  lastModifiedBy: fzBjA63BB4hW4rQb
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
+++ b/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
@@ -7964,7 +7964,7 @@ actors:
       modifiedTime: null
       lastModifiedBy: null
       compendiumSource: null
-      duplicateSource: Actor.CTpEm0WlmFAAosBD
+      duplicateSource: null
       exportSource: null
     ownership:
       default: 0
@@ -20382,66 +20382,6 @@ actors:
         sort: 0
         ownership:
           default: 0
-      - name: Penetrating Throw
-        type: talent
-        img: icons/skills/ranged/shuriken-thrown-yellow.webp
-        system:
-          nodes:
-            - str3b
-          description: >-
-            <p>You can hurl your weapon with such ferocity that it strikes all
-            targets in a direct line.</p>
-          actions:
-            - id: penetratingThrow
-              name: Penetrating Throw
-              img: icons/skills/ranged/shuriken-thrown-yellow.webp
-              condition: ''
-              description: >-
-                <p>You perform a <strong>Throw</strong> weapon strike which
-                penetrates to hit all enemies in a straight line.</p>
-              cost:
-                action: 1
-                focus: 1
-                heroism: 0
-                weapon: true
-                hands: 0
-              range:
-                minimum: null
-                maximum: null
-                weapon: false
-              target:
-                type: ray
-                number: 1
-                scope: 4
-                self: false
-              effects: []
-              tags:
-                - thrown
-              summon: null
-          rune: ''
-          gesture: ''
-          inflection: ''
-          iconicSpells: 0
-          training:
-            type: ''
-            rank: null
-        effects: []
-        flags: {}
-        _stats:
-          compendiumSource: Compendium.crucible.talent.Item.penetratingThrow
-          duplicateSource: null
-          exportSource: null
-          coreVersion: '14.364'
-          systemId: crucible
-          systemVersion: 0.10.0
-          createdTime: null
-          modifiedTime: null
-          lastModifiedBy: null
-        _id: penetratingThrow
-        folder: null
-        sort: 0
-        ownership:
-          default: 0
       - name: Stiletto
         type: weapon
         img: icons/weapons/daggers/dagger-straight-thin-black.webp
@@ -20563,6 +20503,67 @@ actors:
           modifiedTime: null
           lastModifiedBy: null
         _id: adrenalineSurge0
+        folder: null
+        sort: 0
+        ownership:
+          default: 0
+      - name: Penetrating Throw
+        type: talent
+        img: icons/skills/ranged/shuriken-thrown-yellow.webp
+        system:
+          nodes:
+            - str3b
+          description: >-
+            <p>You can hurl your weapon with such ferocity that it strikes all
+            targets in a direct line.</p>
+          actions:
+            - id: penetratingThrow
+              name: Penetrating Throw
+              img: icons/skills/ranged/shuriken-thrown-yellow.webp
+              condition: ''
+              description: >-
+                <p>You perform a @Rule[action.thrown] weapon strike which
+                penetrates to hit all enemies in a straight line.</p>
+              cost:
+                action: 1
+                focus: 1
+                heroism: 0
+                weapon: true
+                hands: 0
+              range:
+                minimum: null
+                maximum: null
+                weapon: false
+              target:
+                type: ray
+                number: 1
+                scope: 4
+                self: false
+              effects: []
+              tags:
+                - melee
+                - thrown
+              summon: null
+          rune: ''
+          gesture: ''
+          inflection: ''
+          iconicSpells: 0
+          training:
+            type: ''
+            rank: null
+        effects: []
+        flags: {}
+        _stats:
+          compendiumSource: Compendium.crucible.talent.Item.penetratingThrow
+          duplicateSource: null
+          exportSource: null
+          coreVersion: '14.364'
+          systemId: crucible
+          systemVersion: 0.10.0
+          createdTime: null
+          modifiedTime: null
+          lastModifiedBy: null
+        _id: penetratingThrow
         folder: null
         sort: 0
         ownership:
@@ -31081,7 +31082,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.8.6
   coreVersion: '14.364'
-  modifiedTime: 1781990217998
+  modifiedTime: 1781991026111
   lastModifiedBy: fzBjA63BB4hW4rQb
   compendiumSource: null
   duplicateSource: null

--- a/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
+++ b/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
@@ -15216,8 +15216,8 @@ actors:
         system:
           description: >-
             <p>You understand how to move away from an opponent without exposing
-            yourself to the worst attacks in return. Any <strong>Reactive
-            Strike</strong> against you is performed with <strong>+1
+            yourself to the worst attacks in return. Any @Action[default
+            reactiveStrike] against you is performed with <strong>+1
             Bane</strong>.</p>
           actions: []
           nodes:

--- a/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
+++ b/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
@@ -4642,7 +4642,7 @@ actors:
           description: >-
             <p>You have expertise in using a <strong>Shield</strong> to defend
             yourself and others.</p><p>Once per Turn while you have a Shield
-            equipped, you may use the <strong>Defend</strong> action at a
+            equipped, you may use the @Action[default defend] action at a
             reduced cost of 1 Action Point.</p>
           nodes:
             - tou0a
@@ -12717,7 +12717,7 @@ actors:
           description: >-
             <p>You have expertise in using a <strong>Shield</strong> to defend
             yourself and others.</p><p>Once per Turn while you have a Shield
-            equipped, you may use the <strong>Defend</strong> action at a
+            equipped, you may use the @Action[default defend] action at a
             reduced cost of 1 Action Point.</p>
           nodes:
             - tou0a
@@ -24393,7 +24393,7 @@ actors:
           description: >-
             <p>You have expertise in using a <strong>Shield</strong> to defend
             yourself and others.</p><p>Once per Turn while you have a Shield
-            equipped, you may use the <strong>Defend</strong> action at a
+            equipped, you may use the @Action[default defend] action at a
             reduced cost of 1 Action Point.</p>
           nodes:
             - tou0a

--- a/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
+++ b/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
@@ -10010,7 +10010,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
+            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -15488,7 +15488,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
+            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -17130,7 +17130,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
+            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:
@@ -25934,7 +25934,7 @@ actors:
             <p>The chaotic force of raw electrical energy. The Storm rune
             governs sources of electrical charge and discharge.</p><p>The Storm
             rune scales using <strong>Intellect</strong>, targets
-            <strong>Reflex</strong>, and deals <strong>Electrical</strong>
+            <strong>Reflex</strong>, and deals <strong>Electricity</strong>
             damage to <strong>Health</strong>. It is opposed by the orderly rune
             of <strong>Earth</strong>.</p>
           actions:

--- a/_source/pregens/Agnath_B40EKua2Q7zQ8CFZ.yml
+++ b/_source/pregens/Agnath_B40EKua2Q7zQ8CFZ.yml
@@ -1301,7 +1301,7 @@ items:
         <p>The chaotic force of raw electrical energy. The Storm rune governs
         sources of electrical charge and discharge.</p><p>The Storm rune scales
         using <strong>Intellect</strong>, targets <strong>Reflex</strong>, and
-        deals <strong>Electrical</strong> damage to <strong>Health</strong>. It
+        deals <strong>Electricity</strong> damage to <strong>Health</strong>. It
         is opposed by the orderly rune of <strong>Earth</strong>.</p>
       actions:
         - id: energize

--- a/_source/pregens/Duurath_iLUfMcYjAbZFY4CJ.yml
+++ b/_source/pregens/Duurath_iLUfMcYjAbZFY4CJ.yml
@@ -640,7 +640,7 @@ items:
       description: >-
         <p>You have expertise in using a <strong>Shield</strong> to defend
         yourself and others.</p><p>Once per Turn while you have a Shield
-        equipped, you may use the <strong>Defend</strong> action at a reduced
+        equipped, you may use the @Action[default defend] action at a reduced
         cost of 1 Action Point.</p>
       actions: []
       iconicSpells: 0

--- a/_source/pregens/Duurath_nPOVNsOFhqA7SUud.yml
+++ b/_source/pregens/Duurath_nPOVNsOFhqA7SUud.yml
@@ -861,7 +861,7 @@ items:
       description: >-
         <p>You have expertise in using a <strong>Shield</strong> to defend
         yourself and others.</p><p>Once per Turn while you have a Shield
-        equipped, you may use the <strong>Defend</strong> action at a reduced
+        equipped, you may use the @Action[default defend] action at a reduced
         cost of 1 Action Point.</p>
       actions: []
       iconicSpells: 0

--- a/_source/pregens/Eliorwen_2lvTCCOj4dnBI774.yml
+++ b/_source/pregens/Eliorwen_2lvTCCOj4dnBI774.yml
@@ -1562,7 +1562,7 @@ items:
         <p>The chaotic force of raw electrical energy. The Storm rune governs
         sources of electrical charge and discharge.</p><p>The Storm rune scales
         using <strong>Intellect</strong>, targets <strong>Reflex</strong>, and
-        deals <strong>Electrical</strong> damage to <strong>Health</strong>. It
+        deals <strong>Electricity</strong> damage to <strong>Health</strong>. It
         is opposed by the orderly rune of <strong>Earth</strong>.</p>
       actions:
         - id: energize

--- a/_source/pregens/Eliorwen_2lvTCCOj4dnBI774.yml
+++ b/_source/pregens/Eliorwen_2lvTCCOj4dnBI774.yml
@@ -1283,8 +1283,8 @@ items:
     system:
       description: >-
         <p>You understand how to move away from an opponent without exposing
-        yourself to the worst attacks in return. Any <strong>Reactive
-        Strike</strong> against you is performed with <strong>+1
+        yourself to the worst attacks in return. Any @Action[default
+        reactiveStrike] against you is performed with <strong>+1
         Bane</strong>.</p>
       actions: []
       nodes:

--- a/_source/pregens/Fizzit_TffJlCvt39DEhFX7.yml
+++ b/_source/pregens/Fizzit_TffJlCvt39DEhFX7.yml
@@ -716,7 +716,7 @@ items:
         <p>The chaotic force of raw electrical energy. The Storm rune governs
         sources of electrical charge and discharge.</p><p>The Storm rune scales
         using <strong>Intellect</strong>, targets <strong>Reflex</strong>, and
-        deals <strong>Electrical</strong> damage to <strong>Health</strong>. It
+        deals <strong>Electricity</strong> damage to <strong>Health</strong>. It
         is opposed by the orderly rune of <strong>Earth</strong>.</p>
       actions:
         - id: energize

--- a/_source/pregens/Fizzit_lP2MOJyk5oHs6oSS.yml
+++ b/_source/pregens/Fizzit_lP2MOJyk5oHs6oSS.yml
@@ -1550,7 +1550,7 @@ items:
         <p>The chaotic force of raw electrical energy. The Storm rune governs
         sources of electrical charge and discharge.</p><p>The Storm rune scales
         using <strong>Intellect</strong>, targets <strong>Reflex</strong>, and
-        deals <strong>Electrical</strong> damage to <strong>Health</strong>. It
+        deals <strong>Electricity</strong> damage to <strong>Health</strong>. It
         is opposed by the orderly rune of <strong>Earth</strong>.</p>
       actions:
         - id: energize

--- a/_source/pregens/Ulfen_L0qEPpUQBZQPCxN3.yml
+++ b/_source/pregens/Ulfen_L0qEPpUQBZQPCxN3.yml
@@ -1449,8 +1449,8 @@ items:
           img: icons/skills/ranged/shuriken-thrown-yellow.webp
           condition: ''
           description: >-
-            <p>You perform a <strong>Throw</strong> weapon strike which
-            penetrates to hit all enemies in a straight line.</p>
+            <p>You perform a @Rule[action.thrown] weapon strike which penetrates
+            to hit all enemies in a straight line.</p>
           cost:
             action: 1
             focus: 1

--- a/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
+++ b/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
@@ -820,8 +820,8 @@ pages:
         disengage in search of more vulnerable prey. Two of the four goblins may
         move away from Krag without reciprocity, because Krag is otherwise
         <strong>Fully Engaged</strong> and therefore cannot retaliate. When the
-        third goblin moves away, however, Krag performs a <strong>Reactive
-        Strike</strong>, burying his battle axe in the back of the retreating
+        third goblin moves away, however, Krag performs a @Action[default
+        reactiveStrike], burying his battle axe in the back of the retreating
         evildoer!</p></section>
     video:
       controls: true
@@ -838,7 +838,7 @@ pages:
       systemId: crucible
       systemVersion: 0.8.6
       createdTime: 1726930849493
-      modifiedTime: 1781993300418
+      modifiedTime: 1781993712288
       lastModifiedBy: fzBjA63BB4hW4rQb
       exportSource: null
     category: null

--- a/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
+++ b/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
@@ -812,7 +812,7 @@ pages:
         against the Flanked creature.</p></section><h2
         class="divider">Disengagement</h2><p>When an opponent attempts to
         disengage from you in melee combat it becomes temporarily vulnerable,
-        allowing you to perform a <strong>Reactive Strike</strong>, a weapon
+        allowing you to perform a @Action[default reactiveStrike], a weapon
         attack as a Reaction. You may not make a Reactive Strike if you are
         @Condition[unaware] or @Condition[flanked] by other remaining
         opponents.</p><section class="gameplay"><p>The Goblins in our previous
@@ -834,11 +834,11 @@ pages:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.363'
+      coreVersion: '14.364'
       systemId: crucible
       systemVersion: 0.8.6
       createdTime: 1726930849493
-      modifiedTime: 1780583682384
+      modifiedTime: 1781993300418
       lastModifiedBy: fzBjA63BB4hW4rQb
       exportSource: null
     category: null

--- a/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
+++ b/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
@@ -909,34 +909,34 @@ pages:
         resource that allows combatants to perform legendary or iconic feats of
         power or resilience.</p><p>Heroism is accumulated by any Action which
         applies healing, damage, or effects to some other character. Actions
-        which only target yourself, like <strong>Move</strong> or
-        <strong>Defend</strong> do not contribute towards Heroism. The actions
-        of both allies and adversaries count towards Heroism accumulation. The
-        amount of Heroism accumulated by each Action is equal to its<strong>
-        Action</strong> cost.</p><section class="foundryvtt"><p>The progress of
-        Heroism accumulation is visualized at the top of the Combat Tracker. A
-        customizable game setting exists to configure whether this progress bar
-        is visible to all players or only to Gamemasters. If you are new to the
-        Crucible system, we encourage you to allow this progress bar to be
-        visible to everyone, but once you are used to the rules of the system
-        concealing it from players can help reduce metagaming that may occur
-        from players trying to precisely anticipate the award of their next
-        Heroism point.</p></section><p>The number of <strong>Action
-        Points</strong> that need to be spent in order to yield a
+        which only target yourself, like @Action[default move]<strong>
+        </strong>or @Action[default defend] do not contribute towards Heroism.
+        The actions of both allies and adversaries count towards Heroism
+        accumulation. The amount of Heroism accumulated by each Action is equal
+        to its<strong> Action</strong> cost.</p><section
+        class="foundryvtt"><p>The progress of Heroism accumulation is visualized
+        at the top of the Combat Tracker. A customizable game setting exists to
+        configure whether this progress bar is visible to all players or only to
+        Gamemasters. If you are new to the Crucible system, we encourage you to
+        allow this progress bar to be visible to everyone, but once you are used
+        to the rules of the system concealing it from players can help reduce
+        metagaming that may occur from players trying to precisely anticipate
+        the award of their next Heroism point.</p></section><p>The number of
+        <strong>Action Points</strong> that need to be spent in order to yield a
         <strong>Heroism Point</strong> depends on the number of Hero characters
         in the Combat encounter:</p><section class="formula"><p
         class="value">Action per Heroism</p><p class="equals">=</p><p
         class="equation">Number of Heroes × 12</p></section><section
         class="gameplay"><h4>Example: Ray of Life</h4><p>Suppose Kagura, a
-        powerful Healer, casts a spell <strong>Composed Ray of Life</strong>
-        which heals two of her allies and costs <strong>5 Action</strong> to
-        cast. Since this spell heals other characters, this action contributes 5
-        Action towards Heroism accumulation. If this accumulation were enough to
-        fill the Heroism meter, then Kagura and each of her allies would
-        immediately gain <strong>+1 Heroism</strong>.</p><p>With her remaining
-        Action for the turn, Kagura uses <strong>Defend</strong> which
-        costs<strong> 1 Action</strong>. Since this Action only affects herself,
-        it does not contribute towards Heroism accumulation.</p></section>
+        powerful Healer, casts a spell @Spell[life.ray.compose] which heals two
+        of her allies and costs <strong>5 Action</strong> to cast. Since this
+        spell heals other characters, this action contributes 5 Action towards
+        Heroism accumulation. If this accumulation were enough to fill the
+        Heroism meter, then Kagura and each of her allies would immediately gain
+        <strong>+1 Heroism</strong>.</p><p>With her remaining Action for the
+        turn, Kagura uses @Action[default defend] which costs<strong> 1
+        Action</strong>. Since this Action only affects herself, it does not
+        contribute towards Heroism accumulation.</p></section>
     video:
       controls: true
       volume: 0.5
@@ -950,12 +950,12 @@ pages:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '13.346'
+      coreVersion: '14.364'
       systemId: crucible
       systemVersion: 0.8.6
       createdTime: 1749693502753
-      modifiedTime: 1753540966957
-      lastModifiedBy: AnoypGxxNIMOS0XY
+      modifiedTime: 1781973085207
+      lastModifiedBy: fzBjA63BB4hW4rQb
     _key: '!journal.pages!QhZgmBrdLAGwYy5c.4rapfbyanVHveRme'
   - sort: 900000
     name: Balance and Difficulty

--- a/_source/summons/Storm_Visitor_c5B0l3VQPNMSw0MQ.yml
+++ b/_source/summons/Storm_Visitor_c5B0l3VQPNMSw0MQ.yml
@@ -280,8 +280,8 @@ items:
         the orderly rune of Earth.</p>
 
         <p>The Storm rune scales using <strong>Intellect</strong>, targets
-        <strong>Reflex</strong>, and deals <strong>Electrical</strong> damage to
-        <strong>Health</strong>.</p>
+        <strong>Reflex</strong>, and deals <strong>Electricity</strong> damage
+        to <strong>Health</strong>.</p>
       actions: []
       rune: storm
       nodes:

--- a/_source/talent/Alchemical_Resolve_alchemicalresolv.yml
+++ b/_source/talent/Alchemical_Resolve_alchemicalresolv.yml
@@ -11,7 +11,7 @@ system:
       description: >-
         <p>You rapidly bolster the Morale of an ally within 4 feet by applying
         vapours. Perform a <strong>Medicine</strong> check against the target's
-        <strong>Madness Threshold</strong>. Successful checks restore
+        <strong>Rallying Threshold</strong>. Successful checks restore
         <strong>Morale</strong>.</p>
       tags:
         - rallying

--- a/_source/talent/Bulwark_bulwark000000000.yml
+++ b/_source/talent/Bulwark_bulwark000000000.yml
@@ -5,7 +5,7 @@ system:
   description: >-
     <p>You have expertise in using a <strong>Shield</strong> to defend yourself
     and others.</p><p>Once per Turn while you have a Shield equipped, you may
-    use the <strong>Defend</strong> action at a reduced cost of 1 Action
+    use the @Action[default defend] action at a reduced cost of 1 Action
     Point.</p>
   nodes:
     - tou0a
@@ -25,11 +25,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.9.0
-  coreVersion: '14.356'
+  systemVersion: 0.10.0
+  coreVersion: '14.364'
   createdTime: 1772307160128
-  modifiedTime: 1773514792562
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1781972841916
+  lastModifiedBy: fzBjA63BB4hW4rQb
   compendiumSource: Item.bulwark000000000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Carefree_carefree00000000.yml
+++ b/_source/talent/Carefree_carefree00000000.yml
@@ -7,7 +7,7 @@ system:
     <p>You are able to compartmentalize and brush off setbacks, providing a
     remarkable ability to recover from damage to your Morale.</p>
 
-    <p>Your <strong>Madness Threshold</strong> is reduced by 1, making you
+    <p>Your <strong>Rallying Threshold</strong> is reduced by 1, making you
     easier to heal.</p>
   actions: []
   nodes:

--- a/_source/talent/Combat_Medicine_combatmedicine00.yml
+++ b/_source/talent/Combat_Medicine_combatmedicine00.yml
@@ -13,7 +13,7 @@ system:
       condition: ''
       description: >-
         <p>You rapidly treat the wounds of an ally within 4 feet. Perform a
-        <strong>Medicine Check</strong> against the target's Wounds Threshold.
+        <strong>Medicine Check</strong> against the target's Healing Threshold.
         Your ally's Health is increased by the amount of the Roll in excess of
         the threshold.</p>
       tags:

--- a/_source/talent/Control_Proficiency_controlProficien.yml
+++ b/_source/talent/Control_Proficiency_controlProficien.yml
@@ -8,7 +8,8 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Control. You
     gain a <strong>+1 Skill Bonus</strong> for spells cast using this
     Rune.</p><h3 class="divider">Playtest Notes</h3><p>This talent will
-    eventually also provide an upgrade to the <strong>Motivate </strong>action,
+    eventually also provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeControl00000 motivate] action,
     expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763163877936
-  modifiedTime: 1773514792549
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1781971062882
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: controlProficien
 sort: 800000
 _key: '!items!controlProficien'

--- a/_source/talent/Death_Proficiency_deathProficiency.yml
+++ b/_source/talent/Death_Proficiency_deathProficiency.yml
@@ -8,8 +8,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Death. You gain
     a <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Ennervate </strong>action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeDeath0000000 ennervate] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1763163881562
-  modifiedTime: 1773514792549
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1781971105030
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: deathProficiency
 sort: 900000
 _key: '!items!deathProficiency'

--- a/_source/talent/Earth_Proficiency_earthProficiency.yml
+++ b/_source/talent/Earth_Proficiency_earthProficiency.yml
@@ -8,8 +8,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Earth. You gain
     a <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Mould</strong> action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeEarth0000000 mould] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763163884518
-  modifiedTime: 1773514792550
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971142712
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: earthProficiency
 sort: 1000000
 _key: '!items!earthProficiency'

--- a/_source/talent/Flame_Proficiency_flameProficiency.yml
+++ b/_source/talent/Flame_Proficiency_flameProficiency.yml
@@ -10,8 +10,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Flame. You gain
     a <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Enkindle</strong> action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeFlame0000000 enkindle] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -30,10 +31,10 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763154150208
-  modifiedTime: 1773514792575
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1781971163829
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _key: '!items!flameProficiency'

--- a/_source/talent/Frost_Proficiency_frostProficiency.yml
+++ b/_source/talent/Frost_Proficiency_frostProficiency.yml
@@ -8,8 +8,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Frost. You gain
     a <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Condense </strong>action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeFrost0000000 condense] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763163886659
-  modifiedTime: 1773514792550
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1781971445091
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: frostProficiency
 sort: 1100000
 _key: '!items!frostProficiency'

--- a/_source/talent/Gesture__Conjure_gestureConjure00.yml
+++ b/_source/talent/Gesture__Conjure_gestureConjure00.yml
@@ -20,7 +20,7 @@ system:
     be attainable at a higher level (probably Level 6 required). It is currently
     available "early" for testing.</p><p>Not all Runes have a Visitor actor
     defined yet. Runes that do not yet have a defined Conjuration will — for now
-    — manifest a <strong>Flame Visitor</strong>.</p>
+    — manifest a@UUID[Compendium.crucible.summons.Actor.AlwoqQKoL1BnnZjd].</p>
   actions: []
   rune: ''
   gesture: conjure
@@ -39,10 +39,10 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1762718477065
-  modifiedTime: 1773514792578
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1781974591630
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _key: '!items!gestureConjure00'

--- a/_source/talent/Gesture__Create_gesturecreate000.yml
+++ b/_source/talent/Gesture__Create_gesturecreate000.yml
@@ -13,7 +13,8 @@ system:
     has a base cost of <strong>4 Action</strong> and <strong>1
     Focus</strong>.</p><h3 class="divider">Playtest Notes</h3><p>Not all Runes
     have a Sprite actor defined yet. Runes that do not yet have a defined
-    Creation will — for now — manifest a <strong>Flame Sprite</strong>.</p>
+    Creation will — for now — manifest
+    a@UUID[Compendium.crucible.summons.Actor.RuNh1bFGiHKdHeKI].</p>
   actions: []
   gesture: create
   nodes:
@@ -29,11 +30,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.9.0
-  coreVersion: '14.356'
+  systemVersion: 0.10.0
+  coreVersion: '14.364'
   createdTime: 1772307160133
-  modifiedTime: 1773514792580
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1781974541170
+  lastModifiedBy: fzBjA63BB4hW4rQb
   compendiumSource: Compendium.crucible.talent.gesturecreate000
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Illumination_Proficiency_illuminationProf.yml
+++ b/_source/talent/Illumination_Proficiency_illuminationProf.yml
@@ -8,7 +8,8 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Illumination.
     You gain a <strong>+1 Skill Bonus</strong> for spells cast using this
     Rune.</p><h3 class="divider">Playtest Notes</h3><p>This talent will
-    eventually also provide an upgrade to the <strong>Reveal</strong> action,
+    eventually also provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeIllumination reveal] action,
     expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1763163889572
-  modifiedTime: 1773514792551
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971461864
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: illuminationProf
 sort: 700000
 _key: '!items!illuminationProf'

--- a/_source/talent/Illusion_Proficiency_illusionProficie.yml
+++ b/_source/talent/Illusion_Proficiency_illusionProficie.yml
@@ -8,7 +8,8 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Illusion. You
     gain a <strong>+1 Skill Bonus</strong> for spells cast using this
     Rune.</p><h3 class="divider">Playtest Notes</h3><p>This talent will
-    eventually also provide an upgrade to the <strong>Seeming </strong>action,
+    eventually also provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeIllusion0000 seeming] action,
     expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763163891870
-  modifiedTime: 1773514792551
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971484674
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: illusionProficie
 sort: 100000
 _key: '!items!illusionProficie'

--- a/_source/talent/Kinesis_Proficiency_kinesisProficien.yml
+++ b/_source/talent/Kinesis_Proficiency_kinesisProficien.yml
@@ -8,7 +8,8 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Kinesis. You
     gain a <strong>+1 Skill Bonus</strong> for spells cast using this
     Rune.</p><h3 class="divider">Playtest Notes</h3><p>This talent will
-    eventually also provide an upgrade to the <strong>Propel </strong>action,
+    eventually also provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeKinesis00000 propel] action,
     expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1763163893756
-  modifiedTime: 1773514792551
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971509727
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: kinesisProficien
 sort: 200000
 _key: '!items!kinesisProficien'

--- a/_source/talent/Life_Proficiency_lifeProficiency0.yml
+++ b/_source/talent/Life_Proficiency_lifeProficiency0.yml
@@ -8,8 +8,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Life. You gain a
     <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Blossom </strong>action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeLife00000000 bloom] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1763163895456
-  modifiedTime: 1773514792551
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971526007
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: lifeProficiency0
 sort: 300000
 _key: '!items!lifeProficiency0'

--- a/_source/talent/Oblivion_Proficiency_oblivionProficie.yml
+++ b/_source/talent/Oblivion_Proficiency_oblivionProficie.yml
@@ -8,7 +8,8 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Oblivion. You
     gain a <strong>+1 Skill Bonus</strong> for spells cast using this
     Rune.</p><h3 class="divider">Playtest Notes</h3><p>This talent will
-    eventually also provide an upgrade to the <strong>Erase </strong>action,
+    eventually also provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeOblivion0000 erase] action,
     expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763163905709
-  modifiedTime: 1773514792552
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971544754
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: oblivionProficie
 sort: 400000
 _key: '!items!oblivionProficie'

--- a/_source/talent/Penetrating_Throw_penetratingThrow.yml
+++ b/_source/talent/Penetrating_Throw_penetratingThrow.yml
@@ -13,8 +13,8 @@ system:
       img: icons/skills/ranged/shuriken-thrown-yellow.webp
       condition: ''
       description: >-
-        <p>You perform a <strong>Throw</strong> weapon strike which penetrates
-        to hit all enemies in a straight line.</p>
+        <p>You perform a @Rule[action.thrown] weapon strike which penetrates to
+        hit all enemies in a straight line.</p>
       cost:
         action: 1
         focus: 1
@@ -32,10 +32,9 @@ system:
         self: false
       effects: []
       tags:
+        - melee
         - thrown
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   rune: ''
   gesture: ''
   inflection: ''
@@ -53,12 +52,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307160140
-  modifiedTime: 1773514792600
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1781990887072
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: penetratingThrow
 sort: 200000
 _key: '!items!penetratingThrow'

--- a/_source/talent/Powerful_Throw_powerfulThrow000.yml
+++ b/_source/talent/Powerful_Throw_powerfulThrow000.yml
@@ -5,8 +5,8 @@ system:
   nodes:
     - str3b
   description: >-
-    <p>The maximum range of actions with the <strong>Throw</strong> tag or
-    actions from <strong>Bomb</strong> consumables are doubled</p>
+    <p>The maximum range of actions with the @Rule[action.thrown] tag or actions
+    from <strong>Bomb</strong> consumables are doubled</p>
   actions: []
   rune: ''
   gesture: ''
@@ -25,12 +25,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1749329319147
-  modifiedTime: 1773514792603
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1781990827898
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: powerfulThrow000
 sort: 400000
 _key: '!items!powerfulThrow000'

--- a/_source/talent/Resilient_resilient0000000.yml
+++ b/_source/talent/Resilient_resilient0000000.yml
@@ -7,7 +7,7 @@ system:
     <p>Your body responds eagerly to healing, demonstrating a remarkable ability
     to recover from wounds.</p>
 
-    <p>Your <strong>Wounds Threshold</strong> is reduced by 1, making you easier
+    <p>Your <strong>Healing Threshold</strong> is reduced by 1, making you easier
     to heal.</p>
   actions: []
   nodes:

--- a/_source/talent/Resilient_resilient0000000.yml
+++ b/_source/talent/Resilient_resilient0000000.yml
@@ -7,8 +7,8 @@ system:
     <p>Your body responds eagerly to healing, demonstrating a remarkable ability
     to recover from wounds.</p>
 
-    <p>Your <strong>Healing Threshold</strong> is reduced by 1, making you easier
-    to heal.</p>
+    <p>Your <strong>Healing Threshold</strong> is reduced by 1, making you
+    easier to heal.</p>
   actions: []
   nodes:
     - tou2c

--- a/_source/talent/Rune__Illumination_runeIllumination.yml
+++ b/_source/talent/Rune__Illumination_runeIllumination.yml
@@ -4,7 +4,7 @@ img: icons/magic/light/projectile-beam-yellow.webp
 system:
   description: >-
     <p>The orderly force of light and energy. The Illumination rune governs
-    light and radiance. </p><p>The Illumination rune scales using
+    light and radiance.</p><p>The Illumination rune scales using
     <strong>Presence</strong>, targets <strong>Reflex</strong>, and deals
     <strong>Radiant</strong> damage to <strong>Health</strong>. It is opposed by
     the chaotic rune of <strong>Illusion</strong>.</p>
@@ -72,12 +72,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307160143
-  modifiedTime: 1773514792608
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1781971279621
+  lastModifiedBy: fzBjA63BB4hW4rQb
 folder: Dy9HnwadNE3kSZ4f
 ownership:
   default: 0

--- a/_source/talent/Rune__Storm_runeStorm0000000.yml
+++ b/_source/talent/Rune__Storm_runeStorm0000000.yml
@@ -6,8 +6,8 @@ system:
     <p>The chaotic force of raw electrical energy. The Storm rune governs
     sources of electrical charge and discharge.</p><p>The Storm rune scales
     using <strong>Intellect</strong>, targets <strong>Reflex</strong>, and deals
-    <strong>Electrical</strong> damage to <strong>Health</strong>. It is opposed
-    by the orderly rune of <strong>Earth</strong>.</p>
+    <strong>Electricity</strong> damage to <strong>Health</strong>. It is
+    opposed by the orderly rune of <strong>Earth</strong>.</p>
   actions:
     - id: energize
       name: Energize

--- a/_source/talent/Soul_Proficiency_soulProficiency0.yml
+++ b/_source/talent/Soul_Proficiency_soulProficiency0.yml
@@ -8,8 +8,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Soul. You gain a
     <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Evoke </strong>action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeSoul00000000 evoke] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1763163907163
-  modifiedTime: 1773514792552
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971567441
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: soulProficiency0
 sort: 0
 _key: '!items!soulProficiency0'

--- a/_source/talent/Storm_Proficiency_stormProficiency.yml
+++ b/_source/talent/Storm_Proficiency_stormProficiency.yml
@@ -8,8 +8,9 @@ system:
     <p>You have fluency in weaving spellcraft using the Rune of Storm. You gain
     a <strong>+1 Skill Bonus</strong> for spells cast using this Rune.</p><h3
     class="divider">Playtest Notes</h3><p>This talent will eventually also
-    provide an upgrade to the <strong>Energize </strong>action, expanding its
-    effectiveness or including new options for how to use it.</p>
+    provide an upgrade to the
+    @Action[Compendium.crucible.talent.Item.runeStorm0000000 energize] action,
+    expanding its effectiveness or including new options for how to use it.</p>
   actions: []
   rune: ''
   gesture: ''
@@ -28,12 +29,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1763163898743
-  modifiedTime: 1773514792552
-  lastModifiedBy: vke929uLgNzbrY41
+  modifiedTime: 1781971588870
+  lastModifiedBy: fzBjA63BB4hW4rQb
 _id: stormProficiency
 sort: 500000
 _key: '!items!stormProficiency'

--- a/_source/talent/Stunning_Strike_stunningstrike00.yml
+++ b/_source/talent/Stunning_Strike_stunningstrike00.yml
@@ -14,10 +14,12 @@ system:
     - id: stunningStrike
       condition: ''
       description: >-
-        <p>You <strong>Strike</strong> a vital pressure point, inflicting
-        <strong>Stun</strong> on your enemy for 1 Round if successful.</p>
+        <p>You <strong>Strike</strong> a vital pressure point, inflicting the
+        @Rule[condition.stunned] condition on your enemy for 1 Round if
+        successful.</p>
       tags:
         - unarmed
+        - melee
         - mainhand
         - difficult
         - fortitude
@@ -41,6 +43,7 @@ system:
             value: 1
             units: rounds
             expiry: turnEnd
+            expired: false
           result:
             type: success
             all: false
@@ -50,15 +53,15 @@ system:
             maintenance: null
             regions: []
             summons: []
+            dc: null
+            properties: []
       name: Stunning Strike
       img: icons/magic/lightning/fist-unarmed-strike-blue.webp
       range:
         maximum: 1
         weapon: true
         minimum: null
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   nodes:
     - strwis1
   rune: ''
@@ -70,11 +73,11 @@ system:
     rank: null
 _stats:
   systemId: crucible
-  systemVersion: 0.9.4
-  coreVersion: '14.363'
+  systemVersion: 0.10.0
+  coreVersion: '14.364'
   createdTime: 1772307160150
-  modifiedTime: 1779907081391
-  lastModifiedBy: ZXJsFnFZuf21WDAk
+  modifiedTime: 1781990371948
+  lastModifiedBy: fzBjA63BB4hW4rQb
   compendiumSource: Compendium.crucible.talent.CANFHQxFjIJwgEYK
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Subtle_Extrication_subtleextricatio.yml
+++ b/_source/talent/Subtle_Extrication_subtleextricatio.yml
@@ -5,8 +5,8 @@ img: icons/magic/air/wind-stream-blue-gray.webp
 system:
   description: >-
     <p>You understand how to move away from an opponent without exposing
-    yourself to the worst attacks in return. Any <strong>Reactive
-    Strike</strong> against you is performed with <strong>+1 Bane</strong>.</p>
+    yourself to the worst attacks in return. Any @Action[default reactiveStrike]
+    against you is performed with <strong>+1 Bane</strong>.</p>
   actions: []
   nodes:
     - intdex2
@@ -26,11 +26,11 @@ ownership:
 flags: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.9.4
-  coreVersion: '14.363'
+  systemVersion: 0.10.0
+  coreVersion: '14.364'
   createdTime: 1772307160150
-  modifiedTime: 1780501015695
-  lastModifiedBy: ZXJsFnFZuf21WDAk
+  modifiedTime: 1781993430935
+  lastModifiedBy: fzBjA63BB4hW4rQb
   compendiumSource: null
   duplicateSource: null
   exportSource: null

--- a/_source/talent/Warchanter_warchanter000000.yml
+++ b/_source/talent/Warchanter_warchanter000000.yml
@@ -221,8 +221,8 @@ system:
       description: >-
         <p>You drone a dragging requiem to the <strong>Glutton</strong>, too
         bloated and idle to stir. Enemy creatures within <strong>15
-        feet</strong> gain lose <strong>Free</strong> <strong>Movement</strong>
-        and reduce their <strong>Stride</strong> by 2.</p>
+        feet</strong> lose <strong>Free Movement</strong> and reduce their
+        <strong>Stride</strong> by 2.</p>
       tags:
         - vocal
       cost:


### PR DESCRIPTION
I plan to use this branch for any replacements of plain text with enrichers.
The first commit is about rune proficiency referencing actions from rune training properly. This may seem like a weird place to start, but it came about from me trying to categorize what we have as bolded text and noticing that the life proficiency talent used the wrong name for the action (Blossom instead of Bloom)