### PR TITLE
bug fix for #1379

### DIFF
--- a/module/applications/elements/currency.mjs
+++ b/module/applications/elements/currency.mjs
@@ -27,7 +27,7 @@ export default class HTMLCrucibleCurrencyElement extends foundry.applications.el
   _buildElements() {
     // Initialize existing raw value
     this._value = Number(this.getAttribute("value") || 0);
-    this.removeAttribute("value");
+    this.setAttribute("value", String(this._value));
 
     // Create input fields for each denomination
     const elements = [];
@@ -154,6 +154,7 @@ export default class HTMLCrucibleCurrencyElement extends foundry.applications.el
     }
 
     // Dispatch change
+    this.setAttribute("value", String(this._value));
     this.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
     this._refresh();
   }


### PR DESCRIPTION
## Fix currency showing 0 when a sheet is popped out to a separate window

for #1379

**Problem:** `<crucible-currency>`'s `_buildElements()` reads the `value` attribute once on connect, then removes it from the DOM — after that, the correct amount only exists as an internal `_value` property on that element instance. Popping a sheet out to its own window forces the browser to reconstruct the custom element in a new document context, which re-runs `_buildElements()` without preserving the old instance's JS state. With the attribute already stripped, it reads `null` and falls back to 0. Any subsequent currency change re-renders the element fresh with the correct value, which is why it "fixes itself."

**Fix:** `module/applications/elements/currency.mjs`
- `_buildElements()` — write the normalized value back to the `value` attribute instead of removing it.
- `#onChangeInput()` — keep the `value` attribute in sync whenever the user changes an amount, not just on initial build.

Net effect: the real currency amount is always recoverable from the DOM attribute, so reconstructing the element elsewhere (e.g. a popped-out window) no longer loses it.

**Testing:** give a character nonzero currency, pop the sheet out to its own window, confirm the correct amount displays (not 0); edit currency in the popped-out window and confirm it updates/persists correctly.
