### PR TITLE
Fix enchantment attack bonus when enchantment tier is derived from affixes

### DIFF
--- a/module/models/item-armor.mjs
+++ b/module/models/item-armor.mjs
@@ -58,7 +58,7 @@ export default class CrucibleArmorItem extends CruciblePhysicalItem {
    */
   prepareBaseData() {
     super.prepareBaseData();
-    const {category, quality, enchantment} = this.config;
+    const {category, quality} = this.config;
 
     // Armor Defense
     this.armor.base = Math.clamp(this.armor.base, category.armor.min, category.armor.max);
@@ -66,7 +66,7 @@ export default class CrucibleArmorItem extends CruciblePhysicalItem {
 
     // Dodge Defense
     this.dodge ||= {};
-    this.dodge.base = category.dodge.base(this.armor.base) + enchantment.bonus;
+    this.dodge.base = category.dodge.base(this.armor.base);
     this.dodge.scaling = category.dodge.scaling;
 
     // Natural applies property
@@ -83,6 +83,7 @@ export default class CrucibleArmorItem extends CruciblePhysicalItem {
       this.rarity -= 2;
     }
     super.prepareDerivedData();
+    this.dodge.base += this.config.enchantment.bonus;
   }
 
   /* -------------------------------------------- */

--- a/module/models/item-weapon.mjs
+++ b/module/models/item-weapon.mjs
@@ -122,7 +122,6 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
    */
   prepareBaseData() {
     super.prepareBaseData();
-    const {enchantment} = this.config;
 
     // Equipment Slot
     if ( this.dropped ) this.equipped = false;
@@ -142,7 +141,7 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
     this.range = this.#prepareRange();
 
     // Weapon Bonuses
-    this.actionBonuses = {ability: 0, skill: -4, enchantment: enchantment.bonus};
+    this.actionBonuses = {ability: 0, skill: -4, enchantment: 0};
     this.actionCost = category.actionCost;
   }
 
@@ -156,6 +155,7 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
       this.rarity -= 2;
     }
     super.prepareDerivedData();
+    this.actionBonuses.enchantment = this.config.enchantment.bonus;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
# Main

Fixes #1378.

### Problem

`actionBonuses.enchantment` was being initialized during `prepareBaseData()`, before an item's enchantment tier had been recalculated from its affixes.

For weapons whose enchantment tier is provided by affixes:

* the displayed enchantment tier was correct,
* the tier was correctly locked,
* but attack rolls continued using the pre-derived enchantment value (typically `mundane`), resulting in no enchantment bonus.

Manually setting the enchantment tier worked because that value already existed during `prepareBaseData()`.

### Cause

Affix-derived enchantment is computed in `CruciblePhysicalItem.prepareDerivedData()`, after Active Effects have been initialized. `Weapon.prepareBaseData()` was caching the enchantment bonus before that override occurred.

### Fix

* Initialize `actionBonuses.enchantment` to `0` in `prepareBaseData()`.
* Populate it in `prepareDerivedData()`, after `super.prepareDerivedData()` has applied the affix-derived enchantment tier.

This ensures attack bonuses always reflect the final computed enchantment tier, whether it comes from a manually assigned value or from affixes.

