### PR TITLE
Remove playtest notes from Counterspell descriptions for clarity 

### DIFF
--- a/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
+++ b/_source/playtest/Playtest_1___The_Ring_of_Valor_F8AILycmdj2kuOVa.yml
@@ -16400,15 +16400,7 @@ actors:
           description: >-
             <p>You immediately react to a spell being cast and compose a rune
             and gesture designed to unravel and negate the spellcraft of an
-            enemy mage.</p><h2 class="divider">Playtest Notes</h2><p>This action
-            can now be used in playtesting, but it is not yet <em>fully
-            automated</em>. The Counterspell can be performed, but it is up to
-            the Gamemaster to manually reverse a previously applied spell and to
-            manually deduct its <strong>Action</strong> and
-            <strong>Focus</strong> cost. These steps of the overall Counterspell
-            workflow <em>will be automated</em> in a subsequent update such that
-            a confirmed Counterspell will also confirm the spell that was
-            countered, but with its effects removed.</p>
+            enemy mage.</p>
           actions:
             - id: counterspell
               condition: Another creature which you can see is casting a spell.
@@ -21804,15 +21796,7 @@ actors:
           description: >-
             <p>You immediately react to a spell being cast and compose a rune
             and gesture designed to unravel and negate the spellcraft of an
-            enemy mage.</p><h2 class="divider">Playtest Notes</h2><p>This action
-            can now be used in playtesting, but it is not yet <em>fully
-            automated</em>. The Counterspell can be performed, but it is up to
-            the Gamemaster to manually reverse a previously applied spell and to
-            manually deduct its <strong>Action</strong> and
-            <strong>Focus</strong> cost. These steps of the overall Counterspell
-            workflow <em>will be automated</em> in a subsequent update such that
-            a confirmed Counterspell will also confirm the spell that was
-            countered, but with its effects removed.</p>
+            enemy mage.</p>
           actions:
             - id: counterspell
               condition: Another creature which you can see is casting a spell.

--- a/_source/pregens/Fizzit_lP2MOJyk5oHs6oSS.yml
+++ b/_source/pregens/Fizzit_lP2MOJyk5oHs6oSS.yml
@@ -708,14 +708,7 @@ items:
       description: >-
         <p>You immediately react to a spell being cast and compose a rune and
         gesture designed to unravel and negate the spellcraft of an enemy
-        mage.</p><h2 class="divider">Playtest Notes</h2><p>This action can now
-        be used in playtesting, but it is not yet <em>fully automated</em>. The
-        Counterspell can be performed, but it is up to the Gamemaster to
-        manually reverse a previously applied spell and to manually deduct its
-        <strong>Action</strong> and <strong>Focus</strong> cost. These steps of
-        the overall Counterspell workflow <em>will be automated</em> in a
-        subsequent update such that a confirmed Counterspell will also confirm
-        the spell that was countered, but with its effects removed.</p>
+        mage.</p>
       actions:
         - id: counterspell
           condition: Another creature which you can see is casting a spell.

--- a/_source/pregens/Zarajah_tCBBi3Kyc3M4KHGZ.yml
+++ b/_source/pregens/Zarajah_tCBBi3Kyc3M4KHGZ.yml
@@ -1115,14 +1115,7 @@ items:
       description: >-
         <p>You immediately react to a spell being cast and compose a rune and
         gesture designed to unravel and negate the spellcraft of an enemy
-        mage.</p><h2 class="divider">Playtest Notes</h2><p>This action can now
-        be used in playtesting, but it is not yet <em>fully automated</em>. The
-        Counterspell can be performed, but it is up to the Gamemaster to
-        manually reverse a previously applied spell and to manually deduct its
-        <strong>Action</strong> and <strong>Focus</strong> cost. These steps of
-        the overall Counterspell workflow <em>will be automated</em> in a
-        subsequent update such that a confirmed Counterspell will also confirm
-        the spell that was countered, but with its effects removed.</p>
+        mage.</p>
       actions:
         - id: counterspell
           condition: Another creature which you can see is casting a spell.

--- a/_source/talent/Counterspell_counterspell0000.yml
+++ b/_source/talent/Counterspell_counterspell0000.yml
@@ -5,14 +5,7 @@ system:
   description: >-
     <p>You immediately react to a spell being cast and compose a rune and
     gesture designed to unravel and negate the spellcraft of an enemy
-    mage.</p><h2 class="divider">Playtest Notes</h2><p>This action can now be
-    used in playtesting, but it is not yet <em>fully automated</em>. The
-    Counterspell can be performed, but it is up to the Gamemaster to manually
-    reverse a previously applied spell and to manually deduct its
-    <strong>Action</strong> and <strong>Focus</strong> cost. These steps of the
-    overall Counterspell workflow <em>will be automated</em> in a subsequent
-    update such that a confirmed Counterspell will also confirm the spell that
-    was countered, but with its effects removed.</p>
+    mage.</p>
   actions:
     - id: counterspell
       condition: Another creature which you can see is casting a spell.


### PR DESCRIPTION
Remove playtest notes from Counterspell descriptions for clarity  -- now that automation has been implemented for Counterspell