### PR TITLE
[#1322] Fix NaN-displayed percentages for physical defenses on sheet, ensure minimum per physical defense is 0

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -254,6 +254,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
     const data = this.document.system.defenses;
 
     // Physical defenses
+    const safeTotal = Math.max(data.physical.total, 1);
     const defenses = {
       physical: {
         value: data.physical.total,
@@ -263,28 +264,28 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
           armor: {
             value: data.armor.total,
             label: SYSTEM.DEFENSES.armor.label,
-            pct: Math.round(data.armor.total * 100 / data.physical.total),
+            pct: Math.round(data.armor.total * 100 / safeTotal),
             cssClass: data.armor.total > 0 ? "active" : "inactive",
             separator: "="
           },
           dodge: {
             value: data.dodge.total,
             label: SYSTEM.DEFENSES.dodge.label,
-            pct: Math.round(data.dodge.total * 100 / data.physical.total),
+            pct: Math.round(data.dodge.total * 100 / safeTotal),
             cssClass: data.dodge.total > 0 ? "active" : "inactive",
             separator: "+"
           },
           parry: {
             value: data.parry.total,
             label: SYSTEM.DEFENSES.parry.label,
-            pct: Math.round(data.parry.total * 100 / data.physical.total),
+            pct: Math.round(data.parry.total * 100 / safeTotal),
             cssClass: data.parry.total > 0 ? "active" : "inactive",
             separator: "+"
           },
           block: {
             value: data.block.total,
             label: SYSTEM.DEFENSES.block.label,
-            pct: Math.round(data.block.total * 100 / data.physical.total),
+            pct: Math.round(data.block.total * 100 / safeTotal),
             cssClass: data.block.total > 0 ? "active" : "inactive",
             separator: "+"
           }

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -1021,7 +1021,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
 
     // Compute defense totals
     for ( const defense of Object.values(defenses) ) {
-      defense.total = defense.base + defense.bonus;
+      defense.total = Math.max(0, defense.base + defense.bonus);
     }
 
     // Cannot parry or block while enraged


### PR DESCRIPTION
Closes #1322 
If total physical defense is 0, treat it as 1 purely for the purposes of determining a percentage contribution of each (0, mandatorily) physical defense.
Additionally, during final defense prep, cap each individual total (armor, dodge, parry, block) to a minimum of 0, preventing negative totals.