### PR TITLE
Miscellaneous cleanup for proficiencies branch

### DIFF
--- a/module/applications/sheets/item-tool-sheet.mjs
+++ b/module/applications/sheets/item-tool-sheet.mjs
@@ -33,7 +33,7 @@ export default class CrucibleToolItemSheet extends CrucibleBaseItemSheet {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     context.skillOptions = Object.values(SYSTEM.SKILLS).map(({id: value, label, group}) => {
-      return {value, label, group: _loc(SYSTEM.PROFICIENCY.GROUPS[group].label)};
+      return {value, label, group: SYSTEM.PROFICIENCY.GROUPS[group].label};
     });
     return context;
   }

--- a/module/canvas/tree/talent-hud.mjs
+++ b/module/canvas/tree/talent-hud.mjs
@@ -133,7 +133,7 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
       actions: await talent.prepareActionsContext(),
       prerequisites: reqs,
       training: training
-        ? _loc("TALENT.TrainingGrant", {training: _loc(SYSTEM.PROFICIENCIES[training].label)})
+        ? _loc("TALENT.TrainingGrant", {training: SYSTEM.PROFICIENCIES[training].label})
         : null
     };
   }

--- a/module/const/effects.mjs
+++ b/module/const/effects.mjs
@@ -401,14 +401,13 @@ export function shocked(actor, {ability="intellect", amount, turns=3}={}) {
 }
 
 /**
- * Generate a standardized hexed effect, applying the hexed status condition to the target.
- * Change keys are resolved against the Document, so the "system." prefix is required.
+ * Generate a standardized hexed effect.
  * @param {Actor} actor
  * @param {{turns?: number}} [options]
  * @returns {Partial<ActiveEffectData>}
  */
 export function hexed(actor, {turns=1}={}) {
-  let {name, img} = CONFIG.statusEffects.hexed.name;
+  let {name, img} = CONFIG.statusEffects.hexed;
   name = _loc(name);
   return {
     _id: getEffectId("Hexed"),
@@ -429,7 +428,7 @@ export function hexed(actor, {turns=1}={}) {
 /**
  * Generate a standardized staggered effect, applying the staggered status condition to the target.
  * @param {Actor} actor
- * @param {CrucibleDoTConfig} options
+ * @param {{turns?: number}} [options]
  * @returns {Partial<ActiveEffectData>}
  */
 export function staggered(actor, {turns=1}={}) {

--- a/module/const/proficiencies.mjs
+++ b/module/const/proficiencies.mjs
@@ -200,22 +200,54 @@ export const SKILLS = defineEnum({
  * @type {Readonly<Record<WeaponTrainingTypes, {id: string, label: string, icon: string, abilities: string[]}>>}
  **/
 export const WEAPONS = defineEnum({
-  talisman: {label: "TRAINING.LABELS.talisman", short: "TRAINING.LABELS.talismanShort",
-    icon: "icons/weapons/polearms/trident-fork-white.webp", abilities: ["presence"]},
-  heavy: {label: "TRAINING.LABELS.heavy", short: "TRAINING.LABELS.heavyShort",
-    icon: "icons/skills/melee/weapons-crossed-poleaxes-white.webp", abilities: ["strength"]},
-  light: {label: "TRAINING.LABELS.light", short: "TRAINING.LABELS.lightShort",
-    icon: "icons/weapons/swords/sword-simple-white.webp", abilities: ["dexterity"]},
-  mechanical: {label: "TRAINING.LABELS.mechanical", short: "TRAINING.LABELS.mechanicalShort",
-    icon: "icons/weapons/crossbows/crossbow-white.webp", abilities: ["dexterity"]},
-  natural: {label: "TRAINING.LABELS.natural", short: "TRAINING.LABELS.naturalShort",
-    icon: "systems/crucible/icons/proficiencies/natural-weapon.webp", abilities: ["strength", "dexterity"]},
-  projectile: {label: "TRAINING.LABELS.projectile", short: "TRAINING.LABELS.projectileShort",
-    icon: "icons/weapons/bows/shortbow-white.webp", abilities: ["strength", "dexterity"]},
-  shield: {label: "TRAINING.LABELS.shield", short: "TRAINING.LABELS.shieldShort",
-    icon: "icons/equipment/shield/buckler-wooden-boss-lightning.webp", abilities: ["strength", "dexterity"]},
-  unarmed: {label: "TRAINING.LABELS.unarmed", short: "TRAINING.LABELS.unarmedShort",
-    icon: "icons/skills/melee/unarmed-punch-fist-white.webp", abilities: ["strength", "dexterity"]}
+  talisman: {
+    label: "TRAINING.LABELS.talisman",
+    short: "TRAINING.LABELS.talismanShort",
+    icon: "icons/weapons/polearms/trident-fork-white.webp",
+    abilities: ["presence"]
+  },
+  heavy: {
+    label: "TRAINING.LABELS.heavy",
+    short: "TRAINING.LABELS.heavyShort",
+    icon: "icons/skills/melee/weapons-crossed-poleaxes-white.webp",
+    abilities: ["strength"]
+  },
+  light: {
+    label: "TRAINING.LABELS.light",
+    short: "TRAINING.LABELS.lightShort",
+    icon: "icons/weapons/swords/sword-simple-white.webp",
+    abilities: ["dexterity"]
+  },
+  mechanical: {
+    label: "TRAINING.LABELS.mechanical",
+    short: "TRAINING.LABELS.mechanicalShort",
+    icon: "icons/weapons/crossbows/crossbow-white.webp",
+    abilities: ["dexterity"]
+  },
+  natural: {
+    label: "TRAINING.LABELS.natural",
+    short: "TRAINING.LABELS.naturalShort",
+    icon: "systems/crucible/icons/proficiencies/natural-weapon.webp",
+    abilities: ["strength", "dexterity"]
+  },
+  projectile: {
+    label: "TRAINING.LABELS.projectile",
+    short: "TRAINING.LABELS.projectileShort",
+    icon: "icons/weapons/bows/shortbow-white.webp",
+    abilities: ["strength", "dexterity"]
+  },
+  shield: {
+    label: "TRAINING.LABELS.shield",
+    short: "TRAINING.LABELS.shieldShort",
+    icon: "icons/equipment/shield/buckler-wooden-boss-lightning.webp",
+    abilities: ["strength", "dexterity"]
+  },
+  unarmed: {
+    label: "TRAINING.LABELS.unarmed",
+    short: "TRAINING.LABELS.unarmedShort",
+    icon: "icons/skills/melee/unarmed-punch-fist-white.webp",
+    abilities: ["strength", "dexterity"]
+  }
 });
 
 /* -------------------------------------------- */
@@ -230,8 +262,12 @@ export const WEAPONS = defineEnum({
  *   abilities: string[]}>>}
  */
 export const EQUIPMENT = defineEnum({
-  armor: {label: "TRAINING.LABELS.armor", short: "TRAINING.LABELS.armorShort",
-    icon: "systems/crucible/icons/proficiencies/armor.webp", abilities: ["strength", "toughness"]}
+  armor: {
+    label: "TRAINING.LABELS.armor",
+    short: "TRAINING.LABELS.armorShort",
+    icon: "systems/crucible/icons/proficiencies/armor.webp",
+    abilities: ["strength", "toughness"]
+  }
 });
 
 /* -------------------------------------------- */
@@ -245,15 +281,24 @@ export const EQUIPMENT = defineEnum({
  * @type {Readonly<Record<string, {id: string, label: string, icon: string, abilities: string[]}>>}
  */
 export const SPELLCRAFT = {
-  physical: {id: "physical", label: "TRAINING.LABELS.physical", short: "TRAINING.LABELS.physicalShort",
+  physical: {id: "physical",
+    label: "TRAINING.LABELS.physical",
+    short: "TRAINING.LABELS.physicalShort",
     icon: "icons/magic/movement/pinwheel-turning-blue.webp",
-    abilities: ["wisdom", "presence"]},
-  elemental: {id: "elemental", label: "TRAINING.LABELS.elemental", short: "TRAINING.LABELS.elementalShort",
+    abilities: ["wisdom", "presence"]
+  },
+  elemental: {id: "elemental",
+    label: "TRAINING.LABELS.elemental",
+    short: "TRAINING.LABELS.elementalShort",
     icon: "icons/magic/symbols/elements-air-earth-fire-water.webp",
-    abilities: ["wisdom", "intellect"]},
-  spiritual: {id: "spiritual", label: "TRAINING.LABELS.spiritual", short: "TRAINING.LABELS.spiritualShort",
+    abilities: ["wisdom", "intellect"]
+  },
+  spiritual: {id: "spiritual",
+    label: "TRAINING.LABELS.spiritual",
+    short: "TRAINING.LABELS.spiritualShort",
     icon: "icons/magic/light/projectile-halo-teal.webp",
-    abilities: ["intellect", "presence"]}
+    abilities: ["intellect", "presence"]
+  }
 };
 
 /* -------------------------------------------- */

--- a/module/const/spellcraft.mjs
+++ b/module/const/spellcraft.mjs
@@ -158,7 +158,6 @@ export const RUNES = {
   }
 };
 
-
 /**
  * The Somatic Gestures which exist in the Crucible spellcraft system.
  * These config objects are instantiated as CrucibleSpellcraftGesture instances during system initialization.

--- a/module/const/talents.mjs
+++ b/module/const/talents.mjs
@@ -80,12 +80,7 @@ export const TALENT_ID_MIGRATIONS = {
   runetime00000000: "Compendium.crucible.talent.Item.runeIllusion0000",
   runevoid00000000: "Compendium.crucible.talent.Item.runeOblivion0000",
 
-  /*
-   * Weapon Trainings, renamed to the action each carries. Training ceased to be the point of these talents,
-   * so each is now named for what it actually does and contributes its training point as a side effect.
-   * Two of the ids they reclaim, lunge and shieldBash, were previously migrated away from and now point at
-   * themselves once more, so those entries are gone rather than inverted.
-   */
+  // Weapon Trainings
   heavystrike00000: "Compendium.crucible.talent.Item.heavyStrike00000",
   heavyWeaponTrain: "Compendium.crucible.talent.Item.heavyStrike00000",
   lightWeaponTrain: "Compendium.crucible.talent.Item.lunge00000000000",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2793,7 +2793,7 @@ export default class CrucibleActor extends Actor {
               morale: {value: 1}  // Clear broken
             }
           },
-          items: globalThis._del
+          items: _del
         }, {inplace: false, applyOperators: true});
         clone.updateSource(simulateData);
       } finally {

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -514,14 +514,14 @@ function enrichHazard([_match, terms, name]) {
   const listFormatter = game.i18n.getListFormatter({style: "short", type: "unit"});
   const hazardRank = _loc("HAZARD.Rank", {danger});
   const parenthetical = name ? [hazardRank] : [];
-  if ( tags.includes("severe") ) parenthetical.push(_loc(SYSTEM.ACTION.TAGS.severe.label));
+  if ( tags.includes("severe") ) parenthetical.push(SYSTEM.ACTION.TAGS.severe.label);
   let label = name || hazardRank;
   if ( parenthetical.length ) label = _loc("HAZARD.Parenthetical", {label, tags: listFormatter.format(parenthetical)});
 
   // Prepare tooltip
-  const defenseLabel = _loc(SYSTEM.DEFENSES[defenseType]?.label);
-  const resourceLabel = _loc(SYSTEM.RESOURCES[resource]?.label);
-  const damageLabel = _loc(SYSTEM.DAMAGE_TYPES[damageType]?.label) || "";
+  const defenseLabel = SYSTEM.DEFENSES[defenseType]?.label;
+  const resourceLabel = SYSTEM.RESOURCES[resource]?.label;
+  const damageLabel = SYSTEM.DAMAGE_TYPES[damageType]?.label || "";
   let tooltip = restoration
     ? _loc("HAZARD.TooltipRestoration", {rank: hazardRank, defense: defenseLabel, resource: resourceLabel})
     : _loc("HAZARD.TooltipDamage", {rank: hazardRank, defense: defenseLabel, damage: damageLabel, resource: resourceLabel});

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -1374,7 +1374,7 @@ HOOKS.hamstring = {
  * @returns {string[]}
  */
 function _concealmentEffectIds() {
-  return ["hide", "sneak"].map(id => SYSTEM.EFFECTS.getEffectId(id, {suffix: "0"}));
+  return ["hide", "sneak"].map(id => SYSTEM.EFFECTS.getEffectId(id));
 }
 
 /* -------------------------------------------- */

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -437,7 +437,7 @@ HOOKS.carefree00000000 = {
 
 HOOKS.chameleon0000000 = {
   prepareActions(_item, actions) {
-    if ( !this.effects.has(SYSTEM.EFFECTS.getEffectId("hide", {suffix: "0"})) ) return;
+    if ( !this.effects.has(SYSTEM.EFFECTS.getEffectId("hide")) ) return;
     actions.move?.tags.add("subtle");
   }
 };
@@ -935,7 +935,7 @@ HOOKS.hide000000000000 = {
     rollData.dc = target.skills.awareness.passive;
   },
   preActivateAction(_item, action) {
-    const effectId = SYSTEM.EFFECTS.getEffectId("hide", {suffix: "0"});
+    const effectId = SYSTEM.EFFECTS.getEffectId("hide");
     if ( !this.effects.has(effectId) || action.tags.has("subtle") ) return;
     // noinspection ES6MissingAwait
     this.deleteEmbeddedDocuments("ActiveEffect", [effectId]);
@@ -1253,7 +1253,6 @@ HOOKS.nosferatu0000000 = {
 /* -------------------------------------------- */
 
 HOOKS.orbitingAegis000 = {
-  // Action effects carry no explicit _id, so the id is derived: getEffectId("orbitingAegis", {suffix: "0"})
   _EFFECT_ID: "orbitingAegis000",
   prepareDefenses(_item, defenses) {
     if ( !this.effects.has(HOOKS.orbitingAegis000._EFFECT_ID) ) return;

--- a/module/models/actor-adversary.mjs
+++ b/module/models/actor-adversary.mjs
@@ -100,7 +100,7 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
 
   /**
    * The number of training points this Adversary allocates according to Archetype preference.
-   * The flat grant buys the parity a level 1 hero already has from background and starting choices, above which the
+   * The flat grant buys parity with a level 1 hero's points from background and starting choices, above which the
    * rate scales on effective threat so an Elite out-trains a Normal of the same level.
    * @type {number}
    */
@@ -251,8 +251,7 @@ export default class CrucibleAdversaryActor extends CrucibleBaseActor {
       natural.initial = Math.max(natural.initial, required);
     }
 
-    // Allocate the training budget by Archetype preference, breaking ties on aptitude.
-    // Ability values are pre-Effect here, so progression cannot drift with transient buffs.
+    // Allocate the training budget by Archetype preference, breaking ties on aptitude
     const budget = this.trainingBudget;
     const {trainingCap} = this.details.progression;
     const preferences = this.details.archetype?.training ?? {};

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -1028,7 +1028,7 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     const {equipment} = this.parent;
     const {abilities, defenses} = this;
 
-    // Armor and Dodge from equipped Armor.
+    // Armor and Dodge from equipped Armor
     const armorData = equipment.armor.system;
     const dodgeScaling = Math.max(armorData.dodge.scaling - this.training.armor.rank, 0);
     defenses.armor.base = armorData.armor.base;
@@ -1140,8 +1140,6 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     }
   }
 
-  /* -------------------------------------------- */
-  /*  Skill Preparation                           */
   /* -------------------------------------------- */
 
   /**

--- a/module/models/item-archetype.mjs
+++ b/module/models/item-archetype.mjs
@@ -106,7 +106,7 @@ export default class CrucibleArchetypeItem extends foundry.abstract.TypeDataMode
       }, {});
     }
 
-    /** @deprecated since 0.9.2 */
+    /** @deprecated since 0.10.3 */
     if ( source.skills ) {
       source.training ??= {};
       for ( const skillId of source.skills ) {

--- a/module/models/item-talent.mjs
+++ b/module/models/item-talent.mjs
@@ -329,7 +329,7 @@ export default class CrucibleTalentItem extends foundry.abstract.TypeDataModel {
       prerequisites: reqs,
       origin: this.isOrigin ? _loc("TALENT.NODES.Origin") : null,
       training: this.training
-        ? _loc("TALENT.TrainingGrant", {training: _loc(SYSTEM.PROFICIENCIES[this.training].label)})
+        ? _loc("TALENT.TrainingGrant", {training: SYSTEM.PROFICIENCIES[this.training].label})
         : null
     });
   }

--- a/module/models/item-weapon.mjs
+++ b/module/models/item-weapon.mjs
@@ -336,7 +336,7 @@ export default class CrucibleWeaponItem extends CruciblePhysicalItem {
   _getUntrainedTooltip(actor) {
     if ( this.properties.has("intuitive") ) return null;
     if ( actor.getSkillBonus(this.proficiencies) >= 0 ) return null;
-    const labels = this.proficiencies.map(t => _loc(SYSTEM.PROFICIENCY.WEAPONS[t].label));
+    const labels = this.proficiencies.map(t => SYSTEM.PROFICIENCY.WEAPONS[t].label);
     const training = game.i18n.getListFormatter({type: "disjunction"}).format(labels);
     return _loc("WEAPON.TAGS.UntrainedTooltip", {training});
   }


### PR DESCRIPTION
Changes:
- Removed a number of unnecessary `_loc`s (things being translated were prelocalized)
- Removed unnecessary jsdoc for Hexed
- Fixed acquisition of `name` and `img` for Hexed
- Used more accurate jsdoc for Staggered
- Expanded each entry in `proficiency.mjs` enums which did not fit entirely on one line such that each property is on its own line to improve readability
- Removed an unnecessary newline in `module/const/spellcraft.mjs`
- Removed unnecessarily verbose comment regarding weapon training talent migrations
- Changed `globalThis._del` to simply `_del`
- Removed a number of unnecessary `{suffix: "0"}` arguments when calling `getEffectId` - by default the return value is right-padded with `0`s to length 16, `suffix` is only necessary if you explicitly want whatever suffix is being provided to be the last `n` characters of the ID (where `n` is the length of `suffix`)
- Removed an unnecessary comment in Orbiting Aegis hook
- Enforced minor grammatical pedantry on `trainingBudget` getter's docstring
- Removed an unnecessary comment in `CrucibleAdversaryActor#_prepareTraining`
- Removed an out-of-place `.` from an inline comment in `CrucibleBaseActor##preparePhysicalDefenses`
- Removed "Skill Preparation" section label in `CrucibleBaseActor` in favor of the new "Training Preparation"
- Amended an incorrect deprecation tag in `CrucibleArchetypeItem.migrateData`