### PR TITLE
[#1351, #1325] Improve ruler labeling of forced movement, implement mechanism for overriding calculated cost

### DIFF
--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -58,7 +58,7 @@ export function configure() {
     icon: "fa-solid fa-explosion",
     img: "icons/svg/explosion.svg",
     teleport: false,
-    measure: false,
+    measure: true,
     visualize: true,
     costMultiplier: 0,
     speedMultiplier: 1,

--- a/module/canvas/token-ruler.mjs
+++ b/module/canvas/token-ruler.mjs
@@ -42,7 +42,7 @@ export default class CrucibleTokenRuler extends foundry.canvas.placeables.tokens
       units: grid.units,
       total: (waypoint.measurement.distance - state.priorDistance).toNearest(0.01).toLocaleString(game.i18n.lang)
     });
-    const isForced = game.user.isGM && !!ui.controls.controls.tokens?.tools?.forcedMovement?.active;
+    const isForced = waypoint.action === "push";
     if ( isForced ) context.cost = {units: "", delta: game.i18n.localize("TOKEN.MOVEMENT.COST.Forced"),
       displayCost: isFinalOfSubpath};
     else if ( !Number.isFinite(deltaCost) ) context.cost = {units: "",

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -303,6 +303,14 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   /*  Movement                                    */
   /* -------------------------------------------- */
 
+  /** @inheritDoc */
+  _getDragMovementAction() {
+    if ( game.user.isGM && ui.controls.controls.tokens?.tools?.forcedMovement?.active ) return "push";
+    return super._getDragMovementAction();
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   _getDragLeftDropUpdateOptions() {
     const options = super._getDragLeftDropUpdateOptions();
@@ -315,10 +323,11 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   /* -------------------------------------------- */
 
   /** @override */
-  _getMovementCostFunction(options) {
+  _getMovementCostFunction(options={}) {
     const calculateTerrainCost = CONFIG.Token.movement.TerrainData.getMovementCostFunction(this.document, options);
     const actionCostFunctions = {};
     const actor = this.actor;
+    if ( "overrideCost" in options ) return (from, to, distance, segment) => options.overrideCost;
 
     // Construct and return cost function
     return (from, to, distance, segment) => {
@@ -357,6 +366,18 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
     // Unlike the predicate, movement strength is a plain number, so it rides the serialized options to execution
     if ( options.crucible?.movementStrength ) config.movementStrength = options.crucible.movementStrength;
     return config;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  // TODO: Remove once Core passes measureOptions in #updatePlannedMovement
+  measureMovementPath(waypoints, options) {
+    const context = this.layer._movementPlanningContext;
+    if ( context?.object === this ) {
+      options = {...context.measureOptions, ...(options ?? {})};
+    }
+    return super.measureMovementPath(waypoints, options);
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -371,7 +371,7 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  // TODO: Remove once Core passes measureOptions in #updatePlannedMovement
+  // FIXME remove this override once 14.365 is out with https://github.com/foundryvtt/foundry-vtt/pull/5764
   measureMovementPath(waypoints, options) {
     const context = this.layer._movementPlanningContext;
     if ( context?.object === this ) {

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -657,7 +657,8 @@ export default class ActionUseDialog extends StandardCheckDialog {
             excludeTokens,
             movementStrength: movementUsage.strength
           }
-        }
+        },
+        measureOptions: movementUsage.measureOptions ?? {}
       });
     } finally {
       token.object._movementExcludeTest = null;
@@ -675,7 +676,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
     }
 
     // Measure the cost of the planned path, then store the movement on the action
-    const {cost} = token.object.measureMovementPath([plan.origin, ...plan.waypoints]);
+    const {cost} = token.object.measureMovementPath([plan.origin, ...plan.waypoints], movementUsage.measureOptions);
     const movement = {id: plan.id, origin: plan.origin, waypoints: plan.waypoints, cost, plan};
     Object.defineProperty(this.action, "movement", {value: movement, configurable: true});
     this.action.prepare();

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -124,11 +124,12 @@ export default class CrucibleToken extends foundry.documents.TokenDocument {
       return;
     }
 
+    const isForced = [...movement.passed.waypoints, ...movement.pending.waypoints].every(w => w.action === "push");
     if ( !this.parent?.useMicrogrid                             // Must be a crucible 1ft grid scene
       || !this.actor?.inCombat                                  // Must have an Actor in combat
       || (movement.method !== "dragging")                       // Must be a drag action
       || movement.chain.length                                  // Must be the first segment
-      || CrucibleToken.#isForcedMovement                        // Forced Movement bypasses AP entirely
+      || isForced                                               // Forced Movement bypasses AP entirely
       || this._confirmedMovements?.has(movement.id) ) return;   // AP already spent via dialog
 
     // Verify that the movement cost is affordable and either prevent movement or record the total cost
@@ -158,23 +159,17 @@ export default class CrucibleToken extends foundry.documents.TokenDocument {
     }
 
     if ( (movement.method !== "dragging") || movement.chain.length ) return;
-    if ( CrucibleToken.#isForcedMovement ) return;              // Forced Movement skips Move action creation
-    if ( this._confirmedMovements?.has(movement.id) ) {         // AP already spent via dialog
+
+    // Forced Movement skips Move action creation
+    if ( [...movement.passed.waypoints, ...movement.pending.waypoints].every(w => w.action === "push") ) return;
+
+    // AP already spent via dialog
+    if ( this._confirmedMovements?.has(movement.id) ) {
       this._confirmedMovements.delete(movement.id);
       return;
     }
     const costFeet = movement.passed.cost + movement.pending.cost;
     this.actor.useMove(costFeet, {dialog: false, movement});
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is the GM's "Forced Movement" scene controls toggle currently active?
-   * @type {boolean}
-   */
-  static get #isForcedMovement() {
-    return game.user.isGM && !!ui.controls.controls.tokens?.tools?.forcedMovement?.active;
   }
 
   /* -------------------------------------------- */

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -620,18 +620,23 @@ HOOKS.electrochargeAmpoule = {
 
 /* -------------------------------------------- */
 
-// TODO: Currently this will consume free movement. Determine how to make that not the case while still properly
-// showing 0 cost on the token ruler
 HOOKS.evasiveShot = {
   prepare() {
     this.range.maximum = Math.round(this.actor.system.movement.stride / 2);
     this.cost.action = 0;
+    this.usage.freeMove = false;
+    this.usage.movement.measureOptions = {
+      overrideCost: 0
+    };
   },
   canUse() {
     const lastAction = this.actor.lastConfirmedAction;
     if ( !lastAction?.tags.has("ranged") ) {
       throw new Error(_loc("ACTION.WARNINGS.MustFollowRanged", {action: this.name}));
     }
+  },
+  postActivate() {
+    delete this.selfEvents.actorUpdate.actorUpdates.system.status.hasMoved;
   }
 };
 

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -66,6 +66,7 @@ import CrucibleActionConfig from "../applications/config/action-config.mjs";
  * @property {boolean} [direct=true]        Require the planned path to be a single direct segment with no intermediate
  *                                          waypoints. Otherwise, a multi-segment path is allowed. (default true)
  * @property {object} [constrainOptions]    Movement constraint options passed to `Token#planMovement`
+ * @property {object} [measureOptions]      Movement measurement options passed to `Token#planMovement`
  */
 
 /**


### PR DESCRIPTION
Closes #1351 
Closes #1325 
This is primarily two changes, one to do with forced movement, one which I think will come in handy for talents which let you move for a given static cost, like Evasive Shot.
Changes to **forced movement**:
- Any drag movement made by the GM with Forced Movement toggled on on the tools will default to the **push** movement action.
- Movement made with the **push** action will now display the distance moved on the ruler waypoints, rather than just "0ft | Forced" (set `measure` to `true` on the action config).
  - As a consequence of this change `costMultiplier: 0` is no longer sufficient to allow Infinity-cost movement (e.g. Restrained).
- Whether movement is forced is now detected based on movement action (**push** is forced, others are not) in the token ruler. This addresses the #1351 bug where whether it read Forced was entirely based on the state of the GM's tools at the time of rendering.
- Similarly, early exit from `CrucibleToken#_(pre|on)UpdateMovement` is determined by whether all passed & pending waypoints for the given movement are **push**-action.

New **measureOptions** changes:
- `CrucibleTokenObject#_getMovementCostFunction` now check for the existence of an `overrideCost` field in `options`. If present, the returned function is one which will invariably return the value of `overrideCost`.
- To support this:
  - `ActionMovementUsage` (aka `someAction.usage.movement`) now supports an optional `measureOptions`.
  - In the Action Use Dialog, these `measureOptions` are passed to `planMovement`, and to `CrucibleTokenObject#measureMovementPath`.
  - The latter function above has been temporarily (I think) overridden, as there is [maybe a core bug](https://discord.com/channels/170995199584108546/1421197270375989348/1519727582084333691) where `measureOptions` are not passed to it from `Token##updatePlannedMovement`, so if there is a planning context matching the token in question we will infer them from said context.

And an example of using the latter changes, **Evasive Shot**:
- Sets `this.usage.freeMove` in `prepare` in case an Evasive Shot was the first movement of the actor's turn.
- Sets `this.usage.movement.measureOptions` to `{overrideCost: 0}` in `prepare` to make use of the above changes and ensure that the cost for any planned movement calculates to 0 (it is still constrained by walls and by the `maxDistance`).
- Removes any potential update to `status.hasMoved` in `postActivate` to ensure that free movement isn't consumed by this _special_ free movement.

**Open Question**: Should **push** be visible on the token hud as a movement action? It seems unnecessary with the Forced Movement toggle, and like a tool that players needn't have a use for. That said I don't think it's doing much _harm_ being there.