### PR TITLE
[#1313] Fix enrichers being invisible in RollTable draw cards

### DIFF
--- a/styles/journal.less
+++ b/styles/journal.less
@@ -163,6 +163,7 @@ enriched-content.counterspell {
   --color-background-hover: #000000;
   --color-border: #000000;
   --color-border-hover: #000000;
+  --color-text-emphatic: #eee8df; // Local fallback; legible outside a themed .crucible card (e.g. RollTable draw)
 
   display: inline-flex;
   height: 1.5em;
@@ -268,6 +269,8 @@ enriched-content.counterspell {
 
 enriched-content.rule {
   font-size: 90%;
+  --color-text-emphatic: #eee8df; // Local fallback, same reasoning as .hazard-check et al above
+  --color-border: #3f3128; // Local fallback; matches --color-frame in variables.less
   color: var(--color-text-emphatic);
   border: 1px dashed var(--color-border);
   border-radius: 2px;


### PR DESCRIPTION
Closes #1313

`enriched-content.hazard-check` (and the sibling `.skill-check`/`.passive-check`/`.award`/`.milestone`/`.counterspell`/`.rule` enrichers) color their text with `--color-text-emphatic`, which they never define themselves — it's only supplied by `.themed.theme-dark`, added in `CrucibleChatMessage.onRenderHTML` (`module/documents/chat-message.mjs`) when a message has `flags.crucible` or a `StandardCheck` roll. A native `RollTable` draw message has neither, so an enricher inside a result's description (e.g. `[[/hazard]]`) renders its background/border but not legible text.

Added local fallbacks for `--color-text-emphatic` (and `--color-border` for `.rule`, same gap) directly on the affected selectors in `styles/journal.less`, matching the existing `--color-text`/`--color-frame` values from `variables.less`. Ran `npm run less` to confirm a clean rebuild.