### PR TITLE
Automate Eye of the Storm boon

### DIFF
--- a/_source/talent/Eye_of_the_Storm_eyeofthestorm000.yml
+++ b/_source/talent/Eye_of_the_Storm_eyeofthestorm000.yml
@@ -5,8 +5,7 @@ img: icons/magic/water/wave-water-explosion.webp
 system:
   description: >-
     <p>After you Delay your Turn, gain +2 Boons on any Strike or Spell attack
-    against an enemy that you allowed to act before you that Round.</p><p>TODO:
-    Needs automation. For now apply boons manually.</p>
+    against an enemy that you allowed to act before you that Round.</p>
   actions: []
   nodes:
     - wis1a

--- a/_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml
+++ b/_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml
@@ -37,7 +37,7 @@ system:
           duration:
             value: 1
             units: rounds
-            expiry: turnEnd
+            expiry: turnStart
           system:
             dot: []
             maintenance: null

--- a/_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml
+++ b/_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml
@@ -37,7 +37,7 @@ system:
           duration:
             value: 1
             units: rounds
-            expiry: turnStart
+            expiry: turnEnd
           system:
             dot: []
             maintenance: null

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1048,7 +1048,7 @@ export default class CrucibleActor extends Actor {
     await this.update(foundry.utils.mergeObject(actorUpdates, {"flags.crucible.delay": {
       round: game.combat.round,
       from: combatant.initiative,
-      fromTurn: combatant.flags.crucible?.turnNumber ?? 0,
+      fromTurn: combatant.turnNumber ?? 0,
       to: initiative
     }
     }));

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1048,6 +1048,7 @@ export default class CrucibleActor extends Actor {
     await this.update(foundry.utils.mergeObject(actorUpdates, {"flags.crucible.delay": {
       round: game.combat.round,
       from: combatant.initiative,
+      fromTurn: combatant.flags.crucible?.turnNumber ?? 0,
       to: initiative
     }
     }));

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -114,8 +114,33 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @override */
   async _onStartTurn(combatant, context) {
     await super._onStartTurn(combatant, context);
+    if ( game.user.isActiveGM ) await this.#recordDelayWitnesses(combatant);
     // TODO forward turn events to the system subtype
     return combatant.actor.onStartTurn(context);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Record enemy Actors who act while another Actor is Delaying, for talents like Eye of the Storm.
+   * @param {Combatant} combatant     The Combatant whose turn is starting
+   */
+  async #recordDelayWitnesses(combatant) {
+    const actingActor = combatant.actor;
+    if ( !actingActor ) return;
+    const round = this.round;
+    const updates = [];
+    for ( const other of this.combatants ) {
+      const delayingActor = other.actor;
+      if ( !delayingActor || (delayingActor === actingActor) ) continue;
+      const delay = delayingActor.flags.crucible?.delay;
+      if ( !delay || (delay.round !== round) ) continue;
+      if ( delayingActor.getDispositionTowards(actingActor) !== CONST.TOKEN_DISPOSITIONS.HOSTILE ) continue;
+      const witnessed = delay.witnessed || [];
+      if ( witnessed.includes(actingActor.id) ) continue;
+      updates.push({_id: delayingActor.id, "flags.crucible.delay.witnessed": [...witnessed, actingActor.id]});
+    }
+    if ( updates.length ) await Actor.updateDocuments(updates);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -114,33 +114,11 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @override */
   async _onStartTurn(combatant, context) {
     await super._onStartTurn(combatant, context);
-    if ( game.user.isActiveGM ) await this.#recordDelayWitnesses(combatant);
+     const turnNumber = (this.flags.crucible?.turnNumber ?? 0) + 1;
+     await this.update({"flags.crucible.turnNumber": turnNumber});
+     await combatant.update({"flags.crucible.turnNumber": turnNumber});
     // TODO forward turn events to the system subtype
     return combatant.actor.onStartTurn(context);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Record enemy Actors who act while another Actor is Delaying, for talents like Eye of the Storm.
-   * @param {Combatant} combatant     The Combatant whose turn is starting
-   */
-  async #recordDelayWitnesses(combatant) {
-    const actingActor = combatant.actor;
-    if ( !actingActor ) return;
-    const round = this.round;
-    const updates = [];
-    for ( const other of this.combatants ) {
-      const delayingActor = other.actor;
-      if ( !delayingActor || (delayingActor === actingActor) ) continue;
-      const delay = delayingActor.flags.crucible?.delay;
-      if ( !delay || (delay.round !== round) ) continue;
-      if ( delayingActor.getDispositionTowards(actingActor) !== CONST.TOKEN_DISPOSITIONS.HOSTILE ) continue;
-      const witnessed = delay.witnessed || [];
-      if ( witnessed.includes(actingActor.id) ) continue;
-      updates.push({_id: delayingActor.id, "flags.crucible.delay.witnessed": [...witnessed, actingActor.id]});
-    }
-    if ( updates.length ) await Actor.updateDocuments(updates);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -114,9 +114,7 @@ export default class CrucibleCombat extends foundry.documents.Combat {
   /** @override */
   async _onStartTurn(combatant, context) {
     await super._onStartTurn(combatant, context);
-     const turnNumber = (this.flags.crucible?.turnNumber ?? 0) + 1;
-     await this.update({"flags.crucible.turnNumber": turnNumber});
-     await combatant.update({"flags.crucible.turnNumber": turnNumber});
+
     // TODO forward turn events to the system subtype
     return combatant.actor.onStartTurn(context);
   }

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -547,9 +547,15 @@ HOOKS.echolocation0000 = {
 HOOKS.eyeofthestorm000 = {
   prepareAttack(item, action, target, rollData) {
     if ( !action.tags.has("strike") && !action.tags.has("spell") ) return;
-    const witnessed = this.flags.crucible?.delay?.witnessed;
-    if ( !witnessed?.includes(target.id) ) return;
-    rollData.boons.eyeOfTheStorm = {label: item.name, number: 2};
+    const delay = this.flags.crucible?.delay;
+    if ( !delay ) return;
+    if ( this.getDispositionTowards(target) !== CONST.TOKEN_DISPOSITIONS.HOSTILE ) return;
+    const targetTurn = target.combatant?.flags.crucible?.turnNumber;
+    const myTurn = this.combatant?.flags.crucible?.turnNumber;
+    if ( (targetTurn === undefined) || (myTurn === undefined) ) return;
+    if ( (targetTurn >= delay.fromTurn) && (targetTurn < myTurn) ) {
+      rollData.boons.eyeOfTheStorm = {label: item.name, number: 2};
+    }
   }
 }
 

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -550,10 +550,9 @@ HOOKS.eyeofthestorm000 = {
     const delay = this.flags.crucible?.delay;
     if ( !delay ) return;
     if ( this.getDispositionTowards(target) !== CONST.TOKEN_DISPOSITIONS.HOSTILE ) return;
-    const targetTurn = target.combatant?.flags.crucible?.turnNumber;
-    const myTurn = this.combatant?.flags.crucible?.turnNumber;
-    if ( (targetTurn === undefined) || (myTurn === undefined) ) return;
-    if ( (targetTurn >= delay.fromTurn) && (targetTurn < myTurn) ) {
+    const targetTurn = target.combatant?.turnNumber;
+    if ( !Number.isNumeric(targetTurn) ) return;
+    if ( (targetTurn >= delay.fromTurn) && (targetTurn < (this.combatant?.turnNumber ?? 0)) ) {
       rollData.boons.eyeOfTheStorm = {label: item.name, number: 2};
     }
   }

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -544,6 +544,17 @@ HOOKS.echolocation0000 = {
 
 /* -------------------------------------------- */
 
+HOOKS.eyeofthestorm000 = {
+  prepareAttack(item, action, target, rollData) {
+    if ( !action.tags.has("strike") && !action.tags.has("spell") ) return;
+    const witnessed = this.flags.crucible?.delay?.witnessed;
+    if ( !witnessed?.includes(target.id) ) return;
+    rollData.boons.eyeOfTheStorm = {label: item.name, number: 2};
+  }
+}
+
+/* -------------------------------------------- */
+
 HOOKS.evasiveArmor0000 = {
   prepareDefenses(_item, defenses) {
     const defenseTotals = {};


### PR DESCRIPTION

**Main:**

Eye of the Storm gives +2 boons on a Strike/Spell against an enemy who acted during your delay. This automates it instead of leaving it as a manual reminder.

**How:** `flags.crucible.delay` already tracks your delay for the round and sticks around until your resumed turn ends. So whenever a combatant's turn starts, I check for any other actor currently delaying who considers them an enemy, and add them to a `witnessed` list on that delay flag. Then the talent's `prepareAttack` hook just checks if your target is in your own witnessed list and adds the boons if so.

No extra cleanup needed since `witnessed` lives inside `delay`, which already gets deleted when your resumed turn ends.

Tested manually: delayed, let an enemy act, struck them on my resumed turn — boons applied. Confirmed allies acting in between don't count, and the bonus goes away once the delayed turn ends.
