### PR TITLE
Fix Alchemist's Fire effect description reference

### DIFF
--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1816,17 +1816,8 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
 
   /* -------------------------------------------- */
 
-  /**
-   * Resolve only @ref[...] links in a description against this action, leaving every other enricher (@Rule,
-   * @Condition, etc.) untouched so they still enrich normally whenever the description is later rendered.
-   * Must run before this action's description is copied onto a created effect (see #recordEffectEvents), since
-   * gesture/item hooks (e.g. Alchemist's Fire) can overwrite that effect's own data - including its name - with
-   * generic status data (e.g. "Burning") before the effect is ever displayed. Resolving @refs now, while `this`
-   * still has valid item/gesture context, keeps references like "@ref[item.name]" pinned to the source item's
-   * name instead of silently drifting to whatever the effect's data happens to hold later. See GH #1310.
-   * @param {string} text
-   * @returns {string}
-   */
+  
+ /** Resolve @ref[...] links against this action before copying the description to an effect, preserving source references if the effect's data changes later. */
   #resolveRefEnrichers(text) {
     if ( !text ) return text;
     return text.replace(/@ref\[([\w.]+)](?:{([^}]+)})?/g, (match, path, fallback) => {

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1817,6 +1817,27 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Resolve only @ref[...] links in a description against this action, leaving every other enricher (@Rule,
+   * @Condition, etc.) untouched so they still enrich normally whenever the description is later rendered.
+   * Must run before this action's description is copied onto a created effect (see #recordEffectEvents), since
+   * gesture/item hooks (e.g. Alchemist's Fire) can overwrite that effect's own data - including its name - with
+   * generic status data (e.g. "Burning") before the effect is ever displayed. Resolving @refs now, while `this`
+   * still has valid item/gesture context, keeps references like "@ref[item.name]" pinned to the source item's
+   * name instead of silently drifting to whatever the effect's data happens to hold later. See GH #1310.
+   * @param {string} text
+   * @returns {string}
+   */
+  #resolveRefEnrichers(text) {
+    if ( !text ) return text;
+    return text.replace(/@ref\[([\w.]+)](?:{([^}]+)})?/g, (match, path, fallback) => {
+      const attr = foundry.utils.getProperty(this, path);
+      return attr ?? fallback ?? match;
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Record effect events for each target in the event stream based on the action's defined effects.
    * Effects are attached to qualifying roll events where possible, or recorded as standalone effect events.
    * If action creates a non-ephemeral region, ensure at least one self-effect to record it.
@@ -1842,7 +1863,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         const effect = {
           _id: _id || SYSTEM.EFFECTS.getEffectId(this.id, {suffix: String(i)}),
           name: name || this.name,
-          description: this.description,
+          description: this.#resolveRefEnrichers(this.description),
           img: this.img,
           origin: this.actor.uuid,
           duration: effectDuration,
@@ -1872,7 +1893,7 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
         this.recordEvent({type: "effect", target, effects: [{
           _id: SYSTEM.EFFECTS.getEffectId(this.gesture?.id ?? this.id),
           name: this.name,
-          description: this.description,
+          description: this.#resolveRefEnrichers(this.description),
           img: this.img,
           origin: this.actor.uuid,
           showIcon: CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS,

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1819,11 +1819,8 @@ export default class CrucibleAction extends foundry.abstract.DataModel {
   
  /** Resolve @ref[...] links against this action before copying the description to an effect, preserving source references if the effect's data changes later. */
   #resolveRefEnrichers(text) {
-    if ( !text ) return text;
-    return text.replace(/@ref\[([\w.]+)](?:{([^}]+)})?/g, (match, path, fallback) => {
-      const attr = foundry.utils.getProperty(this, path);
-      return attr ?? fallback ?? match;
-    });
+  const {pattern, enricher} = CONFIG.TextEditor.enrichers.find(e => e.id === "reference");
+  return text.replace(pattern, (...args) => enricher(args.slice(0, -2), {relativeTo: this}).textContent);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
### Summary

Fixes an issue where the **Burning** effect applied by **Alchemist's Fire** displays an incorrect description.

Previously, when the Burning condition was applied, the description would incorrectly replace references to **"Alchemist's Fire"** with **"Burning"**, resulting in misleading text.

### Root Cause

The effect description was being enriched after the applied effect's name had been auto-set, causing `@ref` resolution to use the effect name (`Burning`) instead of the originating action (`Alchemist's Fire`).

### Changes

* Preserve the original action context when resolving `@ref` references for effect descriptions.
* Resolve `@ref` references during action use rather than after the effect has been auto-generated.
* Leave other enrichers to be processed lazily/as needed to avoid changing existing enrichment behavior.

### Result

The Burning effect now correctly references **Alchemist's Fire** in its description while preserving the existing enrichment pipeline for other description content.

### Fixes

potential fix for #1310
