### PR TITLE
[#1298] Fix Invisibility spell and visual bug when applying invisible

### DIFF
--- a/_source/spell/Invisibility_invisibility0000.yml
+++ b/_source/spell/Invisibility_invisibility0000.yml
@@ -39,22 +39,26 @@ system:
           result:
             type: any
             all: false
-          statuses: []
+          statuses:
+            - invisible
+          duration:
+            value: null
+            units: ''
+            expiry: null
+            expired: false
           system:
             changes: []
+            dc: null
             dot: []
             maintenance: null
+            properties: []
             regions: []
             summons: []
       tags:
         - spell
         - iconicSpell
-        - spell
-        - iconicSpell
         - maintained
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
       rune: illumination
       gesture: aspect
       inflection: eluding
@@ -75,12 +79,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307159357
-  modifiedTime: 1773514792468
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1782151852398
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: invisibility0000
 sort: 500000
 _key: '!items!invisibility0000'

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -2040,6 +2040,10 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
           damageType: ann.damageType, restoration: ann.restoration};
       });
 
+      // Remove false dependent tokens from clone to avoid any visual-only local changes stemming from
+      // modifying specialStatusEffects (namely INVISIBLE)
+      for ( const scene of clone._dependentTokens.keys() ) clone._dependentTokens.delete(scene);
+
       // Apply this event's effects so subsequent events observe the resulting statuses (point-in-time)
       if ( event.effects.length ) await clone._applyActionEffects(event.effects, {commit: false});
     }

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1990,7 +1990,14 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
   async #resolveEventStream() {
     const clones = new Map();
     const cloneFor = actor => {
-      if ( !clones.has(actor) ) clones.set(actor, actor.clone({}, {keepId: true}));
+      if ( !clones.has(actor) ) {
+        const clone = actor.clone({}, {keepId: true});
+
+        // Remove false dependent tokens from clone to avoid any visual-only local changes stemming from
+        // modifying specialStatusEffects (namely INVISIBLE)
+        for ( const scene of clone._dependentTokens.keys() ) clone._dependentTokens.delete(scene);
+        clones.set(actor, clone);
+      }
       return clones.get(actor);
     };
 
@@ -2039,10 +2046,6 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         return {resource, delta: after[resource].value - before[resource].value,
           damageType: ann.damageType, restoration: ann.restoration};
       });
-
-      // Remove false dependent tokens from clone to avoid any visual-only local changes stemming from
-      // modifying specialStatusEffects (namely INVISIBLE)
-      for ( const scene of clone._dependentTokens.keys() ) clone._dependentTokens.delete(scene);
 
       // Apply this event's effects so subsequent events observe the resulting statuses (point-in-time)
       if ( event.effects.length ) await clone._applyActionEffects(event.effects, {commit: false});

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1993,8 +1993,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
       if ( !clones.has(actor) ) {
         const clone = actor.clone({}, {keepId: true});
 
-        // Remove false dependent tokens from clone to avoid any visual-only local changes stemming from
-        // modifying specialStatusEffects (namely INVISIBLE)
+        // Prevent unintended side-effects on dependent tokens (like specialStatusEffects)
         for ( const scene of clone._dependentTokens.keys() ) clone._dependentTokens.delete(scene);
         clones.set(actor, clone);
       }


### PR DESCRIPTION
Closes #1298 
Fun double-fix:
1. Just add `invisible` to the statuses on the iconic spell
2. The `commit=false` version of `_applyActionEffects` still recomputed any dependent tokens' filters, so running it with a yet-to-be-confirmed `invisible`-status-granting effect would on the client machine make such tokens appear invisible. Figured nuking `_dependentTokens` on the clone was a satisfying resolution to that issue.