### PR TITLE
Adding support for grappling ideas - v3

### DIFF
--- a/_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml
+++ b/_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml
@@ -34,11 +34,9 @@ system:
             all: false
           statuses:
             - restrained
-          duration:
-            value: 1
-            units: rounds
-            expiry: turnStart
+          duration: {}
           system:
+            dc: -1
             dot: []
             maintenance: null
             regions: []
@@ -51,11 +49,9 @@ system:
             all: false
           statuses:
             - restrained
-          duration:
-            value: 1
-            units: rounds
-            expiry: turnStart
+          duration: {}
           system:
+            dc: -1
             dot: []
             maintenance: null
             regions: []

--- a/crucible.mjs
+++ b/crucible.mjs
@@ -806,6 +806,25 @@ Hooks.on("getSceneControlButtons", controls => {
 Hooks.on("renderCombatTracker", models.CrucibleCombatChallenge.onRenderCombatTracker);
 
 /* -------------------------------------------- */
+/*  grappling solution                          */
+/* -------------------------------------------- */
+Hooks.on("deleteActor", async actor => {
+  if ( !game.user.isActiveGM ) return;
+  const grapple = crucible.api.hooks.action.grapple;
+  const pairs = {
+    [grapple._GRAPPLED_EFFECT_ID]: grapple._GRAPPLING_EFFECT_ID,
+    [grapple._GRAPPLING_EFFECT_ID]: grapple._GRAPPLED_EFFECT_ID
+  };
+  for ( const [ownId, partnerId] of Object.entries(pairs) ) {
+    const effect = actor.effects.get(ownId);
+    if ( !effect?.origin ) continue;
+    const partner = await fromUuid(effect.origin);
+    const partnerEffect = partner?.effects?.get(partnerId);
+    if ( partnerEffect ) await partnerEffect.delete();
+  }
+ });
+
+/* -------------------------------------------- */
 /*  Canvas Hooks                                */
 /* -------------------------------------------- */
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -80,6 +80,21 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
         if ( token ) await token.delete();
       }
     }
+    await this.#endGrapplePair();
+  }
+
+
+  async #endGrapplePair() {
+    const grapple = crucible.api?.hooks?.action?.grapple;
+    if ( !grapple ) return;
+    const partnerId = {
+      [grapple._GRAPPLED_EFFECT_ID]: grapple._GRAPPLING_EFFECT_ID,
+      [grapple._GRAPPLING_EFFECT_ID]: grapple._GRAPPLED_EFFECT_ID
+    }[this.id];
+    if ( !partnerId || !this.origin ) return;
+    const partner = await fromUuid(this.origin);
+    const partnerEffect = partner?.effects?.get(partnerId);
+    if ( partnerEffect ) await partnerEffect.delete();
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2965,6 +2965,15 @@ export default class CrucibleActor extends Actor {
     }
   }
 
+
+  async #endGrappleOnDeath() {
+    const grapple = crucible.api?.hooks?.action?.grapple;
+    if ( !grapple ) return;
+    const ids = [grapple._GRAPPLED_EFFECT_ID, grapple._GRAPPLING_EFFECT_ID]
+    .filter(id => this.effects.has(id));
+    if ( ids.length ) await this.deleteEmbeddedDocuments("ActiveEffect", ids);
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2958,6 +2958,8 @@ export default class CrucibleActor extends Actor {
       await this.toggleStatusEffect("weakened", {active: this.system.isWeakened && !this.system.isDead });
       await this.toggleStatusEffect("dead", {active: this.system.isDead});
       await this.toggleStatusEffect("asleep", {active: false});
+      if ( this.system.isWeakened || this.system.isDead ) await this.#endGrappleOnDeath();
+
     }
     if ( ("morale" in r) || ("madness" in r) ) {
       await this.toggleStatusEffect("broken", {active: this.system.isBroken && !this.system.isInsane });

--- a/module/models/effect-base.mjs
+++ b/module/models/effect-base.mjs
@@ -2,7 +2,7 @@
  * Active Effect subtype containing crucible-specific system schema.
  */
 export default class CrucibleBaseActiveEffect extends foundry.data.ActiveEffectTypeDataModel {
-
+static AUTO_DC = -1;
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -32,8 +32,11 @@ export default class CrucibleBaseActiveEffect extends foundry.data.ActiveEffectT
 
   /** @override */
   prepareBaseData() {
-    // An effect with no removal DC cannot be removed; represent that as an infinite difficulty
     if ( this.dc === null ) this.dc = Infinity;
+    else if ( this.dc === CrucibleBaseActiveEffect.AUTO_DC ) {
+        const actor = this.parent?.parent;
+        this.dc = SYSTEM.PASSIVE_BASE + (actor?.system.advancement?.level ?? 0);
+      }
   }
 
   /* -------------------------------------------- */

--- a/templates/sheets/action/effect.hbs
+++ b/templates/sheets/action/effect.hbs
@@ -24,4 +24,6 @@
                 value=effect.duration.units options=effectDurations}}
     {{formGroup fields.duration.fields.expiry name=(concat effect.fieldPath ".duration.expiry")
                 value=effect.duration.expiry options=effectExpiryEvents}}
+    {{formGroup fields.system.fields.dc name=(concat effect.fieldPath ".system.dc") value=effect.system.dc
+                classes="slim" placeholder="∞"}}
 </fieldset>


### PR DESCRIPTION
## Link Grappling/Grappled effects, fix their duration, and add auto-computed removal DC

### Problem

The Grapple action creates two paired effects — `Grappling` on the attacker and `Grappled` on the target — linked only by `origin`. In practice this pairing wasn't actually enforced outside of a few hardcoded spots:

- Ending one side of a grapple (deleting the effect from a sheet/HUD, natural expiry, the grappler or target dying, or an actor being deleted outright) did **not** reliably end the other side. Only movement-breaking, a successful Escape check, and Throw explicitly handled both sides.
- Both effects were authored with a **1-round duration** (`expiry: turnStart` / `turnEnd`), so grapples silently ended at a turn boundary regardless of whether anyone tried to escape.
- Neither effect had a `dc` set, so it defaulted to `null` → `Infinity` on data prep. This made the Grappled effect **invisible to the Escape action** (`HOOKS.escape._restraints()` only considers effects with a finite `dc`), and there was no way to say "auto-compute this DC" for an effect authored directly on an Item — `dc: null` already means "unremovable," leaving no third state for "figure it out."
- The Action effect editor template (`effect.hbs`) never exposed a Removal DC field at all, so there was no UI path to set one on an action-authored effect like Grapple's.

### Changes

**`module/documents/active-effect.mjs`**
Added a general-purpose pairing cleanup in `_onDelete()`:
```js
await this.#endGrapplePair();
```
`#endGrapplePair()` checks if the deleted effect is the Grappling or Grappled effect, resolves the paired actor via `origin`, and deletes their matching effect too — regardless of *how* this effect was removed (manual delete, natural expiry, etc). Existing hardcoded breaks (movement, Escape, Throw) are unaffected; they just become redundant no-ops once the paired effect is already gone.

**`module/documents/actor.mjs`**
Added `#endGrappleOnDeath()`, called from `#applyResourceStatuses()` when an actor's health update pushes them into `isDead`. Deletes this actor's own Grappling/Grappled effect (if any); the pairing cleanup above cascades to the counterpart. A dead actor can no longer maintain or meaningfully resist a grapple.

**`crucible.mjs`**
Added a `deleteActor` hook. Deleting an Actor document outright doesn't run the normal deletion workflow for its embedded ActiveEffects, so the `_onDelete` pairing cleanup never fires for the counterpart in that case. This hook handles it explicitly by checking the deleted actor's Grappling/Grappled effect and cleaning up the partner directly.

**`module/models/effect-base.mjs`**
Added an `AUTO_DC` sentinel (`-1`) and handled it in `prepareBaseData()`:
```js
static AUTO_DC = -1;

prepareBaseData() {
  if ( this.dc === null ) this.dc = Infinity;
  else if ( this.dc === CrucibleBaseActiveEffect.AUTO_DC ) {
    const actor = this.parent?.parent;
    this.dc = SYSTEM.PASSIVE_BASE + (actor?.system.advancement?.level ?? 0);
  }
}
```
This generalizes DC auto-fill (previously only handled inline in `Action#finalizeEvents()` for effects created through the action/event pipeline) to **any** effect, including ones authored directly on an Item — since `null` already means "unremovable," authors now set `dc: -1` to request "auto-compute" instead. Computes as `12 (PASSIVE_BASE) + the effect bearer's own level`.

**`templates/sheets/action/effect.hbs`**
Added the missing Removal DC field to the Action effect editor, bound to `system.fields.dc` (which already existed in the schema, just wasn't rendered anywhere for action-authored effects):
```hbs
{{formGroup fields.system.fields.dc name=(concat effect.fieldPath ".system.dc") value=effect.system.dc
            classes="slim" placeholder="∞"}}
```

**`_source/talent/Unarmed_Combat_Training_unarmedCombatTra.yml`** (and recompiled `packs/talent`)
Updated the Grapple action's Grappled and Grappling effects:
- Removed the 1-round `duration` on both (now `duration: {}` — persistent until something actually ends it).
- Set `dc: -1` on both, so each computes a real removal/escape DC (`12 + bearer's level`) instead of `Infinity`.

### Known limitation / follow-up

The auto-computed DC scales with the **bearer's own level** for both effects — meaning the DC to escape a grapple currently scales with the *victim's* level, not the grappler's Athletics skill. A weak and a highly skilled grappler produce the same escape DC against the same target. If opposed-skill-based DC is wanted instead, that would mean explicitly setting `dc` in `HOOKS.grapple.postActivate()` (which already sets `grappling.origin`) rather than relying on the generic `AUTO_DC` fallback. Not addressed in this PR.

### Testing notes

- Grapple actor A → actor B; confirm both `Grappling`/`Grappled` effects persist indefinitely (no turn-boundary expiry).
- Delete the `Grappling` effect manually (sheet or HUD) → confirm `Grappled` on the target is also removed, and vice versa.
- Reduce the grappler (or target) to 0 HP → confirm the grapple ends on both sides.
- Delete the grappler (or target) Actor outright → confirm the counterpart's effect is cleaned up.
- Inspect `Grappled.system.dc` on a freshly-created effect → should be a finite number (`12 + level`), not `Infinity`.
- Note: effects created *before* this fix was compiled retain their old snapshot data (1-round duration, `dc: null`) — existing grants of the Unarmed Combat Training talent need to be removed and re-added to pick up the corrected Grapple action data.



# PS: 

This was a complete test case, please suggest changes! 