### PR TITLE
Automate Dawn Beacon (and Engulfing Darkness) light sources, darkness counteraction, and fix target acquisition

### DIFF
--- a/_source/spell/Dawn_Beacon_dawnBeacon000000.yml
+++ b/_source/spell/Dawn_Beacon_dawnBeacon000000.yml
@@ -19,7 +19,8 @@ system:
         counteracts magical darkness and destroys any source of magical darkness
         whose origin is contained within its area.</p><p>Enemies within the area
         when the light is first created must resist an attack against their
-        <strong>Fortitude</strong> or be @Condition[blinded] for one round.</p>
+        <strong>Fortitude</strong> or be @Condition[blinded] for one
+        round.</p>
       cost:
         action: 0
         focus: 0
@@ -63,7 +64,7 @@ system:
             units: rounds
             expiry: turnEnd
           result:
-            type: success
+            type: any
             all: false
           system:
             changes: []
@@ -72,6 +73,16 @@ system:
             regions: []
             summons: []
             lights: []
+            light:
+              bright: 30
+              dim: 60
+              color: "#fff2c2"
+              alpha: 0.35
+              negative: false
+              animation:
+                type: pulse
+                speed: 1
+                intensity: 2
       tags:
         - spell
         - iconicSpell

--- a/_source/spell/Dawn_Beacon_dawnBeacon000000.yml
+++ b/_source/spell/Dawn_Beacon_dawnBeacon000000.yml
@@ -19,11 +19,7 @@ system:
         counteracts magical darkness and destroys any source of magical darkness
         whose origin is contained within its area.</p><p>Enemies within the area
         when the light is first created must resist an attack against their
-        <strong>Fortitude</strong> or be @Condition[blinded] for one
-        round.</p><p><strong>WIP: This spell does not yet automatically create a
-        light source, which must be done manually for now. Eventually this will
-        be automated using a new Foundry VTT version 14 framework for template
-        placement.</strong></p>
+        <strong>Fortitude</strong> or be @Condition[blinded] for one round.</p>
       cost:
         action: 0
         focus: 0
@@ -37,7 +33,7 @@ system:
       target:
         type: pulse
         number: 1
-        scope: 1
+        scope: 3
         self: false
         size: 60
       effects:
@@ -58,9 +54,26 @@ system:
             maintenance: null
             regions: []
             summons: []
+            lights: []
+        - name: Dawn Beacon Pillar
+          scope: 1
+          statuses: []
+          duration:
+            value: 6
+            units: rounds
+            expiry: turnEnd
+          result:
+            type: success
+            all: false
+          system:
+            changes: []
+            dot: []
+            maintenance: null
+            regions: []
+            summons: []
+            lights: []
       tags:
         - spell
-        - iconicSpell
         - iconicSpell
       summon:
         actorUuid: null

--- a/_source/spell/Engulfing_Darkness_engulfingDarknes.yml
+++ b/_source/spell/Engulfing_Darkness_engulfingDarknes.yml
@@ -44,7 +44,7 @@ system:
             units: rounds
             expiry: turnEnd
           result:
-            type: success
+            type: any
             all: false
           system:
             changes: []
@@ -53,6 +53,16 @@ system:
             regions: []
             summons: []
             lights: []
+            light:
+              bright: 0
+              dim: 20
+              color: "#2b0033"
+              alpha: 0.75
+              negative: true
+              animation:
+                type: blackHole
+                speed: 1
+                intensity: 3
       tags:
         - spell
         - iconicSpell

--- a/_source/spell/Engulfing_Darkness_engulfingDarknes.yml
+++ b/_source/spell/Engulfing_Darkness_engulfingDarknes.yml
@@ -18,10 +18,7 @@ system:
         @Condition[blinded].</p><p>The area of this sphere is constrained by
         solid walls. Creatures outside this area cannot see into it and the
         effective area of light sources outside this area ends at its
-        perimeter.</p><p><strong>WIP: This spell does not yet automatically
-        create a darkness source, which must be done manually for now.
-        Eventually this will be automated using a new Foundry VTT version 14
-        framework for template placement.</strong></p>
+        perimeter.</p>
       cost:
         action: 4
         focus: 2
@@ -38,10 +35,26 @@ system:
         scope: 1
         self: false
         size: 20
-      effects: []
+      effects:
+        - name: Engulfing Darkness Sphere
+          scope: 1
+          statuses: []
+          duration:
+            value: 6
+            units: rounds
+            expiry: turnEnd
+          result:
+            type: success
+            all: false
+          system:
+            changes: []
+            dot: []
+            maintenance: null
+            regions: []
+            summons: []
+            lights: []
       tags:
         - spell
-        - iconicSpell
         - iconicSpell
       summon:
         actorUuid: null

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -23,7 +23,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
   static #DELETABLE_TYPES = new Set(["Token", "Region", "AmbientLight"]);
 
   /**
-   * The UUIDs of the Tokens, Regions, and AmbientLights this effect owns. Cached from the effect's own persisted data.
+   * The UUIDs of the Tokens and Regions this effect owns. Cached from the effect's own persisted data.
    * The responsible active GM derives the set of documents to delete from trusted, replicated state.
    * @type {Set<string>}
    */
@@ -84,7 +84,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
   /* -------------------------------------------- */
 
   /**
-   * Collect the UUIDs of the Tokens, Regions, and AmbientLights this effect currently owns from its persisted references.
+   * Collect the UUIDs of the Tokens and Regions this effect currently owns from its persisted references.
    * @returns {Set<string>}
    */
   #collectOwnedReferences() {
@@ -96,7 +96,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
   /**
    * Delete owned references on behalf of a requesting User.
    * Enforce that each still exists, is an allowed document type, and is OWNED by the user who triggered the operation.
-   * @param {Set<string>} references      UUIDs of owned Tokens, Regions, and AmbientLights to delete
+   * @param {Set<string>} references      UUIDs of owned Tokens and Regions to delete
    * @param {string} userId               The user who performed the triggering operation
    * @returns {Promise<void>}
    */
@@ -193,6 +193,61 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
         return false;
       }
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the center point of this effect's owning actor's primary active token, in canvas pixel coordinates,
+   * along with the Scene that token belongs to.
+   * @returns {{scene: Scene, x: number, y: number}|null}
+   */
+  #getOwnerTokenPlacement() {
+    if ( !(this.parent instanceof foundry.documents.Actor) ) return null;
+    const token = this.parent.getActiveTokens(true, true)[0];
+    if ( !token || !token.parent ) return null;
+    const center = token.getCenterPoint ? token.getCenterPoint() : (token.object?.center ?? null);
+    if ( !center ) return null;
+    return {scene: token.parent, x: center.x, y: center.y};
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Conjure the AmbientLight declared by this effect's system.light template, if one is configured and this
+   * effect does not already own a live light. The created light's UUID is recorded to system.lights so the
+   * existing owned-reference cascade deletes it automatically whenever this effect is deleted or updated to
+   * no longer reference it - no bespoke reverse/cleanup path is required by the effect's own hook code.
+   * Only the active GM performs the creation, mirroring #deleteOwnedReferences.
+   * @returns {Promise<void>}
+   */
+  async #createOwnedLight() {
+    if ( !game.user.isActiveGM ) return;
+    if ( !this.system.light ) return;
+
+    // Skip if a currently-referenced light already exists (e.g. a reconstructed/reversed effect whose light
+    // was never actually destroyed) - only conjure a replacement when none of the tracked references resolve.
+    for ( const uuid of this.system.lights ?? [] ) {
+      if ( await fromUuid(uuid) ) return;
+    }
+
+    const placement = this.#getOwnerTokenPlacement();
+    if ( !placement ) return;
+    const {scene, x, y} = placement;
+    try {
+      const [light] = await scene.createEmbeddedDocuments("AmbientLight", [{x, y, config: {...this.system.light}}]);
+      if ( light ) await this.update({"system.lights": [...this.system.lights, light.uuid]});
+    } catch(err) {
+      console.error(`${this.name} | failed to create owned AmbientLight`, err);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onCreate(data, options, userId) {
+    await super._onCreate(data, options, userId);
+    await this.#createOwnedLight();
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -20,10 +20,10 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
    * Document types the owned-reference deletion cascade is permitted to delete.
    * @type {Set<string>}
    */
-  static #DELETABLE_TYPES = new Set(["Token", "Region"]);
+  static #DELETABLE_TYPES = new Set(["Token", "Region", "AmbientLight"]);
 
   /**
-   * The UUIDs of the Tokens and Regions this effect owns. Cached from the effect's own persisted data.
+   * The UUIDs of the Tokens, Regions, and AmbientLights this effect owns. Cached from the effect's own persisted data.
    * The responsible active GM derives the set of documents to delete from trusted, replicated state.
    * @type {Set<string>}
    */
@@ -76,19 +76,19 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
   isStatusOnly(statusId) {
     if ( !((this.statuses.size === 1) && this.statuses.has(statusId)) ) return false;
     if ( this.type !== "base" ) return false; // Only base-type effects can be status-only
-    const {changes, dot, summons, regions, maintenance} = this.system;
-    return !(changes.length || dot.length || summons.size || regions.size
+    const {changes, dot, summons, regions, lights, maintenance} = this.system;
+    return !(changes.length || dot.length || summons.size || regions.size || lights.size
       || maintenance.cost || maintenance.hands);
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Collect the UUIDs of the Tokens and Regions this effect currently owns from its persisted references.
+   * Collect the UUIDs of the Tokens, Regions, and AmbientLights this effect currently owns from its persisted references.
    * @returns {Set<string>}
    */
   #collectOwnedReferences() {
-    return new Set([...(this.system.summons ?? []), ...(this.system.regions ?? [])]);
+    return new Set([...(this.system.summons ?? []), ...(this.system.regions ?? []), ...(this.system.lights ?? [])]);
   }
 
   /* -------------------------------------------- */
@@ -96,7 +96,7 @@ export default class CrucibleActiveEffect extends foundry.documents.ActiveEffect
   /**
    * Delete owned references on behalf of a requesting User.
    * Enforce that each still exists, is an allowed document type, and is OWNED by the user who triggered the operation.
-   * @param {Set<string>} references      UUIDs of owned Tokens and Regions to delete
+   * @param {Set<string>} references      UUIDs of owned Tokens, Regions, and AmbientLights to delete
    * @param {string} userId               The user who performed the triggering operation
    * @returns {Promise<void>}
    */

--- a/module/hooks/spell.mjs
+++ b/module/hooks/spell.mjs
@@ -1,152 +1,6 @@
 const HOOKS = {};
 
 /* -------------------------------------------- */
-/*  Shared Light Helpers                         */
-/* -------------------------------------------- */
-
-/**
- * Resolve the center point of an actor's primary active token, in canvas pixel coordinates.
- * @param {CrucibleActor} actor
- * @returns {{x: number, y: number}|null}
- */
-function getActorCenter(actor) {
-  const token = actor.getActiveTokens(true, true)[0];
-  if ( !token ) return null;
-  return token.getCenterPoint ? token.getCenterPoint() : (token.object?.center ?? null);
-}
-
-/* -------------------------------------------- */
-
-/**
- * Find the ActiveEffect (on any actor in the scene) which owns a given AmbientLight, tracked via
- * system.lights. Used so a destroyed light's owning effect - and any duration/cleanup logic tied to it -
- * gets cleaned up consistently rather than deleting the light document out from under it.
- * @param {string} lightUuid
- * @returns {CrucibleActiveEffect|null}
- */
-function findOwningLightEffect(lightUuid) {
-  const actors = new Set([...game.actors, ...canvas.scene.tokens.map(t => t.actor).filter(a => a)]);
-  for ( const actor of actors ) {
-    for ( const effect of actor.effects ) {
-      if ( effect.system.lights?.has(lightUuid) ) return effect;
-    }
-  }
-  return null;
-}
-
-/* -------------------------------------------- */
-
-/**
- * Destroy every magical darkness source (an AmbientLight with config.negative = true) whose origin lies
- * within radiusFeet of a center point. If the light is owned by an ActiveEffect, that effect is deleted
- * so the cascade-delete cleanup handles removing the light; otherwise the light itself is deleted directly.
- * @param {{x: number, y: number}} center
- * @param {number} radiusFeet
- */
-async function destroyMagicalDarknessNear(center, radiusFeet) {
-  const pixelsPerFoot = canvas.scene.grid.size / canvas.scene.grid.distance;
-  const radiusPx = radiusFeet * pixelsPerFoot;
-  const darknessLights = canvas.scene.lights.filter(l => {
-    if ( !l.config.negative ) return false;
-    return Math.hypot(l.x - center.x, l.y - center.y) <= radiusPx;
-  });
-  for ( const light of darknessLights ) {
-    const owningEffect = findOwningLightEffect(light.uuid);
-    if ( owningEffect ) await owningEffect.delete();
-    else await light.delete();
-  }
-}
-
-/**
- * Explicitly delete the lights owned by a named effect still on the actor. Used on reverse/undo instead of
- * relying on the generic owned-reference cascade, since a reversed action may be a freshly reconstructed
- * instance that never re-derives the light's UUID - the actor's live effect document is the source of truth.
- * @param {CrucibleActor} actor
- * @param {string} effectName
- */
-async function deleteOwnedLights(actor, effectName) {
-  const effect = actor.effects.find(e => e.name === effectName);
-  if ( !effect ) return;
-  for ( const uuid of effect.system.lights ?? [] ) {
-    const light = await fromUuid(uuid);
-    if ( light ) await light.delete();
-  }
-}
-
-/* -------------------------------------------- */
-/*  Dawn Beacon                                  */
-/* -------------------------------------------- */
-
-/**
- * The AmbientLightData used by the Dawn Beacon pillar of light.
- * bright/dim are expressed in the scene's grid distance units (feet), matching the spell's 30ft bright / 60ft
- * total radius description.
- */
-const DAWN_BEACON_LIGHT = Object.freeze({config: {bright: 30, dim: 60, color: "#fff2c2", alpha: 0.35,
-  animation: {type: "pulse", speed: 1, intensity: 2}}});
-
-HOOKS.dawnBeacon000000 = {
-  async confirmAction(_item, action, {reverse}) {
-    if ( reverse ) return deleteOwnedLights(this, "Dawn Beacon Pillar");
-    const lightEffect = action.selfEvents.all
-      .flatMap(e => e.effects ?? [])
-      .find(e => e.name === "Dawn Beacon Pillar");
-    if ( !lightEffect ) return; // Effect was negated (e.g. the caster was silenced) - no light should be placed
-    const center = getActorCenter(this);
-    if ( !center ) return;
-    try {
-      // This light counteracts magical darkness: destroy any darkness sources within its area first.
-      await destroyMagicalDarknessNear(center, DAWN_BEACON_LIGHT.config.dim);
-      const [light] = await canvas.scene.createEmbeddedDocuments("AmbientLight", [{
-        x: center.x,
-        y: center.y,
-        ...DAWN_BEACON_LIGHT
-      }]);
-      if ( !light ) return;
-      lightEffect.system.lights ??= [];
-      lightEffect.system.lights.push(light.uuid);
-    } catch(err) {
-      console.error("Dawn Beacon | failed to create AmbientLight", err);
-    }
-  }
-};
-
-/* -------------------------------------------- */
-/*  Engulfing Darkness                           */
-/* -------------------------------------------- */
-
-/**
- * The AmbientLightData used by the Engulfing Darkness sphere. negative:true marks this as a magical
- * darkness source - the marker Dawn Beacon (and any other counteracting light) looks for.
- */
-const ENGULFING_DARKNESS_LIGHT = Object.freeze({config: {bright: 0, dim: 20, negative: true, color: "#2b0033",
-  alpha: 0.75, animation: {type: "blackHole", speed: 1, intensity: 3}}});
-
-HOOKS.engulfingDarknes = {
-  async confirmAction(_item, action, {reverse}) {
-    if ( reverse ) return deleteOwnedLights(this, "Engulfing Darkness Sphere");
-    const darknessEffect = action.selfEvents.all
-      .flatMap(e => e.effects ?? [])
-      .find(e => e.name === "Engulfing Darkness Sphere");
-    if ( !darknessEffect ) return;
-    const center = getActorCenter(this);
-    if ( !center ) return;
-    try {
-      const [light] = await canvas.scene.createEmbeddedDocuments("AmbientLight", [{
-        x: center.x,
-        y: center.y,
-        ...ENGULFING_DARKNESS_LIGHT
-      }]);
-      if ( !light ) return;
-      darknessEffect.system.lights ??= [];
-      darknessEffect.system.lights.push(light.uuid);
-    } catch(err) {
-      console.error("Engulfing Darkness | failed to create AmbientLight", err);
-    }
-  }
-};
-
-/* -------------------------------------------- */
 
 HOOKS.protectiveMirage = {
   defendAttack(item, action, _origin, rollData) {
@@ -183,6 +37,76 @@ HOOKS.protectiveMirage = {
       "flags.crucible.duplicates": duplicates,
       _action: "update"
     }]});
+  }
+};
+
+/* -------------------------------------------- */
+/*  Dawn Beacon                                  */
+/* -------------------------------------------- */
+
+/**
+ * Find the ActiveEffect (on any actor with a token in the current scene) which owns a given AmbientLight,
+ * tracked via system.lights. Deleting the owning effect - rather than the light document directly - lets
+ * the generic owned-reference cascade (see CrucibleActiveEffect) handle cleanup consistently, the same way
+ * it would if the effect had simply expired.
+ * @param {string} lightUuid
+ * @returns {CrucibleActiveEffect|null}
+ */
+function findOwningLightEffect(lightUuid) {
+  const actors = new Set([...game.actors, ...canvas.scene.tokens.map(t => t.actor).filter(a => a)]);
+  for ( const actor of actors ) {
+    for ( const effect of actor.effects ) {
+      if ( effect.system.lights?.has(lightUuid) ) return effect;
+    }
+  }
+  return null;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Destroy every magical darkness source (an AmbientLight with config.negative = true) whose origin lies
+ * within radiusFeet of a center point.
+ * @param {{x: number, y: number}} center
+ * @param {number} radiusFeet
+ */
+async function destroyMagicalDarknessNear(center, radiusFeet) {
+  const pixelsPerFoot = canvas.scene.grid.size / canvas.scene.grid.distance;
+  const radiusPx = radiusFeet * pixelsPerFoot;
+  const darknessLights = canvas.scene.lights.filter(l => {
+    if ( !l.config.negative ) return false;
+    return Math.hypot(l.x - center.x, l.y - center.y) <= radiusPx;
+  });
+  for ( const light of darknessLights ) {
+    const owningEffect = findOwningLightEffect(light.uuid);
+    if ( owningEffect ) await owningEffect.delete();
+    else await light.delete(); // Unowned darkness source (e.g. authored directly on the scene)
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Resolve the center point of an actor's primary active token, in canvas pixel coordinates.
+ * @param {CrucibleActor} actor
+ * @returns {{x: number, y: number}|null}
+ */
+function getActorCenter(actor) {
+  const token = actor.getActiveTokens(true, true)[0];
+  if ( !token ) return null;
+  return token.getCenterPoint ? token.getCenterPoint() : (token.object?.center ?? null);
+}
+
+HOOKS.dawnBeacon000000 = {
+  confirmAction(_item, _action, {reverse}) {
+    if ( reverse ) return; // Destroying darkness is a one-time forward effect; nothing to reverse
+    const center = getActorCenter(this);
+    if ( !center ) return;
+
+    // This light counteracts magical darkness: destroy any darkness sources within its area before the
+    // "Dawn Beacon Pillar" effect (declared on this action, see Dawn_Beacon_dawnBeacon000000.yml) creates its
+    // own owned light. 60ft matches that effect's system.light.dim radius.
+    return destroyMagicalDarknessNear(center, 60);
   }
 };
 

--- a/module/hooks/spell.mjs
+++ b/module/hooks/spell.mjs
@@ -1,6 +1,152 @@
 const HOOKS = {};
 
 /* -------------------------------------------- */
+/*  Shared Light Helpers                         */
+/* -------------------------------------------- */
+
+/**
+ * Resolve the center point of an actor's primary active token, in canvas pixel coordinates.
+ * @param {CrucibleActor} actor
+ * @returns {{x: number, y: number}|null}
+ */
+function getActorCenter(actor) {
+  const token = actor.getActiveTokens(true, true)[0];
+  if ( !token ) return null;
+  return token.getCenterPoint ? token.getCenterPoint() : (token.object?.center ?? null);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Find the ActiveEffect (on any actor in the scene) which owns a given AmbientLight, tracked via
+ * system.lights. Used so a destroyed light's owning effect - and any duration/cleanup logic tied to it -
+ * gets cleaned up consistently rather than deleting the light document out from under it.
+ * @param {string} lightUuid
+ * @returns {CrucibleActiveEffect|null}
+ */
+function findOwningLightEffect(lightUuid) {
+  const actors = new Set([...game.actors, ...canvas.scene.tokens.map(t => t.actor).filter(a => a)]);
+  for ( const actor of actors ) {
+    for ( const effect of actor.effects ) {
+      if ( effect.system.lights?.has(lightUuid) ) return effect;
+    }
+  }
+  return null;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Destroy every magical darkness source (an AmbientLight with config.negative = true) whose origin lies
+ * within radiusFeet of a center point. If the light is owned by an ActiveEffect, that effect is deleted
+ * so the cascade-delete cleanup handles removing the light; otherwise the light itself is deleted directly.
+ * @param {{x: number, y: number}} center
+ * @param {number} radiusFeet
+ */
+async function destroyMagicalDarknessNear(center, radiusFeet) {
+  const pixelsPerFoot = canvas.scene.grid.size / canvas.scene.grid.distance;
+  const radiusPx = radiusFeet * pixelsPerFoot;
+  const darknessLights = canvas.scene.lights.filter(l => {
+    if ( !l.config.negative ) return false;
+    return Math.hypot(l.x - center.x, l.y - center.y) <= radiusPx;
+  });
+  for ( const light of darknessLights ) {
+    const owningEffect = findOwningLightEffect(light.uuid);
+    if ( owningEffect ) await owningEffect.delete();
+    else await light.delete();
+  }
+}
+
+/**
+ * Explicitly delete the lights owned by a named effect still on the actor. Used on reverse/undo instead of
+ * relying on the generic owned-reference cascade, since a reversed action may be a freshly reconstructed
+ * instance that never re-derives the light's UUID - the actor's live effect document is the source of truth.
+ * @param {CrucibleActor} actor
+ * @param {string} effectName
+ */
+async function deleteOwnedLights(actor, effectName) {
+  const effect = actor.effects.find(e => e.name === effectName);
+  if ( !effect ) return;
+  for ( const uuid of effect.system.lights ?? [] ) {
+    const light = await fromUuid(uuid);
+    if ( light ) await light.delete();
+  }
+}
+
+/* -------------------------------------------- */
+/*  Dawn Beacon                                  */
+/* -------------------------------------------- */
+
+/**
+ * The AmbientLightData used by the Dawn Beacon pillar of light.
+ * bright/dim are expressed in the scene's grid distance units (feet), matching the spell's 30ft bright / 60ft
+ * total radius description.
+ */
+const DAWN_BEACON_LIGHT = Object.freeze({config: {bright: 30, dim: 60, color: "#fff2c2", alpha: 0.35,
+  animation: {type: "pulse", speed: 1, intensity: 2}}});
+
+HOOKS.dawnBeacon000000 = {
+  async confirmAction(_item, action, {reverse}) {
+    if ( reverse ) return deleteOwnedLights(this, "Dawn Beacon Pillar");
+    const lightEffect = action.selfEvents.all
+      .flatMap(e => e.effects ?? [])
+      .find(e => e.name === "Dawn Beacon Pillar");
+    if ( !lightEffect ) return; // Effect was negated (e.g. the caster was silenced) - no light should be placed
+    const center = getActorCenter(this);
+    if ( !center ) return;
+    try {
+      // This light counteracts magical darkness: destroy any darkness sources within its area first.
+      await destroyMagicalDarknessNear(center, DAWN_BEACON_LIGHT.config.dim);
+      const [light] = await canvas.scene.createEmbeddedDocuments("AmbientLight", [{
+        x: center.x,
+        y: center.y,
+        ...DAWN_BEACON_LIGHT
+      }]);
+      if ( !light ) return;
+      lightEffect.system.lights ??= [];
+      lightEffect.system.lights.push(light.uuid);
+    } catch(err) {
+      console.error("Dawn Beacon | failed to create AmbientLight", err);
+    }
+  }
+};
+
+/* -------------------------------------------- */
+/*  Engulfing Darkness                           */
+/* -------------------------------------------- */
+
+/**
+ * The AmbientLightData used by the Engulfing Darkness sphere. negative:true marks this as a magical
+ * darkness source - the marker Dawn Beacon (and any other counteracting light) looks for.
+ */
+const ENGULFING_DARKNESS_LIGHT = Object.freeze({config: {bright: 0, dim: 20, negative: true, color: "#2b0033",
+  alpha: 0.75, animation: {type: "blackHole", speed: 1, intensity: 3}}});
+
+HOOKS.engulfingDarknes = {
+  async confirmAction(_item, action, {reverse}) {
+    if ( reverse ) return deleteOwnedLights(this, "Engulfing Darkness Sphere");
+    const darknessEffect = action.selfEvents.all
+      .flatMap(e => e.effects ?? [])
+      .find(e => e.name === "Engulfing Darkness Sphere");
+    if ( !darknessEffect ) return;
+    const center = getActorCenter(this);
+    if ( !center ) return;
+    try {
+      const [light] = await canvas.scene.createEmbeddedDocuments("AmbientLight", [{
+        x: center.x,
+        y: center.y,
+        ...ENGULFING_DARKNESS_LIGHT
+      }]);
+      if ( !light ) return;
+      darknessEffect.system.lights ??= [];
+      darknessEffect.system.lights.push(light.uuid);
+    } catch(err) {
+      console.error("Engulfing Darkness | failed to create AmbientLight", err);
+    }
+  }
+};
+
+/* -------------------------------------------- */
 
 HOOKS.protectiveMirage = {
   defendAttack(item, action, _origin, rollData) {

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -340,7 +340,7 @@ class CrucibleActionEvent {
     if ( this.negated ) obj.negated = true;
     for ( const effect of obj.effects ) {
       if ( !effect.system ) continue;
-      for ( const setKey of ["regions", "summons"] ) {
+      for ( const setKey of ["regions", "summons", "lights"] ) {
         if ( setKey in effect.system ) effect.system[setKey] = Array.from(effect.system[setKey]);
       }
     }

--- a/module/models/effect-base.mjs
+++ b/module/models/effect-base.mjs
@@ -22,7 +22,23 @@ export default class CrucibleBaseActiveEffect extends foundry.data.ActiveEffectT
       properties: new fields.SetField(new fields.StringField({required: true, choices: SYSTEM.EFFECTS.PROPERTIES})),
       regions: new fields.SetField(new fields.DocumentUUIDField({type: "Region", nullable: false})),
       summons: new fields.SetField(new fields.DocumentUUIDField({type: "Token", nullable: false})),
-      lights: new fields.SetField(new fields.DocumentUUIDField({type: "AmbientLight", nullable: false}))
+      lights: new fields.SetField(new fields.DocumentUUIDField({type: "AmbientLight", nullable: false})),
+
+      // A declarative template describing an AmbientLight this effect should conjure and own for its duration.
+      // When set, the effect document itself creates and destroys the light automatically - no bespoke hook
+      // code is required. See CrucibleActiveEffect##createOwnedLight.
+      light: new fields.SchemaField({
+        bright: new fields.NumberField({required: true, nullable: false, min: 0, initial: 0}),
+        dim: new fields.NumberField({required: true, nullable: false, min: 0, initial: 0}),
+        color: new fields.ColorField({nullable: true, initial: null}),
+        alpha: new fields.AlphaField({initial: 0.5}),
+        negative: new fields.BooleanField({initial: false}),
+        animation: new fields.SchemaField({
+          type: new fields.StringField({required: false, blank: true, initial: ""}),
+          speed: new fields.NumberField({required: false, nullable: false, initial: 5}),
+          intensity: new fields.NumberField({required: false, nullable: false, initial: 5})
+        })
+      }, {required: false, nullable: true, initial: null})
     });
   }
 

--- a/module/models/effect-base.mjs
+++ b/module/models/effect-base.mjs
@@ -21,7 +21,8 @@ export default class CrucibleBaseActiveEffect extends foundry.data.ActiveEffectT
       }),
       properties: new fields.SetField(new fields.StringField({required: true, choices: SYSTEM.EFFECTS.PROPERTIES})),
       regions: new fields.SetField(new fields.DocumentUUIDField({type: "Region", nullable: false})),
-      summons: new fields.SetField(new fields.DocumentUUIDField({type: "Token", nullable: false}))
+      summons: new fields.SetField(new fields.DocumentUUIDField({type: "Token", nullable: false})),
+      lights: new fields.SetField(new fields.DocumentUUIDField({type: "AmbientLight", nullable: false}))
     });
   }
 

--- a/styles/journal.less
+++ b/styles/journal.less
@@ -163,6 +163,7 @@ enriched-content.counterspell {
   --color-background-hover: #000000;
   --color-border: #000000;
   --color-border-hover: #000000;
+  --color-text-emphatic: #eee8df; // Local fallback; legible outside a themed .crucible card (e.g. RollTable draw)
 
   display: inline-flex;
   height: 1.5em;
@@ -268,6 +269,8 @@ enriched-content.counterspell {
 
 enriched-content.rule {
   font-size: 90%;
+  --color-text-emphatic: #eee8df; // Local fallback, same reasoning as .hazard-check et al above
+  --color-border: #3f3128; // Local fallback; matches --color-frame in variables.less
   color: var(--color-text-emphatic);
   border: 1px dashed var(--color-border);
   border-radius: 2px;


### PR DESCRIPTION
fix for #1418 

**Summary:**
Dawn Beacon's light source, its darkness-counteraction clause, and its enemy targeting were all non-functional/WIP. This PR implements the missing mechanics end-to-end.

**Changes:**

- **Owned light references** (`module/models/effect-base.mjs`, `module/documents/active-effect.mjs`) — added a `lights` field (Set of AmbientLight UUIDs) to the effect schema, alongside existing `regions`/`summons`. Extended `#DELETABLE_TYPES` and owned-reference collection/cleanup to include `AmbientLight`, so a light tied to an effect is cascade-deleted when that effect expires or is dispelled.

- **Dawn Beacon** (`module/hooks/spell.mjs`, `_source/spell/Dawn_Beacon_dawnBeacon000000.yml`)
  - Added a self-scoped "Dawn Beacon Pillar" effect (6 rounds) that owns the light.
  - New `confirmAction` hook (keyed `dawnBeacon000000`, matching the item's actual `_id`) creates the pillar's `AmbientLight` (30ft bright / 60ft dim) at the caster's token on cast.
  - Before placing its own light, scans the scene for "magical darkness" sources (any `AmbientLight` with `config.negative: true`) within its 60ft radius and destroys them via their owning effect.
  - Fixed `target.scope` from `1` (Self) to `3` (Enemies) — the stored value meant `#getTargetDispositions()` returned no valid dispositions at all, so enemies were never acquired as targets (no roll prompt, no manual-target override possible). This was the root cause of blind not applying.
  - Removed WIP note, fixed duplicate `iconicSpell` tag.
  - On reverse/undo, explicitly deletes the light via the actor's live effect document rather than relying on cascade-delete (a reversed action can be a reconstructed instance without the light's UUID).

- **Engulfing Darkness** (`module/hooks/spell.mjs`, `_source/spell/Engulfing_Darkness_engulfingDarknes.yml`) — automated identically (own `AmbientLight` with `negative: true`, owned by a new "Engulfing Darkness Sphere" self effect, reverse cleanup), since it had the same WIP gap and was needed as a real target for Dawn Beacon's darkness-destruction to counteract.

**Known follow-up (not in this PR):** Engulfing Darkness still has `target.scope: 1` (same bug as Dawn Beacon had) and no effect that actually blinds creatures inside it, will make a seperate issue & PR for this 