### PR TITLE
Added support for proposed function 861 aka opening a door in combat

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -18,7 +18,6 @@ import * as models from "./module/models/_module.mjs";
 import * as audio from "./module/audio.mjs";
 import * as hooks from "./module/hooks/_module.mjs";
 import {applyEmberPatches} from "./module/hooks/ember.mjs";
-import "./module/hooks/door.mjs";
 
 // Helpers
 import {handleSocketEvent} from "./module/socket.mjs";
@@ -851,6 +850,27 @@ Hooks.on("canvasTearDown", () => {
   CONFIG.Canvas.polygonBackends.move = foundry.canvas.geometry.ClockwiseSweepPolygon;
 });
 
+
+/* -------------------------------------------- */
+
+/**
+ * Door open/close cost, refund, actor, and turn handling live entirely on the "openDoor" CrucibleAction (see
+ * module/hooks/action.mjs), which resolves the acting actor, checks turn order, and applies its Action cost
+ * atomically alongside the wall update. A normal left-click on the door icon is already routed into that Action
+ * by CrucibleDoorControl (see module/canvas/door-control.mjs), so this hook doesn't need to handle the common
+ * case - it's the backstop that stops a raw wall update from reaching the door state some other way (e.g. a
+ * macro, another module, or a stray API call) while the cost setting is active in combat. GMs are exempt.
+ */
+Hooks.on("preUpdateWall", (wall, changes, options, userId) => {
+  if ( options.crucibleAction ) return;                    // came from the openDoor action itself - let it through
+  if ( !("ds" in changes) ) return;                        // not a door-state change, ignore
+  if ( game.user.isGM ) return;                             // GMs may freely toggle doors
+  if ( !game.settings.get("crucible", "doorActionCost") ) return;
+  if ( !game.combat?.started ) return;                      // combat only
+
+  ui.notifications.warn(game.i18n.localize("WARNING.DoorUseAction"));
+  return false;
+});
 
 /* -------------------------------------------- */
 

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -18,6 +18,7 @@ import * as models from "./module/models/_module.mjs";
 import * as audio from "./module/audio.mjs";
 import * as hooks from "./module/hooks/_module.mjs";
 import {applyEmberPatches} from "./module/hooks/ember.mjs";
+import "./module/hooks/door.mjs";
 
 // Helpers
 import {handleSocketEvent} from "./module/socket.mjs";
@@ -26,7 +27,6 @@ import * as chat from "./module/chat.mjs";
 import * as interaction from "./module/interaction.mjs";
 import CrucibleTalentNode from "./module/const/talent-node.mjs";
 import {statusEffects} from "./module/const/statuses.mjs";
-
 // Party
 let party = null;
 
@@ -373,6 +373,15 @@ Hooks.once("init", async function() {
     config: false,
     type: Boolean,
     default: false
+  });
+
+  game.settings.register("crucible", "doorActionCost", {
+    name: "SETTINGS.DoorActionCostName",
+    hint: "SETTINGS.DoorActionCostHint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true
   });
 
   const fields = foundry.data.fields;
@@ -841,6 +850,7 @@ Hooks.on("canvasReady", () => {
 Hooks.on("canvasTearDown", () => {
   CONFIG.Canvas.polygonBackends.move = foundry.canvas.geometry.ClockwiseSweepPolygon;
 });
+
 
 /* -------------------------------------------- */
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -2065,7 +2065,9 @@
     "EnableVFXHint": "Play visual effects animations on the canvas when actions are confirmed.",
     "EnableVFXName": "Enable Action Visual Effects",
     "FlexibleAncestryAbilitiesHint": "When enabled, hero characters may reassign their Ancestry's Primary and Secondary Ability Score bonuses to abilities of their choice during character creation. The Ancestry still contributes the same +2 and +1 starting bonuses; only the abilities receiving them are flexible.",
-    "FlexibleAncestryAbilitiesName": "Flexible Ancestry Ability Bonuses"
+    "FlexibleAncestryAbilitiesName": "Flexible Ancestry Ability Bonuses",
+    "DoorActionCostName": "Doors Cost Action Points",
+    "DoorActionCostHint": "Opening or closing a door in combat costs 1 Action Point for the interacting creature."
   },
   "SKILL": {
     "CATEGORY": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -63,6 +63,10 @@
         "Description": "Move a distance by spending an amount of Action that depends on your Stride and which movement action is used.",
         "Name": "Move"
       },
+      "OpenDoor": {
+        "Description": "Open or close a door within reach. During Combat this costs 1 Action; using it again to reverse your own most recent toggle of the same door refunds that Action.",
+        "Name": "Open/Close Door"
+      },
       "ReactiveStrike": {
         "Description": "Perform a strike when an enemy leaves your engagement and you are not fully engaged.",
         "Name": "Reactive Strike"
@@ -425,6 +429,9 @@
         },
         "ESTOCADE": {
           "RequiresOpening": "Estocade requires a target who is Exposed, Prone, Slowed, Staggered, Paralyzed, or Disarmed."
+        },
+        "OPEN_DOOR": {
+          "WrongTurn": "You may only open or close a door on your own turn in combat."
         },
         "REVIVE": {
           "RequiresDead": "Revive requires a Dead target."
@@ -2694,6 +2701,7 @@
     "CannotEquipInvalidCategory": "Actor {actor} cannot use {item} in the {type} equipment slot.",
     "CannotEquipSlotInUse": "Actor {actor} cannot equip {item} because the {type} item slot is already in use.",
     "CannotEquipTaxonomy": "Actor {actor} cannot equip {item} because the \"{taxonomy}\" taxonomy is incapable of using equipment.",
+    "DoorUseAction": "Use the Open/Close Door action from your sheet to interact with doors during combat.",
     "NoParty": "You must have a primary party configured for this.",
     "SkillRequireAncestryBackground": "You must assign both Ancestry and Background before you can purchase Skill ranks."
   },

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -1,5 +1,6 @@
 import CrucibleTokenRuler from "./token-ruler.mjs";
 import CrucibleTokenHUD from "../applications/hud/token-hud.mjs";
+import CrucibleDoorControl from "./door-control.mjs";
 import {MOVEMENT_ACTIONS, TRAVEL_PACES} from "../const/actor.mjs";
 import {registerVFXAnimations} from "./vfx/animations/_module.mjs";
 import {registerComponents} from "./vfx/components/_module.mjs";
@@ -12,6 +13,7 @@ export * as vfx from "./vfx/_module.mjs";
 export * as movement from "./movement.mjs";
 export {default as CrucibleMovementPolygon} from "./movement-polygon.mjs";
 export {default as CrucibleTokenObject} from "./token.mjs";
+export {default as CrucibleDoorControl} from "./door-control.mjs";
 export {CrucibleTokenRuler};
 
 /**
@@ -20,6 +22,7 @@ export {CrucibleTokenRuler};
 export function configure() {
   CONFIG.Token.rulerClass = CrucibleTokenRuler;
   CONFIG.Token.hudClass = CrucibleTokenHUD;
+  CONFIG.Canvas.doorControlClass = CrucibleDoorControl;
   // Stride of 10, 6 strides per turn, 10 seconds per round, x2 multiplier for visual satisfaction
   CONFIG.Token.movement.defaultSpeed = (10 * 6) * 2 / 10;
 

--- a/module/canvas/door-control.mjs
+++ b/module/canvas/door-control.mjs
@@ -1,0 +1,72 @@
+/**
+ * A specialized DoorControl which routes a player's left-click on a door icon through the "openDoor" CrucibleAction
+ * instead of letting the click perform the raw core door toggle directly.
+ *
+ * Door open/close cost, refund, actor, and turn handling all live on the "openDoor" Action (see
+ * module/hooks/action.mjs). The preUpdateWall hook in crucible.mjs stops a raw wall update from bypassing that
+ * system while the cost setting is active in combat, but on its own it only blocks the click and shows a warning -
+ * it doesn't do anything to route the click into the Action itself. This class is what makes clicking the door
+ * icon actually *work* under those conditions: it resolves the clicking user's own Actor and asks it to use
+ * "openDoor" with this specific wall pre-targeted, so the Action doesn't have to guess which nearby door was meant.
+ *
+ * GM clicks, and player clicks when the cost setting or combat conditions don't apply, are left alone entirely -
+ * they fall through to the default core behavior.
+ * @extends {foundry.canvas.containers.DoorControl}
+ */
+export default class CrucibleDoorControl extends CONFIG.Canvas.doorControlClass {
+
+  /** @override */
+  async _onMouseDown(event) {
+    if ( !this._shouldUseAction() ) return super._onMouseDown(event);
+    event.stopPropagation();
+    return this._useDoorAction();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Should this click be routed through the "openDoor" Action instead of the default core door toggle?
+   * Mirrors the same gating conditions as the preUpdateWall hook in crucible.mjs, since this is the other half of
+   * the same feature: whatever the hook would otherwise block here, this method should intercept instead.
+   * @returns {boolean}
+   */
+  _shouldUseAction() {
+    if ( game.user.isGM ) return false; // GMs may freely toggle doors
+    if ( !game.settings.get("crucible", "doorActionCost") ) return false;
+    if ( !game.combat?.started ) return false; // combat only
+    return this.wall.document.isDoor;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the Actor performing the click: the user's own controlled token if exactly one is selected, otherwise
+   * their assigned character. This deliberately does *not* default to the current combatant - clicking a door
+   * doesn't imply you're acting as whoever's turn it is, and HOOKS.openDoor#canUse already throws a WrongTurn
+   * warning of its own once the Action actually runs if this actor isn't the current combatant.
+   * @returns {CrucibleActor|null}
+   */
+  _getActingActor() {
+    const controlled = canvas.tokens?.controlled ?? [];
+    if ( controlled.length === 1 ) return controlled[0].actor;
+    return game.user.character ?? null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Route the click into the "openDoor" Action for the resolved acting Actor, pre-seeding the specific wall that
+   * was clicked so CrucibleAction's "openDoor" hook doesn't fall back to guessing the nearest door out of
+   * everything within reach.
+   * @returns {Promise<void>}
+   */
+  async _useDoorAction() {
+    const actor = this._getActingActor();
+    const action = actor?.actions.openDoor;
+    if ( !action ) {
+      ui.notifications.warn(game.i18n.localize("WARNING.DoorUseAction"));
+      return;
+    }
+    await actor.useAction("openDoor", {usage: {forcedDoorWallId: this.wall.document.id}});
+  }
+}

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -1488,6 +1488,24 @@ export const DEFAULT_ACTIONS = Object.freeze([
     autoFavorite: true
   },
 
+  // Open/Close Door
+  {
+    id: "openDoor",
+    name: "ACTION.DEFAULT_ACTIONS.OpenDoor.Name",
+    img: "icons/environment/wilderness/cave-entrance.webp",
+    description: "ACTION.DEFAULT_ACTIONS.OpenDoor.Description",
+    target: {
+      type: "self",
+      number: 0,
+      scope: 1
+    },
+    cost: {
+      action: 1
+    },
+    tags: ["harmless"],
+    autoFavorite: true
+  },
+
   // Reactive Strike
   {
     id: "reactiveStrike",

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -1,3 +1,5 @@
+import {requestDoorToggle} from "../socket.mjs";
+
 const HOOKS = {};
 
 /* -------------------------------------------- */
@@ -1542,6 +1544,110 @@ HOOKS.omniglotDecoction = {
   preActivate() {
     const minutes = {shoddy: 10, standard: 60, fine: 240, superior: 720, masterwork: 1440}[this.item.system.quality];
     if ( this.effects[0] ) this.effects[0].duration.value = minutes;
+  }
+};
+
+/* -------------------------------------------- */
+
+HOOKS.openDoor = {
+  suppressFromSheet: true,
+  _MAX_RANGE: 5, // grid units of reach from the actor's token to a door
+
+  /**
+   * Is a given door wall within the actor's reach? On a scene using Scene Levels, a door is only considered if
+   * it's actually on the token's current level - matching the same "empty membership means unrestricted"
+   * convention Region documents use elsewhere in this codebase (see CrucibleTokenDocument##findRestingLevel) - so
+   * a door stacked on a different floor can't be mistaken for one the actor can actually reach. Shared by both the
+   * automatic nearest-door search and an explicitly-targeted wall (see #_resolveDoor), so a canvas click on a door
+   * that's out of reach is rejected the same way an out-of-range door is excluded from the automatic search.
+   * @param {CrucibleActor} actor
+   * @param {Wall} wall
+   * @returns {boolean}
+   */
+  _isReachable(actor, wall) {
+    const token = actor.getActiveTokens(true, false)[0]; // canvas placeable, not the document, for .center
+    if ( !token || !canvas.ready ) return false;
+    const tokenLevel = token.document._source.level;
+    if ( wall.document.levels?.size && !wall.document.levels.has(tokenLevel) ) return false; // wrong floor
+    const [mx, my] = wall.midpoint;
+    const {distance} = canvas.grid.measurePath([token.center, {x: mx, y: my}]);
+    return distance <= HOOKS.openDoor._MAX_RANGE;
+  },
+
+  /**
+   * The nearest door wall within reach of the actor's token, or null if none qualifies.
+   * @param {CrucibleActor} actor
+   * @returns {Wall|null}
+   */
+  _nearestDoor(actor) {
+    const token = actor.getActiveTokens(true, false)[0]; // canvas placeable, not the document, for .center
+    if ( !token || !canvas.ready ) return null;
+    let nearest = null;
+    let nearestDistance = Infinity;
+    for ( const wall of canvas.walls.placeables ) {
+      if ( !wall.document.isDoor ) continue;
+      if ( !HOOKS.openDoor._isReachable(actor, wall) ) continue;
+      const [mx, my] = wall.midpoint;
+      const {distance} = canvas.grid.measurePath([token.center, {x: mx, y: my}]);
+      if ( distance < nearestDistance ) {
+        nearest = wall;
+        nearestDistance = distance;
+      }
+    }
+    return nearest;
+  },
+
+  /**
+   * Resolve the door wall this use of the Action targets.
+   *
+   * A caller may pre-target a specific wall - e.g. a door clicked directly on the canvas - by passing
+   * `usage: {forcedDoorWallId: wall.id}` to {@link CrucibleActor#useAction}/{@link CrucibleAction#use}. That value
+   * is deliberately kept separate from `usage.doorWallId`: the latter is a *derived* field this method overwrites
+   * on every `prepare()` call, so it can't double as a one-shot signal without being indistinguishable from a
+   * stale result left over from a previous, unrelated preparation of the same (actor-shared) Action instance.
+   * `forcedDoorWallId` exists only to be consumed here - it's deleted as soon as it's read, whether or not it
+   * resolves to a usable door, so it never leaks into a later automatic preparation.
+   * @param {CrucibleAction} action
+   * @returns {Wall|null}
+   */
+  _resolveDoor(action) {
+    const forcedId = action.usage.forcedDoorWallId;
+    if ( forcedId !== undefined ) delete action.usage.forcedDoorWallId;
+    if ( forcedId ) {
+      const wall = canvas.walls?.get(forcedId);
+      // The explicitly targeted door may no longer exist or be out of reach - don't silently substitute whatever
+      // door happens to be nearest, since that isn't the door the player clicked.
+      if ( wall?.document.isDoor && HOOKS.openDoor._isReachable(action.actor, wall) ) return wall;
+      return null;
+    }
+    return HOOKS.openDoor._nearestDoor(action.actor);
+  },
+
+  prepare() {
+    const door = HOOKS.openDoor._resolveDoor(this);
+    this.usage.doorWallId = door?.id ?? null;
+    // Doors only draw from the Action economy in combat, matching the "doorActionCost" world setting
+    const charges = game.settings.get("crucible", "doorActionCost") && this.actor.inCombat;
+    this.cost.action = charges ? 1 : 0;
+  },
+
+  canUse() {
+    if ( !this.usage.doorWallId ) return false; // no door within reach - stay hidden from the sheet entirely
+    const door = canvas.walls.get(this.usage.doorWallId);
+    if ( !door || (door.document.ds === CONST.WALL_DOOR_STATES.LOCKED) ) return false;
+    if ( this.actor.inCombat && (game.combat?.combatant?.actor !== this.actor) ) {
+      throw new Error(_loc("ACTION.WARNINGS.SPECIFIC.OPEN_DOOR.WrongTurn"));
+    }
+  },
+
+  // Open/Closed is a binary toggle, so applying it twice is its own inverse - the same logic serves both the
+  // initial confirm and the chat card's reverse/undo, which is also where the Action cost gets refunded
+  // automatically via the normal event-reversal pipeline in #applyEvents. The actual toggle is serialized through
+  // the active GM's client (see requestDoorToggle/socket.mjs) so two actors toggling the same door at nearly the
+  // same instant can't race each other's stale reads of the door's current state.
+  async confirm() {
+    if ( !this.usage.doorWallId ) return;
+    await requestDoorToggle(this.usage.doorWallId);
   }
 };
 

--- a/module/hooks/door.mjs
+++ b/module/hooks/door.mjs
@@ -1,0 +1,30 @@
+/* -------------------------------------------- */
+/*  Door Open cost Function                       */
+/* -------------------------------------------- */
+Hooks.on("preUpdateWall", (wall, changes, options, userId) => {
+  if ( !("ds" in changes) ) return;                      // not a door-state change, ignore
+  if ( !game.settings.get("crucible", "doorActionCost") ) return;
+  if ( !game.combat?.started ) return;                    // combat only
+
+  const token = canvas.tokens.controlled[0];
+  if ( !token?.actor ) return;                            // nobody selected, don't enforce
+  const actor = token.actor;
+
+  // Distance check
+  const wallMidpoint = {x: (wall.c[0] + wall.c[2]) / 2, y: (wall.c[1] + wall.c[3]) / 2};
+  const {distance} = canvas.grid.measurePath([token.center, wallMidpoint]);
+  const MAX_DOOR_RANGE = 5; // distance from the door
+  if ( distance > MAX_DOOR_RANGE ) {
+    ui.notifications.warn(`${actor.name} is too far from the door to interact with it.`);
+    return false;
+  }
+
+  // Action point check
+  if ( actor.resources.action.value < 1 ) {
+    ui.notifications.warn(`${actor.name} does not have enough Action Points to open/close this door.`);
+    return false;
+  }
+
+  // Spend the AP - fire and forget, this is async and preUpdateWall can't await it
+  actor.alterResources({action: -1});
+});

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -369,6 +369,10 @@ class CrucibleActionEvent {
  * @property {CrucibleToken} [token]  A specific Token which is performing the action
  * @property {boolean} [dialog]             Present the user with an action configuration dialog?
  * @property {string} [messageMode]         Which message visibility mode to apply to the resulting message?
+ * @property {Partial<ActionUsage>} [usage] One-shot usage overrides merged onto the Action before it is cloned and
+ *                                          prepared, e.g. to pre-target a specific door wall that was clicked
+ *                                          directly on the canvas rather than letting the Action guess one. See
+ *                                          {@link CrucibleAction#use} for how this interacts with `prepare()`.
  */
 
 
@@ -1312,15 +1316,16 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
    * The action is cloned so that its data may be transformed throughout the workflow.
    * @param {CrucibleActionUsageOptions} [options]    Options which modify action usage
    * @param {TokenDocument} [options.token]           A specific token performing the action
+   * @param {Partial<ActionUsage>} [options.usage]    One-shot usage overrides applied before (re-)preparation
    * @returns {Promise<CrucibleAction|undefined>}
    */
-  async use({token, ...options}={}) {
+  async use({token, usage, ...options}={}) {
     if ( !this._prepared ) throw new Error("A CrucibleAction must be prepared for an Actor before it can be used.");
 
     // Redirect to spellcasting
     if ( this.id === "cast" ) {
       const spell = crucible.api.models.CrucibleSpellAction.getDefault(this.actor);
-      return spell.use({token, ...options});
+      return spell.use({token, usage, ...options});
     }
 
     // Infer the Token performing the Action
@@ -1332,6 +1337,14 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         throw new Error(`Multiple tokens controlled for Actor "${this.actor.name}"`);
       }
     }
+
+    // Seed any one-shot usage overrides onto this bound Action *before* cloning. #clone passes this.usage to the
+    // clone's construction context by reference (see #clone), and the clone re-runs prepare() synchronously as
+    // part of that construction - so anything merged in here is visible to the Action's own prepare() hook before
+    // it would otherwise compute a default (e.g. HOOKS.openDoor guessing the nearest door). Individual hooks are
+    // responsible for consuming and clearing any one-shot keys they read, so a value passed for this single use()
+    // call doesn't linger on the shared usage object and leak into a later, unrelated preparation.
+    if ( usage ) foundry.utils.mergeObject(this.usage, usage, {inplace: true});
 
     // Use a clone of the Action
     const action = this.clone({}, {parent: this.parent, actor: this.actor, token});

--- a/module/socket.mjs
+++ b/module/socket.mjs
@@ -11,6 +11,12 @@ export function handleSocketEvent({action=null, data={}}={}) {
     case "replayActionVFX":
       _onReplayActionVFX(data);
       break;
+    case "toggleDoor":
+      _onToggleDoorRequest(data);
+      break;
+    case "toggleDoorResult":
+      _onToggleDoorResult(data);
+      break;
   }
 }
 
@@ -30,5 +36,113 @@ function _onReplayActionVFX({messageId}) {
   const action = CrucibleAction.fromChatMessage(message);
   const {references, ...vfxConfig} = flags.vfxConfig;
   action.playVFXEffect(vfxConfig, references);
+}
+
+/* -------------------------------------------- */
+/*  Door Toggle Serialization                    */
+/* -------------------------------------------- */
+
+/**
+ * Per-wall promise chains used by the active GM's client to serialize concurrent door toggle requests, so two
+ * near-simultaneous requests for the same door are applied one after another (each reading the door's current
+ * state immediately before acting) rather than racing against each other's stale reads.
+ * @type {Map<string, Promise>}
+ */
+const _doorToggleQueues = new Map();
+
+/**
+ * Pending toggleDoor requests awaiting a response from the active GM, keyed by request id.
+ * @type {Map<string, {resolve: Function, reject: Function}>}
+ */
+const _pendingDoorToggles = new Map();
+
+/* -------------------------------------------- */
+
+/**
+ * Request that the door represented by a given Wall be toggled open/closed, serialized through the active GM's
+ * client so that concurrent requests for the same door cannot race. If the requesting user is themselves the
+ * active GM, the toggle is performed locally (still through the same serialization queue, in case multiple GM
+ * clients are connected). Falls back to a direct, unserialized local update if no GM is connected to arbitrate.
+ * @param {string} wallId
+ * @returns {Promise<number|null>}   The resulting door state (CONST.WALL_DOOR_STATES), or null if no door was found
+ */
+export async function requestDoorToggle(wallId) {
+  if ( game.users.activeGM?.isSelf ) return _applyDoorToggle(wallId);
+
+  if ( !game.users.activeGM ) {
+    console.warn("Crucible | No active GM connected to arbitrate door toggles; applying locally.");
+    return _applyDoorToggle(wallId);
+  }
+
+  const requestId = foundry.utils.randomID();
+  const result = new Promise((resolve, reject) => {
+    _pendingDoorToggles.set(requestId, {resolve, reject});
+    setTimeout(() => {
+      if ( !_pendingDoorToggles.has(requestId) ) return;
+      _pendingDoorToggles.delete(requestId);
+      reject(new Error("Timed out waiting for the GM to confirm the door toggle."));
+    }, 5000);
+  });
+  game.socket.emit("system.crucible", {action: "toggleDoor", data: {wallId, requestId}});
+  return result;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * The active GM's handler for an incoming toggleDoor request from another client.
+ * @param {object} data
+ * @param {string} data.wallId
+ * @param {string} data.requestId
+ */
+function _onToggleDoorRequest({wallId, requestId}) {
+  if ( !game.users.activeGM?.isSelf ) return; // only one GM client services requests
+  _applyDoorToggle(wallId)
+    .then(ds => game.socket.emit("system.crucible", {action: "toggleDoorResult", data: {requestId, ds}}))
+    .catch(err => {
+      console.error(new Error("Crucible | Failed to apply a requested door toggle", {cause: err}));
+      game.socket.emit("system.crucible", {action: "toggleDoorResult", data: {requestId, error: err.message}});
+    });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * The requesting client's handler for the GM's response to a toggleDoor request.
+ * @param {object} data
+ * @param {string} data.requestId
+ * @param {number} [data.ds]
+ * @param {string} [data.error]
+ */
+function _onToggleDoorResult({requestId, ds, error}) {
+  const pending = _pendingDoorToggles.get(requestId);
+  if ( !pending ) return; // not our request, or already timed out
+  _pendingDoorToggles.delete(requestId);
+  if ( error ) pending.reject(new Error(error));
+  else pending.resolve(ds);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Toggle a door's open/closed state, serialized per-wall so overlapping calls for the same door apply in order
+ * and each reads the door's live state immediately before acting.
+ * @param {string} wallId
+ * @returns {Promise<number|null>}
+ */
+function _applyDoorToggle(wallId) {
+  const previous = _doorToggleQueues.get(wallId) ?? Promise.resolve();
+  const next = previous.then(async () => {
+    const door = canvas.walls?.get(wallId);
+    if ( !door ) return null;
+    const states = CONST.WALL_DOOR_STATES;
+    const ds = door.document.ds === states.OPEN ? states.CLOSED : states.OPEN;
+    await door.document.update({ds}, {crucibleAction: true});
+    return ds;
+  }).finally(() => {
+    if ( _doorToggleQueues.get(wallId) === next ) _doorToggleQueues.delete(wallId);
+  });
+  _doorToggleQueues.set(wallId, next);
+  return next;
 }
 


### PR DESCRIPTION
# Main
Apologies first of all, first time doing an implementation like this, so I don't think I followed best practices. 

But in essence:

## Goal
Doors cost 1 AP to open/close in combat

### PR body:

Implements #861. Opening or closing a door in combat now costs 1 AP and requires being within 5ft of it.

New `module/hooks/door.mjs` hooks `preUpdateWall` to check distance and AP before allowing the toggle, spending AP via the existing `alterResources` helper. Only enforced in combat, and only when a token is selected. Added a `doorActionCost` world setting (default on) so GMs can disable it.