### PR TITLE
Change damage type of noxious spray to poison

### DIFF
--- a/_source/adversary-talents/Noxious_Spray_noxiousSpray0000.yml
+++ b/_source/adversary-talents/Noxious_Spray_noxiousSpray0000.yml
@@ -58,7 +58,7 @@ system:
         - melee
         - natural
         - reflex
-        - electricity
+        - poison
   rune: ''
   gesture: ''
   inflection: ''


### PR DESCRIPTION
### Summary

Changes the damage type of the noxious spray attack from electricity to poison.
This is how it is described in the text.