### PR TITLE
[#1242] Query maintenance dialog, fix `CrucibleActor#getDesignatedUser`

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -605,12 +605,12 @@ export default class CrucibleActor extends Actor {
   /**
    * Find the best active user to roll on this actor's behalf, preferring an assigned character match then any
    * owner, falling back to the active GM.
-   * @returns {User|undefined}    The designated user, or undefined if none is found
+   * @returns {User|null}    The designated user, or null if none is found
    */
   getDesignatedUser() {
-    return game.users.getDesignatedUser(user => {
+    const assigned = game.users.find(user => user.active && (user.character === this));
+    return assigned ?? game.users.getDesignatedUser(user => {
       if ( !user.active || user.isGM ) return false;
-      if ( user.character === this ) return true;
       return this.testUserPermission(user, "OWNER");
     }) ?? game.users.activeGM;
   }
@@ -1384,7 +1384,7 @@ export default class CrucibleActor extends Actor {
           effectChanges.toDelete.push(effect.id);
           continue;
         }
-        const confirm = await DialogV2.confirm({
+        const confirm = await DialogV2.query(this.getDesignatedUser(), "confirm", {
           window: {
             title: _loc("ACTION.MaintainTitle", {effect: effect.name})
           },


### PR DESCRIPTION
Closes #1242 
Not null-checking `this.getDesignatedUser()` because I _know_ there will be an active GM at least, otherwise this code wouldn't be running. 

Fixes to the `getDesignatedUser` function are
1. Typing - would be `null` not `undefined`
2. An earlier `return true` doesn't matter; if any user returns `true` they'll be the designated user. So if we want to prioritize (i.e. user with this actor assigned, but if no such user then any player owner) then we need to do it separately.