### PR TITLE
[#1278] Ensure description doesn't populate an unnecessary scrollbar

### DIFF
--- a/styles/dice.less
+++ b/styles/dice.less
@@ -453,7 +453,7 @@
   .description {
     max-height: 200px;
     overflow-y: auto;
-    line-height: normal;
+    line-height: var(--font-size-16);
   }
 }
 

--- a/styles/dice.less
+++ b/styles/dice.less
@@ -453,6 +453,7 @@
   .description {
     max-height: 200px;
     overflow-y: auto;
+    line-height: normal;
   }
 }
 


### PR DESCRIPTION
Closes #1278 
Not sure if maybe there's some secret sauce we should be using instead of this but it feels like a fairly harmless solution. Before & after pics below, showing both a valid "needs to scroll" box on the left and an invalid "no need to scroll" box on the right.

**With font size 4**:
Before: 
<img width="692" height="370" alt="image" src="https://github.com/user-attachments/assets/5cf41ed0-dd65-477f-a932-427ecdf7ca6d" />
After: 
<img width="698" height="368" alt="image" src="https://github.com/user-attachments/assets/8a947cd8-9251-43d2-aac3-c5a820a4b120" />

**With font size 5 (default)**:
Before: 
<img width="695" height="383" alt="image" src="https://github.com/user-attachments/assets/05c04a5c-f084-4190-b67b-28e03f0cc692" />
After: 
<img width="692" height="389" alt="image" src="https://github.com/user-attachments/assets/5ff3eaa9-5856-4dbb-8d46-f33071b77f6b" />