### PR TITLE
[#1285, #1293, #1294] Fix various bomb misconfigurations

### DIFF
--- a/_source/equipment/Alchemist_s_Fire_alchemistsFire00.yml
+++ b/_source/equipment/Alchemist_s_Fire_alchemistsFire00.yml
@@ -27,13 +27,14 @@ system:
       condition: ''
       description: >-
         <p>You hurl the @ref[name], dealing @Rule[action.weakened] immediate
-        damage but causing the @Condition[burning] condition to all enemies in a
-        4 foot radius <strong>Blast</strong> who fail to avoid the
-        attack.</p><p>The amount of burning damage and its duration is dependent
-        on the quality of the @ref[name]:</p><ul><li><p><strong>Shoddy</strong>
-        - 2 damage for 2 rounds</p></li><li><p><strong>Standard</strong> - 3
-        damage for 3 rounds</p></li><li><p><strong>Fine</strong> - 4 damage for
-        4 rounds</p></li><li><p><strong>Superior</strong> - 6 damage for 5
+        <strong>Fire</strong> damage but causing the @Condition[burning]
+        condition to all enemies in a 4 foot radius <strong>Blast</strong> who
+        fail to avoid the attack.</p><p>The amount of burning damage and its
+        duration is dependent on the quality of the
+        @ref[name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 2
+        rounds</p></li><li><p><strong>Standard</strong> - 3 damage for 3
+        rounds</p></li><li><p><strong>Fine</strong> - 4 damage for 4
+        rounds</p></li><li><p><strong>Superior</strong> - 6 damage for 5
         rounds</p></li><li><p><strong>Masterwork</strong> - 8 damage for 6
         rounds</p></li></ul>
       cost:
@@ -54,7 +55,10 @@ system:
         size: 4
       effects:
         - name: Alchemist's Fire
-          scope: 3
+          scope: 4
+          result:
+            type: success
+            all: false
           statuses:
             - burning
           duration:
@@ -62,26 +66,22 @@ system:
             units: rounds
             expiry: turnEnd
             expired: false
-          result:
-            type: success
-            all: false
           system:
-            dot: []
-            maintenance: null
-            regions: []
-            summons: []
             changes: []
             dc: null
+            dot: []
+            maintenance: null
             properties: []
+            regions: []
+            summons: []
       tags:
         - consume
         - weakened
         - reflex
+        - fire
         - skill
         - athletics
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -101,9 +101,9 @@ _stats:
   exportSource: null
   coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.5
+  systemVersion: 0.10.0
   createdTime: 1772307157757
-  modifiedTime: 1781394998737
-  lastModifiedBy: fzBjA63BB4hW4rQb
+  modifiedTime: 1782153571418
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 sort: 500000
 _key: '!items!alchemistsFire00'

--- a/_source/equipment/Blast_Flask_KdlUUFhAnpv6YIHT.yml
+++ b/_source/equipment/Blast_Flask_KdlUUFhAnpv6YIHT.yml
@@ -31,9 +31,9 @@ system:
       condition: ''
       description: >-
         <p>You light and throw the @ref[name], dealing <strong>Fire
-        </strong>damage to all enemies in the radius of the explosion. The
-        radius of the <strong>Blast</strong> depends on the quality of the
-        bomb:</p><ul><li><p><strong>Shoddy</strong> - 3
+        </strong>damage to all enemies in the radius of the explosion who fail
+        to avoid the attack. The radius of the <strong>Blast</strong> depends on
+        the quality of the bomb:</p><ul><li><p><strong>Shoddy</strong> - 3
         feet</p></li><li><p><strong>Standard</strong> - 4
         feet</p></li><li><p><strong>Fine</strong> - 6
         feet</p></li><li><p><strong>Superior</strong> - 8
@@ -59,12 +59,9 @@ system:
         - consume
         - reflex
         - fire
-        - dexterity
         - skill
         - athletics
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -89,11 +86,11 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307157756
-  modifiedTime: 1776980754315
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1782153594707
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 sort: 600000
 _key: '!items!KdlUUFhAnpv6YIHT'

--- a/_source/equipment/Caustic_Phial_causticPhial0000.yml
+++ b/_source/equipment/Caustic_Phial_causticPhial0000.yml
@@ -27,13 +27,14 @@ system:
       condition: ''
       description: >-
         <p>You fling the @ref[name], dealing @Rule[action.weakened] immediate
-        damage but causing the @Condition[corroding] condition to all enemies in
-        a 4 foot radius <strong>Blast</strong> who fail to avoid the
-        attack.</p><p>The amount of burning damage and its duration is dependent
-        on the quality of the @ref[name]:</p><ul><li><p><strong>Shoddy</strong>
-        - 2 damage for 2 rounds</p></li><li><p><strong>Standard</strong> - 3
-        damage for 3 rounds</p></li><li><p><strong>Fine</strong> - 4 damage for
-        4 rounds</p></li><li><p><strong>Superior</strong> - 6 damage for 5
+        <strong>Acid</strong> damage but causing the @Condition[corroding]
+        condition to all enemies in a 4 foot radius <strong>Blast</strong> who
+        fail to avoid the attack.</p><p>The amount of corroding damage and its
+        duration is dependent on the quality of the
+        @ref[name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 2
+        rounds</p></li><li><p><strong>Standard</strong> - 3 damage for 3
+        rounds</p></li><li><p><strong>Fine</strong> - 4 damage for 4
+        rounds</p></li><li><p><strong>Superior</strong> - 6 damage for 5
         rounds</p></li><li><p><strong>Masterwork</strong> - 8 damage for 6
         rounds</p></li></ul>
       cost:
@@ -54,7 +55,10 @@ system:
         size: 4
       effects:
         - name: Caustic Phial
-          scope: 3
+          scope: 4
+          result:
+            type: success
+            all: false
           statuses:
             - corroding
           duration:
@@ -62,26 +66,22 @@ system:
             units: rounds
             expiry: turnEnd
             expired: false
-          result:
-            type: success
-            all: false
           system:
-            dot: []
-            maintenance: null
-            regions: []
-            summons: []
             changes: []
             dc: null
+            dot: []
+            maintenance: null
             properties: []
+            regions: []
+            summons: []
       tags:
         - consume
         - weakened
         - reflex
+        - acid
         - skill
         - athletics
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -101,10 +101,10 @@ _stats:
   exportSource: null
   coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.5
+  systemVersion: 0.10.0
   createdTime: 1772307157760
-  modifiedTime: 1781395012898
-  lastModifiedBy: fzBjA63BB4hW4rQb
+  modifiedTime: 1782153633842
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: causticPhial0000
 sort: 100000
 _key: '!items!causticPhial0000'

--- a/_source/equipment/Choking_Ampoule_chokingAmpoule00.yml
+++ b/_source/equipment/Choking_Ampoule_chokingAmpoule00.yml
@@ -58,7 +58,7 @@ system:
         size: 8
       effects:
         - name: ''
-          scope: 3
+          scope: 4
           result:
             type: success
             all: false
@@ -68,21 +68,22 @@ system:
             value: 3
             units: rounds
             expiry: turnEnd
+            expired: false
           system:
+            changes: []
+            dc: null
             dot: []
             maintenance: null
+            properties: []
             regions: []
             summons: []
-            changes: []
       tags:
         - consume
         - harmless
-        - reflex
         - skill
         - athletics
-      summon:
-        actorUuid: null
-        permanent: true
+        - fortitude
+      summon: null
   uses:
     value: 1
     max: 1
@@ -100,12 +101,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307157761
-  modifiedTime: 1776980754314
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1782153373664
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: chokingAmpoule00
 sort: 300000
 _key: '!items!chokingAmpoule00'

--- a/_source/equipment/Electrocharge_Ampoule_electrochargeFla.yml
+++ b/_source/equipment/Electrocharge_Ampoule_electrochargeFla.yml
@@ -33,9 +33,9 @@ system:
       condition: ''
       description: >-
         <p>You throw the @ref[name], dealing weakened <strong>Electricity
-        </strong>damage to all enemies in the radius of the discharge and
-        leaving them briefly @Condition[staggered]. The radius of the
-        <strong>Discharge</strong> depends on the quality of the
+        </strong>damage to all enemies in the radius of the discharge who fail
+        to avoid the attack and leaving them briefly @Condition[staggered]. The
+        radius of the <strong>Discharge</strong> depends on the quality of the
         bomb:</p><ul><li><p><strong>Shoddy</strong> - 3
         feet</p></li><li><p><strong>Standard</strong> - 4
         feet</p></li><li><p><strong>Fine</strong> - 6
@@ -59,7 +59,7 @@ system:
         size: 4
       effects:
         - name: ''
-          scope: 3
+          scope: 4
           result:
             type: success
             all: false
@@ -72,8 +72,10 @@ system:
             expired: false
           system:
             changes: []
+            dc: null
             dot: []
             maintenance: null
+            properties: []
             regions: []
             summons: []
       tags:
@@ -81,12 +83,9 @@ system:
         - weakened
         - reflex
         - electricity
-        - dexterity
         - skill
         - athletics
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -108,12 +107,12 @@ flags:
   ember:
     crucibleOverride: true
 _stats:
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.1
+  systemVersion: 0.10.0
   createdTime: 1776980627490
-  modifiedTime: 1776980754314
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1782153705650
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null
   duplicateSource: null

--- a/_source/equipment/Frostdrop_Phial_frostdropFlask00.yml
+++ b/_source/equipment/Frostdrop_Phial_frostdropFlask00.yml
@@ -27,14 +27,14 @@ system:
       living tissue if exposed for a long period of time.</p>
   actions:
     - id: frostFlask
-      name: Frostdrop Flask
+      name: Frostdrop Phial
       img: icons/consumables/potions/flask-corked-blue-glow.webp
       condition: ''
       description: >-
         <p>You throw the @ref[name], dealing weakened <strong>Cold
-        </strong>damage to all enemies in the radius of the explosion and
-        causing them to be @Condition[slowed] briefly. The radius of the
-        <strong>Blast</strong> depends on the quality of the
+        </strong>damage to all enemies in the radius of the explosion who fail
+        to avoid the attack and causing them to be @Condition[slowed] briefly.
+        The radius of the <strong>Blast</strong> depends on the quality of the
         bomb:</p><ul><li><p><strong>Shoddy</strong> - 3
         feet</p></li><li><p><strong>Standard</strong> - 4
         feet</p></li><li><p><strong>Fine</strong> - 6
@@ -58,7 +58,7 @@ system:
         size: 4
       effects:
         - name: ''
-          scope: 3
+          scope: 4
           result:
             type: success
             all: false
@@ -71,8 +71,10 @@ system:
             expired: false
           system:
             changes: []
+            dc: null
             dot: []
             maintenance: null
+            properties: []
             regions: []
             summons: []
       tags:
@@ -80,12 +82,9 @@ system:
         - weakened
         - reflex
         - cold
-        - dexterity
         - skill
         - athletics
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -107,12 +106,12 @@ flags:
   ember:
     crucibleOverride: true
 _stats:
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.1
+  systemVersion: 0.10.0
   createdTime: 1776980754250
-  modifiedTime: 1776980754314
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1782153465865
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null
   duplicateSource: null


### PR DESCRIPTION
Closes #1285 by changing effect scope on each bomb from "Enemies" to "All"
Closes #1293 by adding Fire & Acid tags, specifying that type of damage in their description, and fixing the mentioned typo
Closes #1294 by addressing each point in the issue