### PR TITLE
adding a fix for #1312

### DIFF
--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -1205,9 +1205,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
         creationData.items.push(itemData);
       }
       else {
-        // NOTE: Each unit must be a deep clone (not a shallow spread) so that per-unit mutations - such as
-        // auto-equipping only one of several identical purchased copies - do not leak across sibling units via a
-        // shared "system" object reference.
+        // Deep clone each unit so that can have different stateful properties
         const units = Array.from({length: quantity}, () => foundry.utils.deepClone(itemData));
         creationData.items.push(...units);
 
@@ -1228,8 +1226,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
 
   /**
    * Auto-equips purchased Weapons and Armor, favoring higher-value items.
-   * Armor occupies a single slot; Weapons are assigned to available hand slots
-   * according to their category.
+   * Armor occupies a single slot; Weapons are assigned to available hand slots according to their category.
    * @param {{itemData: object, sourceItem: CrucibleItem, scaledPrice: number}[]} candidates
    * @protected
    */

--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -597,7 +597,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
       });
 
       // Ability Step
-      if ( step.id === "abilities" ) {
+      if ( step.id === "background" ) {
         const ap = this._clone.points.ability.pool;
         const chosen = context[step.id];
         tab.selectionLabel = (ap || !chosen)
@@ -1199,22 +1199,17 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
     for ( const {item, quantity, scaledPrice} of Object.values(this._state.equipment) ) {
       if ( quantity <= 0 ) continue;
       const itemData = this._clone._cleanItemData(item);
-      // FIXME: Once https://github.com/foundryvtt/foundry-vtt/pull/5570 merged this can just be `delete itemData._id`
+      delete itemData._id
       itemData._id = foundry.utils.randomID();
       if ( itemData.system.properties.includes("stackable") ) {
         itemData.system.quantity = quantity;
         creationData.items.push(itemData);
       }
       else {
-        // FIXME: Once https://github.com/foundryvtt/foundry-vtt/pull/5570 is merged this can just be `.fill(itemData)`
         // NOTE: Each unit must be a deep clone (not a shallow spread) so that per-unit mutations - such as
         // auto-equipping only one of several identical purchased copies - do not leak across sibling units via a
         // shared "system" object reference.
-        const units = Array.from({length: quantity}, () => {
-          const unitData = foundry.utils.deepClone(itemData);
-          unitData._id = foundry.utils.randomID();
-          return unitData;
-        });
+        const units = Array.from({length: quantity}, () => foundry.utils.deepClone(itemData));
         creationData.items.push(...units);
 
         // Each individually equippable unit of a purchased Weapon or Armor is a candidate for auto-equip
@@ -1227,21 +1222,19 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
     creationData.system.currency = SYSTEM.ACTOR.STARTING_EQUIPMENT_BUDGET - spent;
 
     // Automatically equip the highest-value purchased Weapons and Armor that fit available equipment slots
-    this.constructor._autoEquipPurchasedItems(autoEquipCandidates);
+    this._autoEquipPurchasedItems(autoEquipCandidates);
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Automatically equip purchased Weapon and Armor items into available equipment slots, preferring the
-   * highest-value (price) options first. Only one Armor item may be equipped, and Weapons are greedily assigned
-   * to the Mainhand, Offhand, and Twohand slots as their category and remaining slot availability allow.
-   * @param {{itemData: object, sourceItem: CrucibleItem, scaledPrice: number}[]} candidates  Individually
-   *  equippable units of purchased Weapon or Armor items, paired with the source Item document used to determine
-   *  their equipment category and the price used to rank them.
+   * Auto-equips purchased Weapons and Armor, favoring higher-value items.
+   * Armor occupies a single slot; Weapons are assigned to available hand slots
+   * according to their category.
+   * @param {{itemData: object, sourceItem: CrucibleItem, scaledPrice: number}[]} candidates
    * @protected
    */
-  static _autoEquipPurchasedItems(candidates) {
+   _autoEquipPurchasedItems(candidates) {
     const SLOTS = SYSTEM.WEAPON.SLOTS;
     const byHighestValue = (a, b) => (b.scaledPrice - a.scaledPrice) || a.sourceItem.name.localeCompare(b.sourceItem.name);
 
@@ -1268,6 +1261,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
         if ( !(mainhandFree && offhandFree) ) continue;
         itemData.system.equipped = true;
         itemData.system.slot = SLOTS.TWOHAND;
+        if ( sourceItem.system.requiresInvestment ) itemData.system.invested = true;
         mainhandFree = offhandFree = false;
       }
 
@@ -1275,15 +1269,15 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
       else if ( category.main && mainhandFree ) {
         itemData.system.equipped = true;
         itemData.system.slot = SLOTS.MAINHAND;
+        if ( sourceItem.system.requiresInvestment ) itemData.system.invested = true;
         mainhandFree = false;
       }
       else if ( category.off && offhandFree ) {
         itemData.system.equipped = true;
         itemData.system.slot = SLOTS.OFFHAND;
+        if ( sourceItem.system.requiresInvestment ) itemData.system.invested = true;
         offhandFree = false;
       }
-      else continue;
-      if ( sourceItem.system.requiresInvestment ) itemData.system.invested = true;
     }
   }
 

--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -1200,7 +1200,6 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
       if ( quantity <= 0 ) continue;
       const itemData = this._clone._cleanItemData(item);
       delete itemData._id
-      itemData._id = foundry.utils.randomID();
       if ( itemData.system.properties.includes("stackable") ) {
         itemData.system.quantity = quantity;
         creationData.items.push(itemData);

--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -597,7 +597,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
       });
 
       // Ability Step
-      if ( step.id === "background" ) {
+      if ( step.id === "abilities" ) {
         const ap = this._clone.points.ability.pool;
         const chosen = context[step.id];
         tab.selectionLabel = (ap || !chosen)
@@ -1195,6 +1195,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
 
     // Grant purchased equipment items and apply remaining currency
     let spent = 0;
+    const autoEquipCandidates = [];
     for ( const {item, quantity, scaledPrice} of Object.values(this._state.equipment) ) {
       if ( quantity <= 0 ) continue;
       const itemData = this._clone._cleanItemData(item);
@@ -1204,11 +1205,86 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
         itemData.system.quantity = quantity;
         creationData.items.push(itemData);
       }
-      // FIXME: Once https://github.com/foundryvtt/foundry-vtt/pull/5570 is merged this can just be `.fill(itemData)`
-      else creationData.items.push(...Array.from({length: quantity}, () => ({...itemData, _id: foundry.utils.randomID()})));
+      else {
+        // FIXME: Once https://github.com/foundryvtt/foundry-vtt/pull/5570 is merged this can just be `.fill(itemData)`
+        // NOTE: Each unit must be a deep clone (not a shallow spread) so that per-unit mutations - such as
+        // auto-equipping only one of several identical purchased copies - do not leak across sibling units via a
+        // shared "system" object reference.
+        const units = Array.from({length: quantity}, () => {
+          const unitData = foundry.utils.deepClone(itemData);
+          unitData._id = foundry.utils.randomID();
+          return unitData;
+        });
+        creationData.items.push(...units);
+
+        // Each individually equippable unit of a purchased Weapon or Armor is a candidate for auto-equip
+        if ( ["weapon", "armor"].includes(item.type) ) {
+          for ( const unitData of units ) autoEquipCandidates.push({itemData: unitData, sourceItem: item, scaledPrice});
+        }
+      }
       spent += scaledPrice * quantity;
     }
     creationData.system.currency = SYSTEM.ACTOR.STARTING_EQUIPMENT_BUDGET - spent;
+
+    // Automatically equip the highest-value purchased Weapons and Armor that fit available equipment slots
+    this.constructor._autoEquipPurchasedItems(autoEquipCandidates);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Automatically equip purchased Weapon and Armor items into available equipment slots, preferring the
+   * highest-value (price) options first. Only one Armor item may be equipped, and Weapons are greedily assigned
+   * to the Mainhand, Offhand, and Twohand slots as their category and remaining slot availability allow.
+   * @param {{itemData: object, sourceItem: CrucibleItem, scaledPrice: number}[]} candidates  Individually
+   *  equippable units of purchased Weapon or Armor items, paired with the source Item document used to determine
+   *  their equipment category and the price used to rank them.
+   * @protected
+   */
+  static _autoEquipPurchasedItems(candidates) {
+    const SLOTS = SYSTEM.WEAPON.SLOTS;
+    const byHighestValue = (a, b) => (b.scaledPrice - a.scaledPrice) || a.sourceItem.name.localeCompare(b.sourceItem.name);
+
+    // Armor: equip the single highest-value Armor unit, if any was purchased
+    const armors = candidates.filter(c => c.sourceItem.type === "armor").sort(byHighestValue);
+    const bestArmor = armors[0];
+    if ( bestArmor ) {
+      bestArmor.itemData.system.equipped = true;
+      if ( bestArmor.sourceItem.system.requiresInvestment ) bestArmor.itemData.system.invested = true;
+    }
+
+    // Weapons: greedily fill the Mainhand, Offhand, and Twohand slots with the highest-value options that fit
+    const weapons = candidates.filter(c => c.sourceItem.type === "weapon").sort(byHighestValue);
+    let mainhandFree = true;
+    let offhandFree = true;
+    for ( const {itemData, sourceItem} of weapons ) {
+      if ( !mainhandFree && !offhandFree ) break;
+      if ( sourceItem.system.properties.has("natural") ) continue;
+      const category = sourceItem.system.config?.category;
+      if ( !category ) continue;
+
+      // Two-Handed weapons require both slots to be free
+      if ( category.hands === 2 ) {
+        if ( !(mainhandFree && offhandFree) ) continue;
+        itemData.system.equipped = true;
+        itemData.system.slot = SLOTS.TWOHAND;
+        mainhandFree = offhandFree = false;
+      }
+
+      // Otherwise prefer the Mainhand slot, falling back to the Offhand slot if the weapon allows it
+      else if ( category.main && mainhandFree ) {
+        itemData.system.equipped = true;
+        itemData.system.slot = SLOTS.MAINHAND;
+        mainhandFree = false;
+      }
+      else if ( category.off && offhandFree ) {
+        itemData.system.equipped = true;
+        itemData.system.slot = SLOTS.OFFHAND;
+        offhandFree = false;
+      }
+      else continue;
+      if ( sourceItem.system.requiresInvestment ) itemData.system.invested = true;
+    }
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
## attempted solve for #1312 — Auto-equip purchased Weapons and Armor at character creation

### Summary

Items purchased during the Equipment step currently stay unequipped, requiring a manual pass after creation. This PR auto-equips the highest-value purchased Weapons and Armor into available slots as creation completes.

### Implementation

Added to `_finalizeCreationData()` / new `_autoEquipPurchasedItems()` helper in `hero-creation-sheet.mjs`:

- **Armor:** highest-price purchased unit is equipped (only one Armor slot).
- **Weapons:** sorted by price descending, greedily filled into Mainhand/Offhand/Twohand as category and remaining slots allow.
- Investment-required items are marked `invested: true` on equip, matching existing granted-equipment behavior.

Also fixed a latent bug found along the way: multi-quantity purchases were built via shallow spread, so all units of one purchase shared a single `system` object by reference. Harmless until now, but auto-equip needs to mutate per unit — switched to a deep clone.

### Open questions

- Weapon training isn't factored in — an untrained weapon can still win a slot on price alone. Can add a tiebreak if preferred.
- Heuristic is greedy per-item, not combination-optimal (a 2H weapon could occupy both slots over a higher-total one-handed + shield pair). Flagging the tradeoff rather than deciding it.


### Example process:

#### purchased this
<img width="429" height="438" alt="Image" src="https://github.com/user-attachments/assets/96d7c167-1cb8-4591-addf-d4aa18681310" />

#### this is what got equipped 
<img width="635" height="519" alt="Image" src="https://github.com/user-attachments/assets/c450ed5c-7cd4-4959-9e6d-5dae21d5a411" />
