### PR TITLE
[#1299] Address remaining `@ref[name]`s which should be `@ref[item.name]`s

### DIFF
--- a/_source/equipment/Alchemist_s_Fire_alchemistsFire00.yml
+++ b/_source/equipment/Alchemist_s_Fire_alchemistsFire00.yml
@@ -26,12 +26,12 @@ system:
       img: icons/consumables/potions/bottle-round-corked-yellow.webp
       condition: ''
       description: >-
-        <p>You hurl the @ref[name], dealing @Rule[action.weakened] immediate
-        <strong>Fire</strong> damage but causing the @Condition[burning]
-        condition to all enemies in a 4 foot radius <strong>Blast</strong> who
-        fail to avoid the attack.</p><p>The amount of burning damage and its
-        duration is dependent on the quality of the
-        @ref[name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 2
+        <p>You hurl the @ref[item.name], dealing @Rule[action.weakened]
+        immediate <strong>Fire</strong> damage but causing the
+        @Condition[burning] condition to all enemies in a 4 foot radius
+        <strong>Blast</strong> who fail to avoid the attack.</p><p>The amount of
+        burning damage and its duration is dependent on the quality of the
+        @ref[item.name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 2
         rounds</p></li><li><p><strong>Standard</strong> - 3 damage for 3
         rounds</p></li><li><p><strong>Fine</strong> - 4 damage for 4
         rounds</p></li><li><p><strong>Superior</strong> - 6 damage for 5
@@ -103,7 +103,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.10.0
   createdTime: 1772307157757
-  modifiedTime: 1782153571418
+  modifiedTime: 1782224845578
   lastModifiedBy: ZXJsFnFZuf21WDAk
 sort: 500000
 _key: '!items!alchemistsFire00'

--- a/_source/equipment/Antitoxin_antitoxin0000000.yml
+++ b/_source/equipment/Antitoxin_antitoxin0000000.yml
@@ -27,10 +27,10 @@ system:
       img: icons/consumables/potions/potion-vial-tube-yellow.webp
       condition: ''
       description: >-
-        <p>Consuming this @ref[name] is able to neutralize any
+        <p>Consuming this @ref[item.name] is able to neutralize any
         @Condition[poisoned] conditions affecting the target. Stronger poisons
         require a stronger antitoxin to neutralize.</p><p>The category of poison
-        negated by this @ref[name] depends on its
+        negated by this @ref[item.name] depends on its
         quality:</p><ul><li><p><strong>Shoddy</strong> - Poisons dealing 3
         damage or less per round</p></li><li><p><strong>Standard</strong> -
         Poisons dealing 5 damage or less per
@@ -58,9 +58,7 @@ system:
       tags:
         - consume
         - healing
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -78,10 +76,10 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307157758
-  modifiedTime: 1773514792257
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1782224860580
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _key: '!items!antitoxin0000000'

--- a/_source/equipment/Blast_Flask_KdlUUFhAnpv6YIHT.yml
+++ b/_source/equipment/Blast_Flask_KdlUUFhAnpv6YIHT.yml
@@ -30,7 +30,7 @@ system:
       img: icons/weapons/thrown/bomb-fuse-red-black.webp
       condition: ''
       description: >-
-        <p>You light and throw the @ref[name], dealing <strong>Fire
+        <p>You light and throw the @ref[item.name], dealing <strong>Fire
         </strong>damage to all enemies in the radius of the explosion who fail
         to avoid the attack. The radius of the <strong>Blast</strong> depends on
         the quality of the bomb:</p><ul><li><p><strong>Shoddy</strong> - 3
@@ -90,7 +90,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.10.0
   createdTime: 1772307157756
-  modifiedTime: 1782153594707
+  modifiedTime: 1782224877464
   lastModifiedBy: ZXJsFnFZuf21WDAk
 sort: 600000
 _key: '!items!KdlUUFhAnpv6YIHT'

--- a/_source/equipment/Caustic_Phial_causticPhial0000.yml
+++ b/_source/equipment/Caustic_Phial_causticPhial0000.yml
@@ -26,12 +26,12 @@ system:
       img: icons/consumables/potions/bottle-conical-fumes-green.webp
       condition: ''
       description: >-
-        <p>You fling the @ref[name], dealing @Rule[action.weakened] immediate
-        <strong>Acid</strong> damage but causing the @Condition[corroding]
-        condition to all enemies in a 4 foot radius <strong>Blast</strong> who
-        fail to avoid the attack.</p><p>The amount of corroding damage and its
-        duration is dependent on the quality of the
-        @ref[name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 2
+        <p>You fling the @ref[item.name], dealing @Rule[action.weakened]
+        immediate <strong>Acid</strong> damage but causing the
+        @Condition[corroding] condition to all enemies in a 4 foot radius
+        <strong>Blast</strong> who fail to avoid the attack.</p><p>The amount of
+        corroding damage and its duration is dependent on the quality of the
+        @ref[item.name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 2
         rounds</p></li><li><p><strong>Standard</strong> - 3 damage for 3
         rounds</p></li><li><p><strong>Fine</strong> - 4 damage for 4
         rounds</p></li><li><p><strong>Superior</strong> - 6 damage for 5
@@ -103,7 +103,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.10.0
   createdTime: 1772307157760
-  modifiedTime: 1782153633842
+  modifiedTime: 1782224894738
   lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: causticPhial0000
 sort: 100000

--- a/_source/equipment/Choking_Ampoule_chokingAmpoule00.yml
+++ b/_source/equipment/Choking_Ampoule_chokingAmpoule00.yml
@@ -27,13 +27,13 @@ system:
       img: icons/consumables/potions/potion-flask-corked-cyan.webp
       condition: ''
       description: >-
-        <p>You hurl the @ref[name], which is <strong>Harmless</strong> in its
-        immediate effect but causes the @Condition[poisoned] condition to all
-        enemies in an 8 foot radius <strong>Blast</strong> who fail to resist
-        the attack with their <strong>Fortitude</strong>.</p><p>The gas deals
-        poison damage to <strong>Morale</strong> in an amount dependent on the
-        quality of the @ref[name]. Upon a critical success, the affected target
-        also becomes @Condition[silenced] for the
+        <p>You hurl the @ref[item.name], which is <strong>Harmless</strong> in
+        its immediate effect but causes the @Condition[poisoned] condition to
+        all enemies in an 8 foot radius <strong>Blast</strong> who fail to
+        resist the attack with their <strong>Fortitude</strong>.</p><p>The gas
+        deals poison damage to <strong>Morale</strong> in an amount dependent on
+        the quality of the @ref[item.name]. Upon a critical success, the
+        affected target also becomes @Condition[silenced] for the
         duration.</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 3
         rounds</p></li><li><p><strong>Standard</strong> - 6 damage for 3
         rounds</p></li><li><p><strong>Fine</strong> - 12 damage for 3
@@ -80,9 +80,9 @@ system:
       tags:
         - consume
         - harmless
+        - fortitude
         - skill
         - athletics
-        - fortitude
       summon: null
   uses:
     value: 1
@@ -105,7 +105,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.10.0
   createdTime: 1772307157761
-  modifiedTime: 1782153373664
+  modifiedTime: 1782224912110
   lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: chokingAmpoule00
 sort: 300000

--- a/_source/equipment/Electrocharge_Ampoule_electrochargeFla.yml
+++ b/_source/equipment/Electrocharge_Ampoule_electrochargeFla.yml
@@ -32,7 +32,7 @@ system:
       img: icons/consumables/potions/flask-corked-yellow-glow.webp
       condition: ''
       description: >-
-        <p>You throw the @ref[name], dealing weakened <strong>Electricity
+        <p>You throw the @ref[item.name], dealing weakened <strong>Electricity
         </strong>damage to all enemies in the radius of the discharge who fail
         to avoid the attack and leaving them briefly @Condition[staggered]. The
         radius of the <strong>Discharge</strong> depends on the quality of the
@@ -111,7 +111,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.10.0
   createdTime: 1776980627490
-  modifiedTime: 1782153705650
+  modifiedTime: 1782224923635
   lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null

--- a/_source/equipment/Frostdrop_Phial_frostdropFlask00.yml
+++ b/_source/equipment/Frostdrop_Phial_frostdropFlask00.yml
@@ -31,7 +31,7 @@ system:
       img: icons/consumables/potions/flask-corked-blue-glow.webp
       condition: ''
       description: >-
-        <p>You throw the @ref[name], dealing weakened <strong>Cold
+        <p>You throw the @ref[item.name], dealing weakened <strong>Cold
         </strong>damage to all enemies in the radius of the explosion who fail
         to avoid the attack and causing them to be @Condition[slowed] briefly.
         The radius of the <strong>Blast</strong> depends on the quality of the
@@ -110,7 +110,7 @@ _stats:
   systemId: crucible
   systemVersion: 0.10.0
   createdTime: 1776980754250
-  modifiedTime: 1782153465865
+  modifiedTime: 1782224940612
   lastModifiedBy: ZXJsFnFZuf21WDAk
   exportSource: null
   compendiumSource: null

--- a/_source/equipment/Lantern_lantern000000000.yml
+++ b/_source/equipment/Lantern_lantern000000000.yml
@@ -24,8 +24,8 @@ system:
       name: Light Lantern
       img: icons/sundries/lights/lantern-iron-yellow.webp
       description: >-
-        <p>You ignite the @ref[name], producing steady illumination in a wide
-        radius. This action consumes one unit of
+        <p>You ignite the @ref[item.name], producing steady illumination in a
+        wide radius. This action consumes one unit of
         @UUID[Compendium.crucible.equipment.Item.lanternOil000000]{Lantern Oil}
         from your inventory; the burn duration depends on the quality of the oil
         consumed:</p><ul><li><p><strong>Shoddy</strong> - 1
@@ -68,11 +68,10 @@ system:
             maintenance: null
             regions: []
             summons: []
+            dc: null
+            properties: []
       tags: []
-      summon:
-        actorUuid: null
-        permanent: true
-      autoFavorite: false
+      summon: null
   skills:
     - awareness
     - stealth
@@ -87,12 +86,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.8.6
+  systemVersion: 0.10.0
   createdTime: 1762712297360
-  modifiedTime: 1773514792276
-  lastModifiedBy: AnoypGxxNIMOS0XY
+  modifiedTime: 1782224955801
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: lantern000000000
 sort: 1400000
 _key: '!items!lantern000000000'

--- a/_source/equipment/Paralytic_Vial_paralyticVial000.yml
+++ b/_source/equipment/Paralytic_Vial_paralyticVial000.yml
@@ -28,7 +28,7 @@ system:
         creature, it is initially <strong>Harmless</strong>, but the target must
         defend an attack against its <strong>Fortitude</strong> or become
         @Condition[paralyzed].</p><p>The duration is dependent on the quality of
-        the @ref[name]:</p><ul><li><p><strong>Shoddy</strong> - 1
+        the @ref[item.name]:</p><ul><li><p><strong>Shoddy</strong> - 1
         rounds</p></li><li><p><strong>Standard</strong> - 2
         rounds</p></li><li><p><strong>Fine</strong> - 4
         rounds</p></li><li><p><strong>Superior</strong> - 8
@@ -63,20 +63,21 @@ system:
             value: 1
             units: rounds
             expiry: turnEnd
+            expired: false
           system:
             dot: []
             maintenance: null
             regions: []
             summons: []
             changes: []
+            dc: null
+            properties: []
       tags:
         - harmless
         - fortitude
         - skill
         - medicine
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
     - id: paralyticApply
       name: Apply Paralytic
       img: icons/consumables/potions/potion-bottle-skull-label-poison-teal.webp
@@ -104,9 +105,7 @@ system:
       effects: []
       tags:
         - consume
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -125,12 +124,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307157771
-  modifiedTime: 1773514792278
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1782224991134
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: paralyticVial000
 sort: 100000
 _key: '!items!paralyticVial000'

--- a/_source/equipment/Poison_Vial_poisonVial000000.yml
+++ b/_source/equipment/Poison_Vial_poisonVial000000.yml
@@ -33,7 +33,7 @@ system:
         defend an attack against its <strong>Fortitude</strong> or become
         @Condition[poisoned].</p><p>The amount of poison damage and its duration
         is dependent on the quality of the
-        @ref[name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 4
+        @ref[item.name]:</p><ul><li><p><strong>Shoddy</strong> - 2 damage for 4
         rounds</p></li><li><p><strong>Standard</strong> - 4 damage for 6
         rounds</p></li><li><p><strong>Fine</strong> - 6 damage for 8
         rounds</p></li><li><p><strong>Superior</strong> - 8 damage for 10
@@ -64,6 +64,7 @@ system:
             value: 6
             units: rounds
             expiry: turnEnd
+            expired: false
           result:
             type: success
             all: false
@@ -73,14 +74,14 @@ system:
             maintenance: null
             regions: []
             summons: []
+            dc: null
+            properties: []
       tags:
         - harmless
         - fortitude
         - skill
         - medicine
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
     - id: poisonApply
       name: Apply Poison
       img: >-
@@ -109,9 +110,7 @@ system:
       effects: []
       tags:
         - consume
-      summon:
-        actorUuid: null
-        permanent: true
+      summon: null
   uses:
     value: 1
     max: 1
@@ -129,10 +128,10 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.356'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.0
+  systemVersion: 0.10.0
   createdTime: 1772307157773
-  modifiedTime: 1773514792280
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1782224976346
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _key: '!items!poisonVial000000'

--- a/_source/equipment/Torch_torch00000000000.yml
+++ b/_source/equipment/Torch_torch00000000000.yml
@@ -25,8 +25,8 @@ system:
       name: Light Torch
       img: icons/sundries/lights/torch-brown-lit.webp
       description: >-
-        <p>You ignite the @ref[name], producing flickering illumination in a
-        wide radius for one hour. The torch is consumed by this action and
+        <p>You ignite the @ref[item.name], producing flickering illumination in
+        a wide radius for one hour. The torch is consumed by this action and
         cannot be used again, but its light remains until it burns out.</p>
       condition: ''
       cost:
@@ -62,12 +62,11 @@ system:
             maintenance: null
             regions: []
             summons: []
+            dc: null
+            properties: []
       tags:
         - consume
-      summon:
-        actorUuid: null
-        permanent: true
-      autoFavorite: false
+      summon: null
   uses:
     value: 1
     max: 1
@@ -86,12 +85,12 @@ _stats:
   compendiumSource: null
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.360'
+  coreVersion: '14.364'
   systemId: crucible
-  systemVersion: 0.9.1
+  systemVersion: 0.10.0
   createdTime: 1772307157781
-  modifiedTime: 1777761009760
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1782225004959
+  lastModifiedBy: ZXJsFnFZuf21WDAk
 _id: torch00000000000
 sort: 0
 _key: '!items!torch00000000000'


### PR DESCRIPTION
Now that the other bomb changes are in, can do this without conflicting with them.
This is _purely_ a replacement of `@ref[name]` to `@ref[item.name]` within the 11 actions.