### PR TITLE
Fix: Create & Conjure summons now replace the previous creature instead of orphaning it

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -615,6 +615,17 @@ export const TAGS = {
       const summonEvents = this.events.filter(e => e.type === "summon");
       if ( !summonEvents.length ) return;
 
+       // Enforce "only one at a time": dismiss whatever creature this gesture's deterministic effect id is currently tracking, before summoning a new one.
+      const priorEffectIds = new Set(summonEvents.map(e => e.summon.effectId).filter(Boolean));
+       for ( const effectId of priorEffectIds ) {
+         const existing = this.actor.effects.get(effectId);
+         if ( !existing ) continue;
+         for ( const uuid of existing.system.summons ?? [] ) {
+           const token = await fromUuid(uuid);
+           if ( token ) await token.delete();
+         }
+       }
+
       // Create summoned tokens, track non-permanent ones
       const summonedTokens = [];
       for ( const event of summonEvents ) {


### PR DESCRIPTION
## Fix: Create & Conjure summons now replace the previous creature instead of orphaning it

potential fix for  #1301

### Problem
Create and Conjure track their summon on an `ActiveEffect` with a deterministic id, so recasting is meant to just refresh that effect. But `summon.confirm()` always created a new token first, so the "refresh" was really an update, not a delete+create — `_onDelete` never fired, and the old token was left orphaned on the scene instead of being cleaned up.

### Fix
In `summon.confirm()`, before creating the new token, delete whatever token the existing same-id effect is currently tracking:

```js
const priorEffectIds = new Set(summonEvents.map(e => e.summon.effectId).filter(Boolean));
for ( const effectId of priorEffectIds ) {
  const existing = this.actor.effects.get(effectId);
  if ( !existing ) continue;
  for ( const uuid of existing.system.summons ?? [] ) {
    const token = await fromUuid(uuid);
    if ( token ) await token.delete();
  }
}
```

### Testing
Cast Conjure twice — only one creature should remain. Same for Create. Cast Conjure then Create — both should coexist (different gestures, different effect ids) -- unsure if this is how we want this so please let me know! 
