### PR TITLE
Implement invisible enemy handling in flanking calculations and updat…

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -602,9 +602,11 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
     engagement.allyBonus = 0;
 
     // Count flankers; an adversary's flankingStrength lets it count as more than one
+    // Invisible enemies do not contribute to flanking - their advantage is a personal, secret boon instead
     let flankers = 0;
     for ( const enemy of engagement.enemies ) {
       const {isBroken, isIncapacitated} = enemy.actor.system;
+      if ( enemy.actor.statuses.has("invisible") ) continue;
       if ( !(isBroken || isIncapacitated) ) flankers += enemy.actor.system.movement?.flankingStrength ?? 1;
     }
     engagement.flankers = flankers;
@@ -613,6 +615,7 @@ export default class CrucibleTokenObject extends foundry.canvas.placeables.Token
     for ( const ally of engagement.allies ) {
       const {isBroken, isIncapacitated} = ally.actor.system;
       if ( isBroken || isIncapacitated ) continue;
+      if ( ally.actor.statuses.has("invisible") ) continue;
       const mutual = ally.engagement.enemies.intersection(engagement.enemies);
       if ( !mutual.size ) continue;
       const allyEngage = ally?.actor.system.movement.engagement ?? 1;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -376,7 +376,7 @@ export default class CrucibleActor extends Actor {
    */
   _configureAttackerRollData(action, rollData) {
     const {boons, banes} = rollData;
-    const {isAttack=false} = action.usage;
+    const {isAttack=false, isRanged=false} = action.usage;
     const statuses = CONFIG.statusEffects;
 
     // Global conditions
@@ -387,6 +387,9 @@ export default class CrucibleActor extends Actor {
       if ( this.statuses.has("blinded") ) banes.blind = {label: statuses.blinded.name, number: 2};
       if ( this.statuses.has("prone") ) banes.prone = {label: statuses.prone.name, number: 1};
       if ( this.statuses.has("restrained") ) banes.restrained = {label: statuses.restrained.name, number: 2};
+      if ( this.statuses.has("invisible") && !isRanged ) {
+        boons.invisible = {label: statuses.invisible.name, number: 1, hidden: true};
+      }
     }
 
     // Temporary boons and banes stored as Actor rollBonuses

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -211,6 +211,11 @@ export default class CrucibleChatMessage extends ChatMessage {
       if ( (flags.action.target.type === "summon") && !game.user.isGM ) html.querySelector(".target-region.full-tags")?.remove();
     }
 
+    // Hide GM-only roll details (e.g. an invisible attacker's secret boon) for non-GMs
+    if ( !game.user.isGM ) {
+      for ( const el of html.querySelectorAll(".gm-only") ) el.remove();
+    }
+
     // Initiative Report
     if ( flags.isInitiativeReport ) {
       crucible.api.models.CrucibleCombatChallenge.onRenderInitiativeReport(message, html);

--- a/templates/dice/partials/standard-check-details.hbs
+++ b/templates/dice/partials/standard-check-details.hbs
@@ -2,7 +2,7 @@
 <div class="boon-details flexcol">
     {{#each boons as |boon|}}
     {{#if boon.number}}
-    <div class="boon flexrow">
+    <div class="boon flexrow{{#if boon.hidden}} gm-only{{/if}}">
         <span class="label">{{localize boon.label}}</span>
         <span class="type"><i class="fa-solid fa-arrow-up"></i> {{localize "DICE.Boons.one"}}</span>
         <span class="value">{{boon.number}}</span>


### PR DESCRIPTION
fix #1391 

based on the chat on discord I went with the idea of: 
- you cannot benefit from flanked if you cannot see the ally flanking to help, thus flanked does not get applied instead the invisable attacker gains a +1 boon. let me know y'all thoughts. 

## Invisible creatures no longer count toward flanking; secret melee boon for invisible attackers

### Problem
Invisible creatures currently contribute to flanking (as flankers, and as allies
reducing a target's flanked stage). Since a target's flanked status/boon is visible
mechanical information, this let players infer "something invisible is here" purely
from watching flanking numbers change — an unintended meta.

### Fix
- **`module/canvas/token.mjs`** — `computeFlanking()` now skips any creature with the
  `invisible` status when counting flankers *and* when computing the ally-bonus
  reduction. Invisibility no longer shows up in flanking math at all, on either side.
- **`module/documents/actor.mjs`** — `_configureAttackerRollData()` grants an invisible
  attacker a personal `+1` boon on **melee attacks only** (mirrors the existing
  flanked-boon's `isRanged` restriction). The boon is flagged `hidden: true`.
- **`templates/dice/partials/standard-check-details.hbs`** — hidden boons still render
  into the chat card (so the roll math/tooltip is correct) but get a `gm-only` CSS
  class instead of a label-only line.
- **`module/documents/chat-message.mjs`** — `onRenderHTML` strips `.gm-only` elements
  for non-GM viewers (same pattern already used to hide summoned-creature names from
  players), so the GM sees the boon's source and players just see the roll total.

### Notes
- Scope is intentionally limited to the `invisible` status; other stealth-like
  statuses are untouched.

### Testing
- Manually verified in Foundry: an invisible enemy adjacent to a target no longer
  raises `flanked`; an invisible ally no longer reduces it.
- Verified the invisible attacker's melee attack boon appears in the GM's chat log
  breakdown but not in a player's, while the roll total is identical for both.