### PR TITLE
[#1404] Ensure Action re-preparation does not double up certain tag effects

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -1067,7 +1067,7 @@ export const TAGS = {
     tooltip: "ACTION.TAG.DeadlyTooltip",
     category: "modifiers",
     prepare() {
-      this.usage.bonuses.multiplier += 1;
+      if ( !this._prepared ) this.usage.bonuses.multiplier += 1;
     }
   },
 
@@ -1087,7 +1087,7 @@ export const TAGS = {
     tooltip: "ACTION.TAG.EmpoweredTooltip",
     category: "modifiers",
     prepare() {
-      this.usage.bonuses.damageBonus += 6;
+      if ( !this._prepared ) this.usage.bonuses.damageBonus += 6;
     }
   },
   keen: {
@@ -1096,7 +1096,7 @@ export const TAGS = {
     tooltip: "ACTION.TAG.KeenTooltip",
     category: "modifiers",
     prepare() {
-      this.usage.bonuses.criticalSuccessThreshold -= 2;
+      if ( !this._prepared ) this.usage.bonuses.criticalSuccessThreshold -= 2;
     }
   },
   accurate: {
@@ -1134,7 +1134,7 @@ export const TAGS = {
     tooltip: "ACTION.TAG.WeakenedTooltip",
     category: "modifiers",
     prepare() {
-      this.usage.bonuses.damageBonus -= 6;
+      if ( !this._prepared ) this.usage.bonuses.damageBonus -= 6;
     }
   },
 


### PR DESCRIPTION
Closes #1404 
The issue was that after planning movement, the action is `prepare`d again. Since Empowered simply adds 6 to the existing `usage.bonuses.damageBonus`, that means preparation was _not_ idempotent.

I see there being two ways to solve this:

The first is what I've done here: focus on the hooks themselves and ensure that they are written in such a way that they won't ruin the idempotency of the `prepare` hook.

The second is perhaps a cleaner option, since it'd make it impossible for a hook to do this, and would mean re-setting all `usage.bonuses` to their defaults inside `Action#_configureUsage`. I wasn't sure whether there might be side effects I wasn't considering for this, so I went with the "easy" solution here.