### PR TITLE
[#1441] Fix certain weapon affixes not working properly

### DIFF
--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -315,7 +315,7 @@ class CrucibleActionEvent {
     if ( this.#weaponItem ) return this.#weaponItem;
     const source = this.#action.actor.items.get(this.weapon._id);
     if ( !source ) return undefined;
-    const clone = source.clone();
+    const clone = source.clone({}, {keepId: true});
     clone.system.updateSource(this.weapon.system);
     return this.#weaponItem = clone;
   }

--- a/module/models/item-weapon.mjs
+++ b/module/models/item-weapon.mjs
@@ -183,7 +183,7 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
     if ( !category.ranged ) bonus += (actorBonuses.melee ?? 0);
     if ( category.ranged ) bonus += (actorBonuses.ranged ?? 0);
     if ( category.hands === 2 ) bonus += (actorBonuses.twoHanded ?? 0);
-    this.damage.bonus = bonus;
+    this.damage.bonus += bonus;
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Closes #1441 
- Weapon damage affixes' change to `system.damage.bonus` were getting clobbered in `CrucibleWeaponItem#prepareEquippedData`. Now adding to the bonus instead of setting it. I _think_ this should be fine, because as far as I can tell we'll never call this outside derived data prep, so it doesn't need to be idempotent.
- Vicious is looking at `event.weaponItem.id`, which is `null` when cloned without `keepId: true`. A different fix would be to just check `event.weapon._id`, instead, which might be better, but I figure this change will keep us from footgunning in the future as well.