### PR TITLE
[#1299] Fix `relativeTo` for various enrichment calls, amend gem descriptions

### DIFF
--- a/_source/equipment/Gem_Of_Conjured_Flame_gemConjuredFlame.yml
+++ b/_source/equipment/Gem_Of_Conjured_Flame_gemConjuredFlame.yml
@@ -27,10 +27,10 @@ system:
       name: Summon Flame Elemental
       img: icons/commodities/gems/gem-rough-cushion-orange-red.webp
       description: >-
-        <p>The @ref[name] shatters in a burst of flame, leaving in its place a
-        fiery elemental. Elementals summoned by this gem remain for 6 Rounds (1
-        minute).</p><ul><li><p><strong>Shoddy - </strong>No elemental is
-        summoned</p></li><li><p><strong>Standard </strong>-
+        <p>The @ref[item.name] shatters in a burst of flame, leaving in its
+        place a fiery elemental. Elementals summoned by this gem remain for 6
+        Rounds (1 minute).</p><ul><li><p><strong>Shoddy - </strong>No elemental
+        is summoned</p></li><li><p><strong>Standard </strong>-
         Mote</p></li><li><p><strong>Fine</strong> -
         Sprite</p></li><li><p><strong>Superior</strong> -
         Visitor</p></li><li><p><strong>Masterwork -
@@ -52,9 +52,7 @@ system:
         scope: 4
         self: false
         size: 4
-      summon:
-        actorUuid: null
-        permanent: false
+      summon: null
       effects: []
       tags:
         - consume
@@ -76,12 +74,12 @@ flags:
   ember:
     crucibleOverride: true
 _stats:
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.1
+  systemVersion: 0.10.0
   createdTime: 1776980906656
-  modifiedTime: 1776980906656
-  lastModifiedBy: QvBFYpRRXHRBcOfP
+  modifiedTime: 1782155983356
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null
   duplicateSource: null

--- a/_source/equipment/Gem_of_Illumination_gemOfIlluminatio.yml
+++ b/_source/equipment/Gem_of_Illumination_gemOfIlluminatio.yml
@@ -52,16 +52,16 @@ effects:
           img: icons/magic/light/orb-shadow-blue.webp
           condition: ''
           description: >-
-            <p>You speak the command word and the @ref[name] kindles into a
-            steady otherworldly glow. The radius of bright light shed depends on
-            the <strong>Tier</strong> of this prefix, with an additional radius
-            of dim light extending an equal distance
+            <p>You speak the command word and the @ref[item.name]{item} kindles
+            into a steady otherworldly glow. The radius of bright light shed
+            depends on the <strong>Tier</strong> of this prefix, with an
+            additional radius of dim light extending an equal distance
             beyond.</p><ul><li><p><strong>Tier 1:</strong> 20 feet of bright
-            light, 40 feet of dim</p></li><li><p><strong>Tier 2:</strong> 40
-            feet of bright light, 80 feet of dim</p></li><li><p><strong>Tier
-            3:</strong> 60 feet of bright light, 120 feet of dim</p></li></ul>
-            <p>The light persists until you dismiss the effect or remove the
-            item.</p>
+            light, 40 feet of dim light.</p></li><li><p><strong>Tier 2:</strong>
+            40 feet of bright light, 80 feet of dim
+            light.</p></li><li><p><strong>Tier 3:</strong> 60 feet of bright
+            light, 120 feet of dim light.</p></li></ul><p>The light persists
+            until you dismiss the effect or remove the item.</p>
           cost:
             action: 1
             focus: 0
@@ -78,8 +78,7 @@ effects:
             scope: 1
             self: false
           effects:
-            - _id: affixLuminous000
-              name: Luminous
+            - name: Luminous
               scope: 1
               result:
                 type: any
@@ -91,10 +90,15 @@ effects:
                 maintenance: null
                 regions: []
                 summons: []
+                dc: null
+                properties: []
+              duration:
+                value: null
+                units: ''
+                expiry: null
+                expired: false
           tags: []
-          summon:
-            actorUuid: null
-            permanent: true
+          summon: null
     _id: luminous00000000
     img: icons/magic/light/orb-shadow-blue.webp
     disabled: false
@@ -108,16 +112,16 @@ effects:
     transfer: false
     statuses: []
     showIcon: 1
-    folder: hd7WNbghiYX3GDXN
-    sort: 300000
+    folder: lCO6ziuWen5phfix
+    sort: 100000
     flags: {}
     _stats:
-      coreVersion: '14.360'
+      coreVersion: '14.364'
       systemId: crucible
-      systemVersion: 0.9.2
-      createdTime: 1777771500000
-      modifiedTime: 1777771500000
-      lastModifiedBy: WRGzDgYAt3ZuX6TU
+      systemVersion: 0.10.0
+      createdTime: 1782156024091
+      modifiedTime: 1782156024091
+      lastModifiedBy: ZXJsFnFZuf21WDAk
       compendiumSource: Compendium.crucible.affixes.ActiveEffect.luminous00000000
       duplicateSource: null
       exportSource: null
@@ -131,12 +135,12 @@ flags:
   ember:
     crucibleOverride: true
 _stats:
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
   systemVersion: 0.9.1
   createdTime: 1776981020859
-  modifiedTime: 1777771497185
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1782156042676
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null
   duplicateSource: null

--- a/module/applications/sheets/effect-affix-sheet.mjs
+++ b/module/applications/sheets/effect-affix-sheet.mjs
@@ -123,7 +123,6 @@ export default class CrucibleAffixEffectSheet extends api.HandlebarsApplicationM
       case "actions":
         context.actionPartial = this.constructor.ACTION_PARTIAL;
         const editorCls = CONFIG.ux.TextEditor;
-        const editorOptions = {relativeTo: effect, secrets: effect.isOwner};
         context.actionGroups = [{
           legend: null,
           canAdd: true,
@@ -133,7 +132,7 @@ export default class CrucibleAffixEffectSheet extends api.HandlebarsApplicationM
             name: action.name,
             img: action.img,
             condition: action.condition,
-            description: await editorCls.enrichHTML(action.description, editorOptions),
+            description: await editorCls.enrichHTML(action.description, {relativeTo: action, secrets: effect.isOwner}),
             tags: action.getTags(),
             effects: action.effects
           })))

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -272,10 +272,9 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
    */
   async #prepareActionGroups() {
     const editorCls = CONFIG.ux.TextEditor;
-    const editorOptions = {relativeTo: this.document, secrets: this.document.isOwner};
     const enrichAction = async action => ({
       id: action.id, name: action.name, img: action.img, condition: action.condition,
-      description: await editorCls.enrichHTML(action.description, editorOptions),
+      description: await editorCls.enrichHTML(action.description, {relativeTo: action, secrets: this.document.isOwner}),
       tags: action.getTags(), effects: action.effects
     });
 
@@ -340,7 +339,6 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
    */
   async #prepareAffixes() {
     const editorCls = CONFIG.ux.TextEditor;
-    const editorOptions = {relativeTo: this.document, secrets: this.document.isOwner};
     const prefixes = [];
     const suffixes = [];
     for ( const affix of Object.values(this.document.system.affixes) ) {
@@ -349,7 +347,7 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         id: affix.id,
         name: affix.name,
         img: affix.img,
-        description: await editorCls.enrichHTML(affix.description, editorOptions),
+        description: await editorCls.enrichHTML(affix.description, {relativeTo: affix, secrets: this.document.isOwner}),
         tier: tierValue,
         tierRoman: ["", "I", "II", "III"][tierValue] ?? tierValue
       };

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -420,13 +420,12 @@ export default class CrucibleItem extends foundry.documents.Item {
    */
   async prepareActionsContext() {
     const editorCls = CONFIG.ux.TextEditor;
-    const editorOptions = {relativeTo: this, secrets: this.isOwner};
     return Promise.all((this.actions ?? []).map(async action => ({
       id: action.id,
       name: action.name,
       img: action.img,
       condition: action.condition,
-      description: await editorCls.enrichHTML(action.description, editorOptions),
+      description: await editorCls.enrichHTML(action.description, {relativeTo: action, secrets: this.isOwner}),
       tags: action.getTags(),
       effects: action.effects
     })));

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1004,7 +1004,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
     Object.defineProperties(this, {
       actor: {value: actor, writable: false, configurable: true},
       affix: {value: affix, writable: false, configurable: true},
-      item: {value: item ?? this.parent?.parent, writable: false, configurable: true},
+      item: {value: item ?? (affix ? affix.item : this.parent?.parent), writable: false, configurable: true},
       token: {value: token, writable: false, configurable: true},
       region: {value: region, writable: false, configurable: true},
       movement: {value: movement, writable: false, configurable: true},


### PR DESCRIPTION
Closes #1299 
Pack changes:
- Gem of Conjured Flame now uses `@ref[item.name]` instead of `@ref[name]`
- Gem of Illumination update to use current version of Luminous affix

Code changes:
- In order to support being able to use `@ref[item.name]` on an action, each time we enrich an action's description it must use itself as the `relativeTo`, where previously it was sometimes using the item it was on. So, each time we enrich actions in a loop, I've ensured we're doing so with `relativeTo` set to the action itself.
- I did the same for actions granted by affixes on the affix sheet, and for _affixes_ on an item on the _item_ sheet.
- Finally, an Action's `item` was pointing at an active effect document in the case that it was granted via affix; I've modified the logic in `CrucibleAction#_configure` such that, if it is indeed an affix-riding action, it uses the affix's `item` property to populate `item`. This means that affixes which reference `@ref[item.name]` will work properly now.

There are additional actions which currently use `@ref[name]` to reference their item's name (which has gone unnoticed because the action shares a name with the item) that I'd like to change, but those should wait until #1347 goes in, as all of the bombs do it. The full list of items using `@ref[name]` when it should be `@ref[item.name]` (which will be a follow-up PR):
- Alchemist's Fire
- Antitoxin
- Blast Flask
- Caustic Phial
- Choking Ampoule
- Electrocharge Ampoule
- Frostdrop Flask/Phial
- Lantern
- Paralytic Vial's "Ingest Paralytic"
- Poison Vial's "Ingest Poison"
- Torch