### PR TITLE
Refactor attack resolution to trigger hooks for all outcomes, includi…

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -845,7 +845,7 @@ export default class CrucibleActor extends Actor {
     // Create and evaluate the AttackRoll instance, then resolve its outcome and structured damage
     const roll = new AttackRoll(rollData);
     await roll.evaluate();
-    const result = roll.resolveDamage(this, target, {
+    roll.resolveDamage(this, target, {
       multiplier: rollData.multiplier,
       base: spell.damage.base,
       bonus: rollData.damageBonus + (this.system.rollBonuses.damage?.[rollData.damageType] ?? 0),
@@ -853,7 +853,7 @@ export default class CrucibleActor extends Actor {
       damageType: rollData.damageType,
       restoration: spell.damage.restoration
     });
-    if ( result >= AttackRoll.RESULT_TYPES.GLANCE ) target.callActorHooks("receiveAttack", spell, roll);
+    target.callActorHooks("receiveAttack", spell, roll);
     return roll;
   }
 
@@ -1017,7 +1017,7 @@ export default class CrucibleActor extends Actor {
     // Create and evaluate the AttackRoll instance, then resolve its outcome and structured damage
     const roll = new AttackRoll(rollData);
     await roll.evaluate();
-    const result = roll.resolveDamage(this, target, {
+    roll.resolveDamage(this, target, {
       multiplier: rollData.multiplier,
       base: weapon.system.damage.weapon,
       bonus: weapon.system.damage.bonus + rollData.damageBonus,
@@ -1025,8 +1025,8 @@ export default class CrucibleActor extends Actor {
       damageType: rollData.damageType
     });
 
-    // Finalize the attack and return; offensive reactions fire only on a connecting hit
-    if ( result >= AttackRoll.RESULT_TYPES.GLANCE ) target.callActorHooks("receiveAttack", action, roll);
+    // Finalize the attack and return; hooks fire for every result so talents can react to misses, dodges, and parries
+    target.callActorHooks("receiveAttack", action, roll);
     return roll;
   }
 

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -1536,6 +1536,24 @@ HOOKS.swarm00000000000 = {
 
 /* -------------------------------------------- */
 
+HOOKS.swashbuckler0000 = {
+  receiveAttack(item, action, roll) {
+    const T = roll.constructor.RESULT_TYPES;
+    if ( ![T.DODGE, T.PARRY].includes(roll.data.result) ) return;
+    const attacker = action.actor;
+    if ( !attacker ) return;
+    const morale = this.system.abilities.presence.value;
+    if ( morale <= 0 ) return;
+    action.recordEvent({
+      target: attacker,
+      resources: [{resource: "morale", delta: -morale}],
+      statusText: [{text: item.name, fillColor: SYSTEM.RESOURCES.morale.color.high.css}]
+    });
+  }
+};
+
+/* -------------------------------------------- */
+
 HOOKS.telekinetic00000 = {
   prepareAction(item, action) {
     if ( !action.tags.has("composed") || !["pull", "push"].includes(action.inflection?.id) ) return;


### PR DESCRIPTION
## Call `receiveAttack` on all results; implement Swashbuckler

**Problem:** `weaponAttack`/`spellAttack` only fired the `receiveAttack` actor hook on Glance/Hit, so defensive talents couldn't react to a dodged/parried attack. Separately, the Swashbuckler talent had rules text but no code behind it.

**Changes:**
- `module/documents/actor.mjs` (+ mirrored in `crucible-compiled.mjs`): removed the `result >= GLANCE` guard on `receiveAttack` in `weaponAttack` and `spellAttack`, so the hook now fires for every result, matching `skillAttack` and the Interposer.
- `module/hooks/talent.mjs` (+ compiled): added `HOOKS.swashbuckler0000.receiveAttack`, draining the attacker's morale (equal to the Swashbuckler's Presence) on Dodge/Parry.

**Not included:** Swashbuckler's crit → nearby-allies-gain-morale effect (no existing passive aura pattern to follow; happy to add in a follow-up).

**For awarness:** Existing `receiveAttack` hooks (`armoredInstinct0`, `swarm`, `duelist`) already guard on specific result types and no-op safely on a miss -- I dont think this would impact but please let me know if you think this could should differ 