### PR TITLE
[#1355] Adding microgrid check for token movement and resizing logic

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2981,6 +2981,7 @@ export default class CrucibleActor extends Actor {
     // Unlinked Token Actor
     if ( this.isToken ) {
       if ( this.token.width === size ) return;
+      if ( !this.token.parent?.useMicrogrid ) return;
       const waypoint = {...dimensions, ...this.#resolveResizePosition(this.token, size)};
       await this.token.parent.moveTokens({[this.token.id]: {waypoints: [waypoint]}}, {_crucibleRelatedUpdate: true});
       return;
@@ -2996,6 +2997,7 @@ export default class CrucibleActor extends Actor {
       // FIXME: Actor#getDependentTokens can return stale/deleted tokens no longer present in the Scene collection.
       //   Remove this guard once core stops returning dead references from Actor#_dependentTokens.
       if ( !token.parent?.tokens.has(token.id) ) continue;
+      if ( !token.parent?.useMicrogrid ) continue;
       const waypoint = {...dimensions, ...this.#resolveResizePosition(token, size)};
       (scenes[token.parent.id] ||= {})[token.id] = {waypoints: [waypoint]};
     }

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -68,7 +68,7 @@ export default class CrucibleToken extends foundry.documents.TokenDocument {
   /** @inheritDoc */
   async _preCreate(data, options, user) {
     if ( (await super._preCreate(data, options, user)) === false ) return false;
-
+    if ( !this.parent?.useMicrogrid ) return; 
     // Enforce Token size as prepared Actor size
     const actor = this.actor ?? this.baseActor;
     if ( actor && (actor.type !== "group") ) {


### PR DESCRIPTION
I know this isn't pr:available, but wanted to take a crack at it, by adding `if ( !this.token.parent?.useMicrogrid ) return;` to the actor and token did fix the issue of small tokens in vistas while keeping the hulking effect working correctly. 