### PR TITLE
Fixes to hooks for proficiencies branch

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -1621,7 +1621,7 @@ export const DEFAULT_ACTIONS = Object.freeze([
     cost: {
       action: 3
     },
-    tags: ["awareness", "subtle"]
+    tags: ["awareness", "subtle", "harmless"]
   },
 
   // Basic Strike

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -1393,6 +1393,7 @@ function _recordConcealmentDC(action) {
     for ( const effect of event.effects ?? [] ) {
       effect.system ??= {};
       effect.system.dc = dc;
+      effect.showIcon = CONST.ACTIVE_EFFECT_SHOW_ICON.ALWAYS;
     }
   }
 }
@@ -1412,7 +1413,7 @@ HOOKS.hide = {
     if ( !token ) return;
 
     const observers = crucible.api.canvas.grid.getTokensInRange(token, this.range.maximum ?? 30, {disposition: "enemy"});
-    const actors = observers.map(t => t.actor).filter(a => a);
+    const actors = observers.map(t => t.token.actor).filter(a => a);
 
     // With nobody positioned to notice you there is nothing to beat, so concealment is automatic
     if ( !actors.length ) {
@@ -2261,7 +2262,7 @@ HOOKS.search = {
     const ids = _concealmentEffectIds();
     const range = action.range.maximum ?? 30;
     const found = [];
-    for ( const t of crucible.api.canvas.grid.getTokensInRange(token, range) ) {
+    for ( const {token: t} of crucible.api.canvas.grid.getTokensInRange(token, range) ) {
       if ( !t.actor ) continue;
       for ( const id of ids ) {
         const effect = t.actor.effects.get(id);

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -361,7 +361,7 @@ HOOKS.brutalDisplay000 = {
       test: (target, deltas) => {
         const {health, wounds} = target.system.resources;
         if ( target.system.isDead ) return false; // Already a corpse before this Action landed
-        if ( wounds ) return (wounds.value + (deltas.wounds ?? 0)) >= wounds.max;
+        if ( target.system.usesReserveResources ) return (wounds.value + (deltas.wounds ?? 0)) >= wounds.max;
         return (health.value + (deltas.health ?? 0)) <= 0;
       },
       radius: 20,
@@ -776,7 +776,7 @@ HOOKS.focalReach000000 = {
     const focus = this.resources.focus.value;
     if ( !focus ) return;
     for ( const w of [weapons.mainhand, weapons.offhand] ) {
-      if ( w?.config.category.training.includes("talisman") ) w.range += focus;
+      if ( w?.config.category.training.includes("talisman") ) w.system.range += focus;
     }
   }
 };
@@ -937,8 +937,7 @@ HOOKS.hide000000000000 = {
   preActivateAction(_item, action) {
     const effectId = SYSTEM.EFFECTS.getEffectId("hide", {suffix: "0"});
     if ( !this.effects.has(effectId) || action.tags.has("subtle") ) return;
-    // noinspection ES6MissingAwait
-    this.deleteEmbeddedDocuments("ActiveEffect", [effectId]);
+    action.recordEvent({type: "effect", target: this, effects: [{_id: effectId, _action: "delete"}]});
   }
 };
 
@@ -1353,7 +1352,7 @@ HOOKS.piercingBolts000 = {
     if ( !weapon?.config.category.training.includes("talisman") ) return;
     for ( const event of action.eventsByTarget.get(target)?.roll ?? [] ) {
       const dmg = event.roll?.data.damage;
-      if ( !dmg?.resistance || dmg.restoration ) continue;
+      if ( !dmg || (dmg.resistance <= 0) || dmg.restoration ) continue;
       dmg.resistance = Math.max(dmg.resistance - 2, 0);
       dmg.total = crucible.api.models.CrucibleAction.computeDamage(dmg);
     }


### PR DESCRIPTION
Changes:
- Search gets `harmless` to avoid dealing damage
- `_recordConcealmentDC` also marks the effect as always show (technically unnecessary for the case of Stealth, but felt cleaner to do so there than to do a nested loop over events & effects just for Hide)
- Fix Hide hook not properly gathering observer actors
- Fix Search hook not properly gathering hiding actors
- Fix Brutal Display not necessarily working for unimportant Adversaries
- Fix Focal Reach not properly adding to weapon range
- Fix Hide erroneously performing an embedded document deletion during `preActivateAction` rather than recording an `effect` event which deletes the effect in question
- Fix Piercing Bolts clobbering any vulnerability 