### PR TITLE
[#1452] Add `blooded` characteristic to ancestries & taxonomies

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1059,8 +1059,10 @@
         "label": "Identifier"
       },
       "characteristics": {
+        "blooded.hint": "Whether this Ancestry has some form of blood.",
+        "blooded.label": "Blooded",
         "label": "Ancestry Characteristics",
-        "temperature.hint": "The body temperature of this Ancestry, neutral by default.",
+        "temperature.hint": "The body temperature of this Ancestry, warm by default.",
         "temperature.label": "Body Temperature"
       },
       "movement": {
@@ -2488,6 +2490,8 @@
         "label": "Category"
       },
       "characteristics": {
+        "blooded.hint": "Whether this Taxonomy has some form of blood. Defaults to the bloodedness of the chosen creature category.",
+        "blooded.label": "Blooded",
         "equipment.label": "Can Use Equipment",
         "label": "Taxonomy Characteristics",
         "spells.label": "Can Cast Spells",

--- a/module/applications/sheets/item-taxonomy-sheet.mjs
+++ b/module/applications/sheets/item-taxonomy-sheet.mjs
@@ -153,7 +153,7 @@ export default class CrucibleTaxonomyItemSheet extends CrucibleActorDetailsItemS
   _processFormData(event, form, formData) {
     const submitData = super._processFormData(event, form, formData);
     const fields = this.document.system.schema.fields;
-    const {abilities, resistances} = submitData.system;
+    const {abilities, resistances, category} = submitData.system;
     for ( const resType of Object.keys(SYSTEM.DAMAGE_TYPES) ) {
       resistances[resType] ??= {};
       resistances[resType].value ??= this.document.system.resistances[resType].value;
@@ -162,6 +162,9 @@ export default class CrucibleTaxonomyItemSheet extends CrucibleActorDetailsItemS
     delete submitData.immunities;
     if ( fields.abilities.validate(abilities) !== undefined ) return {};
     if ( fields.resistances.validate(resistances) !== undefined ) return {};
+    if ( category !== this.document.system.category ) {
+      submitData.system.characteristics.blooded = SYSTEM.ACTOR.CREATURE_CATEGORIES[category]?.blooded ?? true;
+    }
     return submitData;
   }
 }

--- a/module/canvas/detection-modes/blood-sense.mjs
+++ b/module/canvas/detection-modes/blood-sense.mjs
@@ -37,8 +37,11 @@ export default class DetectionModeBloodSense extends foundry.canvas.perception.D
     const health = target.actor?.resources?.health;
     if ( !health ) return true;
 
+    // If creature does not have blood, cannot detect
+    const detailType = (target.actor.type === "hero") ? "ancestry" : "taxonomy";
+    if ( !target.actor.system.details?.[detailType]?.characteristics?.blooded ) return false;
+
     // Otherwise, allow if any health is missing
-    // TODO: return false for non-blooded creatures, once that characteristic is implemented
     return health.value < health.max;
   }
 }

--- a/module/const/actor.mjs
+++ b/module/const/actor.mjs
@@ -1,8 +1,19 @@
 import {defineEnum} from "./enum.mjs";
 
 /**
+ * @typedef CrucibleCreatureCategory
+ * @property {string} id          The id for the creature category; the key in the categories object
+ * @property {string} label       A human-readable and localized label for the creature category
+ * @property {string} skill       The id of the skill associated with knowledge of the creature category
+ * @property {string} knowledge   The id of the knowledge which would grant information about the creature category
+ * @property {string} temperature The default temperature tier for creatures of this category
+ * @property {boolean} blooded    Whether creatures of this category typically have blood
+ * @property {string} [sense]     The id of the Rune which, when used with Sense, grants detection of this category
+ */
+
+/**
  * Creature types supported by the system.
- * @type {Readonly<Record<string, {id: string, label: string, skill: string, knowledge: string, temperature: string, sense?: string}>>}
+ * @type {Readonly<Record<string, CrucibleCreatureCategory>>}
  */
 export const CREATURE_CATEGORIES = defineEnum({
   beast: {
@@ -10,6 +21,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "medicine",
     knowledge: "beasts",
     temperature: "warm",
+    blooded: true,
     sense: "life"
   },
   celestial: {
@@ -17,6 +29,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "celestials",
     temperature: "warm",
+    blooded: true,
     sense: "illumination"
   },
   construct: {
@@ -24,6 +37,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "science",
     knowledge: "machines",
     temperature: "neutral",
+    blooded: false,
     sense: "storm"
   },
   dragon: {
@@ -31,19 +45,22 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "dragons",
     temperature: "warm",
+    blooded: true,
     sense: "flame"
   },
   elemental: {
     label: "TAXONOMY.CATEGORIES.Elemental",
     skill: "arcana",
     knowledge: "elementals",
-    temperature: "neutral"
+    temperature: "neutral",
+    blooded: false
   },
   elementalEarth: {
     label: "TAXONOMY.CATEGORIES.ElementalEarth",
     skill: "arcana",
     knowledge: "elementals",
     temperature: "warm",
+    blooded: false,
     sense: "earth"
   },
   elementalFire: {
@@ -51,6 +68,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "elementals",
     temperature: "boiling",
+    blooded: false,
     sense: "flame"
   },
   elementalFrost: {
@@ -58,6 +76,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "elementals",
     temperature: "gelid",
+    blooded: false,
     sense: "frost"
   },
   elementalStorm: {
@@ -65,6 +84,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "elementals",
     temperature: "cool",
+    blooded: false,
     sense: "storm"
   },
   fey: {
@@ -72,6 +92,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "fey",
     temperature: "warm",
+    blooded: true,
     sense: "illusion"
   },
   fiend: {
@@ -79,6 +100,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "fiends",
     temperature: "cool",
+    blooded: true,
     sense: "control"
   },
   giant: {
@@ -86,6 +108,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "society",
     knowledge: "legends",
     temperature: "warm",
+    blooded: true,
     sense: "frost"
   },
   humanoid: {
@@ -93,6 +116,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "society",
     knowledge: null,
     temperature: "warm",
+    blooded: true,
     sense: "soul"
   },
   monstrosity: {
@@ -100,6 +124,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "medicine",
     knowledge: "monsters",
     temperature: "warm",
+    blooded: true,
     sense: "kinesis"
   },
   ooze: {
@@ -107,6 +132,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "science",
     knowledge: null,
     temperature: "neutral",
+    blooded: false,
     sense: "earth"
   },
   plant: {
@@ -114,6 +140,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "wilderness",
     knowledge: null,
     temperature: "neutral",
+    blooded: false,
     sense: "life"
   },
   outsider: {
@@ -121,6 +148,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "outsiders",
     temperature: "cool",
+    blooded: true,
     sense: "oblivion"
   },
   undead: {
@@ -128,6 +156,7 @@ export const CREATURE_CATEGORIES = defineEnum({
     skill: "arcana",
     knowledge: "undeath",
     temperature: "cool",
+    blooded: true,
     sense: "death"
   }
 });

--- a/module/models/item-ancestry.mjs
+++ b/module/models/item-ancestry.mjs
@@ -35,6 +35,7 @@ export default class CrucibleAncestryItem extends foundry.abstract.TypeDataModel
         level: new fields.NumberField({required: true, nullable: true, integer: true, initial: null})
       })),
       characteristics: new fields.SchemaField({
+        blooded: new fields.BooleanField({required: true, initial: true}),
         temperature: new fields.StringField({required: true, blank: true, initial: "",
           choices: SYSTEM.TEMPERATURE_TIERS})
       }),

--- a/module/models/item-taxonomy.mjs
+++ b/module/models/item-taxonomy.mjs
@@ -44,6 +44,12 @@ export default class CrucibleTaxonomyItem extends foundry.abstract.TypeDataModel
         autoScale: new fields.BooleanField()
       })),
       characteristics: new fields.SchemaField({
+        blooded: new fields.BooleanField({required: true, initial: source => {
+          let category;
+          if ( source?.type === "adversary" ) category = source.system.details.taxonomy?.category;
+          else category = source?.system?.category;
+          return SYSTEM.ACTOR.CREATURE_CATEGORIES[category]?.blooded ?? true;
+        }}),
         equipment: new fields.BooleanField(),
         spells: new fields.BooleanField(),
         temperature: new fields.StringField({required: true, blank: true, initial: "",

--- a/templates/sheets/item/ancestry-config.hbs
+++ b/templates/sheets/item/ancestry-config.hbs
@@ -13,6 +13,7 @@
         {{formGroup fields.movement.fields.stride value=system.movement.stride classes="slim"}}
         {{formGroup fields.characteristics.fields.temperature value=system.characteristics.temperature
                     blank=temperatureBlank}}
+        {{formGroup fields.characteristics.fields.blooded value=system.characteristics.blooded}}
     </fieldset>
 
     <fieldset {{fieldDisabled}}>

--- a/templates/sheets/item/taxonomy-config.hbs
+++ b/templates/sheets/item/taxonomy-config.hbs
@@ -13,6 +13,7 @@
         {{formGroup fields.movement.fields.stride value=source.system.movement.stride classes="slim"}}
         {{formGroup fields.characteristics.fields.temperature value=source.system.characteristics.temperature
                     blank=temperatureBlank}}
+        {{formGroup fields.characteristics.fields.blooded value=source.system.characteristics.blooded}}
         {{formGroup fields.characteristics.fields.equipment value=source.system.characteristics.equipment}}
         {{formGroup fields.characteristics.fields.spells value=source.system.characteristics.spells}}
     </fieldset>


### PR DESCRIPTION
Closes #1452 
Pretty straightforward for the most part. Things worth noting/double checking:
- Fixed the i18n for temperature hint (it's warm by default for ancestries)
- We only inherit creature category bloodedness either in the case that `blooded` doesn't exist in source (`initial`, this way no existing taxonomies need adjusting) _or_ when modifying taxonomy _via the sheet_. Figure a programmatic update would know to set `blooded` if desired
- The `initial` function is a little bit messy because of the way detail items are handled on an actual actor - sometimes the `source` is actor source data, sometimes it's taxonomy source data
- Added a typedef for `CrucibleCreatureCategory` as it was getting a little crowded
- Should probably do a pass on my determination for bloodedness defaults for each category (undead in particular feels like it varies greatly based on the undead itself. I defaulted to `true` but not sure whether it makes more sense to do that and make changes for `skeleton` for instance, or default to false and make changes for something like a recently raised thrall. I guess probably the latter. But I anticipate potential changes there anyway so leaving as-is for your review