### PR TITLE
Fixes/amendments to pack data for proficiencies branch

### DIFF
--- a/_source/rules/Character_Mechanics_characterMechani.yml
+++ b/_source/rules/Character_Mechanics_characterMechani.yml
@@ -660,13 +660,13 @@ pages:
         the Talents it grants.</p><p>Each Background includes:</p><ul><li><p>Six
         trained Proficiencies, each receiving one training point. These need not
         be Skills: a Background may train a weapon category or a family of
-        spellcraft.</p></li><li><p>Two Knowledge
-        Areas</p></li><li><p>One known Language</p></li><li><p>Three
-        Talents</p></li></ul><p>A Background which names fewer than six
-        Proficiencies or fewer than three Talents remains valid, but the
-        Background sheet will warn you that it is incomplete.</p><h2
-        class="divider">Example Backgrounds</h2><p>The table below presents some
-        example Backgrounds which will be familiar for many fantasy RPG
+        spellcraft.</p></li><li><p>Two Knowledge Areas</p></li><li><p>One known
+        Language</p></li><li><p>Three Talents</p></li></ul><p>A Background which
+        names fewer than six Proficiencies or fewer than three Talents remains
+        valid, but the Background sheet will warn you that it is
+        incomplete.</p><h2 class="divider">Example Backgrounds</h2><p>The table
+        below presents some example Backgrounds which will be familiar for many
+        fantasy RPG
         settings.</p><table><thead><tr><th>Background</th><th>Knowledge</th><th>Trained
         Proficiencies</th><th>Talents</th></tr></thead><tbody><tr><td>@UUID[Compendium.crucible.background.Item.acolyte000000000]{Acolyte}</td><td>Gods,
         Souls</td><td>Arcana, Medicine, Talisman Weapons, Spiritual Spellcraft,
@@ -991,9 +991,9 @@ pages:
       content: >-
         <p>A <strong>Proficiency</strong> is something your character can be
         trained in: a Skill, a category of weapon, or a family of spellcraft.
-        Each one holds a total of training points, and the ranks
-        below are thresholds upon that total.</p><p>Training points come from
-        three sources. Your
+        Each one holds a total of training points, and the ranks below are
+        thresholds upon that total.</p><p>Training points come from three
+        sources. Your
         @UUID[Compendium.crucible.rules.JournalEntry.characterMechani.JournalEntryPage.backgrounds00000]{Background}
         grants six areas where you start your journey with some proficiency,
         every
@@ -1003,11 +1003,11 @@ pages:
         the first.</p><table><tbody><tr><th
         data-colwidth="50"><p>Points</p></th><th
         data-colwidth="50"><p>Bonus</p></th><th><p>Rank</p></th><th><p>Scale</p></th></tr><tr><td
-        data-colwidth="50"><p>0</p></td><td
-        data-colwidth="50"><p>-4</p></td><td><p>Untrained</p></td><td><p>You are
-        decidedly as good at this skill as the average person who has absolutely
-        no education or professional training related to
-        it.</p></td></tr><tr><td data-colwidth="50"><p>2</p></td><td
+        data-colwidth="50"><p>0</p></td><td data-colwidth="50"><p>-4,
+        -2</p></td><td><p>Untrained</p></td><td><p>You are decidedly as good at
+        this skill as the average person who has absolutely no education or
+        professional training related to it.</p></td></tr><tr><td
+        data-colwidth="50"><p>2</p></td><td
         data-colwidth="50"><p>0</p></td><td><p>Trained</p></td><td><p>You have
         received training in the basic practices common across all parts of that
         skill.</p></td></tr><tr><td data-colwidth="50"><p>6</p></td><td
@@ -1052,8 +1052,8 @@ pages:
       systemId: crucible
       systemVersion: 0.10.2
       createdTime: 1788600000000
-      modifiedTime: 1788723455219
-      lastModifiedBy: WRGzDgYAt3ZuX6TU
+      modifiedTime: 1788886965442
+      lastModifiedBy: ZXJsFnFZuf21WDAk
     _key: '!journal.pages!characterMechani.proficiencies000'
 folder: MMeWpMmsLOblp07U
 categories: []

--- a/_source/talent/Hide_hide000000000000.yml
+++ b/_source/talent/Hide_hide000000000000.yml
@@ -18,14 +18,13 @@ system:
     - id: hide
       name: Hide
       img: icons/magic/nature/stealth-hide-eyes-green.webp
-      condition: ''
+      condition: You are not engaged.
       description: >-
-        <p>You cannot Hide while engaged. You make a single Stealth check
-        against the Awareness of the most perceptive enemy within 30 feet,
-        taking <strong>+1 Bane</strong> for each further enemy who might notice
-        you. With no enemy near enough to notice you no check is required. Upon
-        a success you are concealed until you perform an action which is not
-        <strong>Subtle</strong>.</p>
+        <p>You make a single Stealth check against the Awareness of the most
+        perceptive enemy within 30 feet, taking <strong>+1 Bane</strong> for
+        each further enemy who might notice you. With no enemy near enough to
+        notice you no check is required. Upon a success you are concealed until
+        you perform an action which is not @Rule[action.subtle].</p>
       cost:
         action: 2
         focus: 1
@@ -67,6 +66,7 @@ system:
         - subtle
         - skill
         - stealth
+        - harmless
       summon: null
   nodes:
     - intdex1
@@ -87,8 +87,8 @@ _stats:
   systemVersion: 0.10.2
   coreVersion: '14.367'
   createdTime: 1788600000000
-  modifiedTime: 1788877781111
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1788886518116
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   compendiumSource: null
   duplicateSource: null
   exportSource: null


### PR DESCRIPTION
Three changes:
1. Change `-4` to `-4, -2` in the table of training bonuses
2. Add `harmless` to Hide so it no longer does damage
3. Clean Hide's action description (use rule enricher for subtle, move conditional into condition)