### PR TITLE
[#1412] Check all knowledge (not only background) for `hasKnowledge`, and allow Adversaries to have knowledge areas

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -881,8 +881,10 @@
       "FavoriteActions": "Favorite Actions",
       "Knowledge": "Knowledge Areas",
       "KnowledgeHint": "Learn some Knowledge Areas from your Background or edit your Hero to gain some.",
+      "KnowledgeHintAdversary": "No Knowledge Areas known.",
       "Languages": "Known Languages",
       "LanguagesHint": "Learn some Languages from your Background or edit your Hero to gain some.",
+      "LanguagesHintAdversary": "No Languages known.",
       "OverCapacity": "Over Capacity"
     },
     "SECTIONS": {

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -176,6 +176,10 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       incomplete: {},
       inventory,
       isEditable: this.isEditable,
+      knowledge: this._prepareBackgroundDetailSet({
+        type: "knowledge",
+        tooltip: "ACTOR.LABELS.BackgroundKnowledgeTooltip"
+      }),
       languages: this._prepareBackgroundDetailSet({
         type: "languages",
         tooltip: "ACTOR.LABELS.BackgroundLanguageTooltip"

--- a/module/applications/sheets/hero-sheet.mjs
+++ b/module/applications/sheets/hero-sheet.mjs
@@ -46,10 +46,6 @@ export default class HeroSheet extends CrucibleBaseActorSheet {
       ancestryName: s.system.details.ancestry?.name || _loc("ANCESTRY.SHEET.Choose"),
       backgroundName: s.system.details.background?.name || _loc("BACKGROUND.SHEET.Choose"),
       capacity: a.system.capacity,
-      knowledge: this._prepareBackgroundDetailSet({
-        type: "knowledge",
-        tooltip: "ACTOR.LABELS.BackgroundKnowledgeTooltip"
-      }),
       talentTreeButtonText: _loc(`ACTOR.ACTIONS.TalentTree${game.system.tree.actor === a ? "Close" : "Open"}`)
     });
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -623,8 +623,7 @@ export default class CrucibleActor extends Actor {
    * @returns {boolean}
    */
   hasKnowledge(knowledgeId) {
-    if ( this.type !== "hero" ) return false; // Relax this assumption eventually?
-    return this.system.details.background.knowledge.has(knowledgeId);
+    return this.system.details?.knowledge?.has(knowledgeId);
   }
 
   /* -------------------------------------------- */

--- a/module/models/actor-adversary.mjs
+++ b/module/models/actor-adversary.mjs
@@ -46,6 +46,7 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
         public: new fields.HTMLField(),
         private: new fields.HTMLField()
       }),
+      knowledge: new fields.SetField(new fields.StringField({blank: false})),
       languages: new fields.SetField(new fields.StringField({blank: false}))
     });
 

--- a/templates/sheets/actor/skills.hbs
+++ b/templates/sheets/actor/skills.hbs
@@ -47,7 +47,13 @@
                     {{label}}
                 </span>
                 {{else}}
-                <p class="hint">{{localize "ACTOR.LABELS.KnowledgeHint"}}</p>
+                <p class="hint">
+                    {{#if (eq actor.type "hero")}}
+                    {{localize "ACTOR.LABELS.KnowledgeHint"}}
+                    {{else}}
+                    {{localize "ACTOR.LABELS.KnowledgeHintAdversary"}}
+                    {{/if}}
+                </p>
                 {{/each}}
             </div>
         </div>
@@ -65,7 +71,13 @@
                     {{label}}
                 </span>
                 {{else}}
-                <p class="hint">{{localize "ACTOR.LABELS.LanguagesHint"}}</p>
+                <p class="hint">
+                    {{#if (eq actor.type "hero")}}
+                    {{localize "ACTOR.LABELS.LanguagesHint"}}
+                    {{else}}
+                    {{localize "ACTOR.LABELS.LanguagesHintAdversary"}}
+                    {{/if}}
+                </p>
                 {{/each}}
             </div>
         </div>


### PR DESCRIPTION
Closes #1412 
Technically, the only thing that's needed to close #1412 is the change in `CrucibleActor#hasKnowledge` - however, when fixing this I realized that currently:
1. The tooltips under Knowledge Areas & Known Languages for Adversaries when they don't have any incorrectly assume a Hero actor sheet is being viewed.
2. The configure button for Knowledge Areas throws an error for Adversaries if pressed.

So I decided hey, why not creep the scope a little bit:
1. Added new simpler variants of those tooltips, and reference them in an if/else in the hbs itself.
2. Add `details.knowledge` to Adversary's schema, move Hero-sheet-only `knowledge` context prep up into base actor sheet. No special data prep is required for the adversary subtype itself, since nothing currently grants them knowledge areas.

If this is a change you don't want to make, I can re-submit with just the `hasKnowledge` fix.