### PR TITLE
[#1444] Add Blood Sense as a detection mode

### DIFF
--- a/crucible.mjs
+++ b/crucible.mjs
@@ -478,6 +478,7 @@ Hooks.once("init", async function() {
 
   // Crucible-specific detection modes
   Object.assign(CONFIG.Canvas.detectionModes, {
+    bloodSense: new canvas.detectionModes.DetectionModeBloodSense(),
     echolocation: new canvas.detectionModes.DetectionModeEcholocation(),
     senseCreature: new canvas.detectionModes.DetectionModeSenseCreature(),
     thermalVision: new canvas.detectionModes.DetectionModeThermalVision()

--- a/module/canvas/detection-modes/_module.mjs
+++ b/module/canvas/detection-modes/_module.mjs
@@ -1,3 +1,4 @@
-export {default as DetectionModeEcholocation} from "./echolocation.mjs"
+export {default as DetectionModeBloodSense} from "./blood-sense.mjs";
+export {default as DetectionModeEcholocation} from "./echolocation.mjs";
 export {default as DetectionModeSenseCreature} from "./sense-creature.mjs";
 export {default as DetectionModeThermalVision} from "./thermal-vision.mjs";

--- a/module/canvas/detection-modes/blood-sense.mjs
+++ b/module/canvas/detection-modes/blood-sense.mjs
@@ -1,3 +1,6 @@
+/**
+ * A custom DetectionMode for perceiving blooded creatures that are wounded.
+ */
 export default class DetectionModeBloodSense extends foundry.canvas.perception.DetectionMode {
   constructor() {
     super({
@@ -35,6 +38,7 @@ export default class DetectionModeBloodSense extends foundry.canvas.perception.D
     if ( !health ) return true;
 
     // Otherwise, allow if any health is missing
+    // TODO: return false for non-blooded creatures, once that characteristic is implemented
     return health.value < health.max;
   }
 }

--- a/module/canvas/detection-modes/blood-sense.mjs
+++ b/module/canvas/detection-modes/blood-sense.mjs
@@ -1,0 +1,40 @@
+export default class DetectionModeBloodSense extends foundry.canvas.perception.DetectionMode {
+  constructor() {
+    super({
+      id: "bloodSense",
+      label: "DETECTION_MODES.BloodSense",
+      type: foundry.canvas.perception.DetectionMode.DETECTION_TYPES.OTHER,
+      walls: false
+    });
+  }
+
+  /** @override */
+  static getDetectionFilter() {
+    return this._detectionFilter ??= foundry.canvas.rendering.filters.OutlineOverlayFilter.create({
+      outlineColor: [0.6, 0, 0, 1],
+      knockout: true,
+      wave: false
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _canDetect(visionSource, target) {
+
+    // Blood sense only works on creatures
+    if ( !(target instanceof foundry.canvas.placeables.Token) ) return false;
+    const source = visionSource.object.document;
+
+    // Cannot smell blood if burrowing, or if target is burrowing
+    if ( source.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
+    if ( target.document.hasStatusEffect(CONFIG.specialStatusEffects.BURROW) ) return false;
+
+    // If actor has no health attribute, allow detection
+    const health = target.actor?.resources?.health;
+    if ( !health ) return true;
+
+    // Otherwise, allow if any health is missing
+    return health.value < health.max;
+  }
+}

--- a/module/canvas/detection-modes/echolocation.mjs
+++ b/module/canvas/detection-modes/echolocation.mjs
@@ -1,3 +1,6 @@
+/**
+ * A custom DetectionMode for perceiving creatures via sonic pulses.
+ */
 export default class DetectionModeEcholocation extends foundry.canvas.perception.DetectionMode {
   constructor() {
     super({

--- a/module/canvas/detection-modes/sense-creature.mjs
+++ b/module/canvas/detection-modes/sense-creature.mjs
@@ -1,3 +1,7 @@
+/**
+ * A custom DetectionMode for use with the Sense gesture. Which rune is used alongside the gesture controls
+ * which types of creatures are perceived.
+ */
 export default class DetectionModeSenseCreature extends foundry.canvas.perception.DetectionMode {
   constructor() {
     super({

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -289,6 +289,9 @@ HOOKS.bloodSense000000 = {
   prepareAttack(_item, action, target, rollData) {
     if ( !["strike", "skill"].some(t => action.tags.has(t)) ) return;
     if ( target.resources.health.value < target.resources.health.max ) delete rollData.banes.blind;
+  },
+  prepareToken(_item, token) {
+    token.detectionModes.bloodSense ??= {enabled: true, range: 20};
   }
 };
 


### PR DESCRIPTION
Closes #1444

Pretty simple one. Only things worth calling out:
- I made it `walls: false`, I think it makes sense to be able to sense blood from around a wall. Sensing it in an entirely closed off room, maybe not, but that's not the sort of logic we can currently perform. Could go either way here.
- I figure burrowing creatures can't sense blood, and the blood of a burrowing creature cannot be sensed.
- If the actor has no `health` resource at all (group actors, module-added subtypes) I figure lenience is better. I don't think this will realistically matter much, but figured it was worth mentioning.