### PR TITLE
Ensure best-ranked weapon is selected, fix unavailable `weaponChoice` sticking on window close

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -694,7 +694,7 @@ export const TAGS = {
         const target = (canvas.ready && this.token?.object && game.user.targets.size)
           ? game.user.targets.values().next().value : null;
         this.usage.weapon = locked ?? choices.reduce((best, c) => {
-          let rank = this._getWeaponAvailability(c.item, {target});
+          let {rank} = this._getWeaponAvailability(c.item, {target});
           if ( c.item.system.properties.has("natural") ) rank -= 0.5; // Prefer equipped > natural at same rank
           return (!best || (rank > best.rank)) ? {item: c.item, rank} : best;
         }, null)?.item;

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -752,6 +752,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
   _onClose(options) {
     this.#clearMovementPlan();
     this.#clearRegionPreview();
+    this.action.usage.weaponChoice = null;
     super._onClose(options);
   }
 }


### PR DESCRIPTION
`action.mjs` fix was a typo - `_getWeaponAvailability` returns an object, not just the rank.
Fix in the use dialog is so that selecting an UNAVAILABLE weapon & then closing the window doesn't try to "lock" the UNAVAILABLE weapon when you go to use a Strike next.