### PR TITLE
Other misc cleanup for proficiencies branch

### DIFF
--- a/module/const/spellcraft.mjs
+++ b/module/const/spellcraft.mjs
@@ -629,9 +629,9 @@ export const COMPOSED_SPELL_NAMES = {
  * Rebuilding mutates in place because Talent schema fields captured this object as their choices.
  */
 export function initializeComponents() {
-  for ( const [type, group] of [["rune", "SPELL.COMPONENTS.RunePl"], ["gesture", "SPELL.COMPONENTS.GesturePl"],
-    ["inflection", "SPELL.COMPONENTS.InflectionPl"]] ) {
-    for ( const [id, c] of Object.entries(COMPONENT_RECORDS[type]) ) COMPONENTS[id] = {id, label: c.name, group, type};
+  for ( const [type, records] of Object.entries(COMPONENT_RECORDS) ) {
+    const group = `SPELL.COMPONENTS.${type.capitalize()}Pl`;
+    for ( const [id, c] of Object.entries(records) ) COMPONENTS[id] = {id, label: c.name, group, type};
   }
 }
 initializeComponents();

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -453,16 +453,10 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Grant one training point for each proficiency a Background names.
-   * Ancestry is biology rather than upbringing and grants none; Archetype numbers are allocation weights, not points.
+   * Prepare training for all Actor subtypes.
    * @protected
    */
-  _prepareTraining() {
-    for ( const type of this.details.background?.training ?? [] ) {
-      const t = this.training[type];
-      if ( t ) t.initial += 1;
-    }
-  }
+  _prepareTraining() {}
 
   /* -------------------------------------------- */
 

--- a/module/models/actor-hero.mjs
+++ b/module/models/actor-hero.mjs
@@ -231,6 +231,19 @@ export default class CrucibleHeroActor extends CrucibleBaseActor {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  _prepareTraining() {
+    super._prepareTraining();
+
+    // Grant one training point for each proficiency a Background names
+    for ( const type of this.details.background?.training ?? [] ) {
+      const t = this.training[type];
+      if ( t ) t.initial += 1;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _prepareEquipment(items) {
     super._prepareEquipment(items);
     this._prepareCapacity(items);

--- a/styles/item.less
+++ b/styles/item.less
@@ -181,6 +181,7 @@
  * ------------------------------------------ */
 
 .crucible.archetype,
+.crucible.talent,
 .crucible.taxonomy {
   .abilities,
   .resistances,


### PR DESCRIPTION
Felt different enough in scope as to merit its own PR, while the previous misc changes one was almost entirely cleanliness, this one has a little bit of potential mechanical impact.
Changes:
- Rewrote `initializeComponents` to not require a hardcoded array
- Moved the Hero-only `_prepareTraining` logic into `CrucibleHeroActor#_prepareTraining`, leaving `CrucibleBaseActor#_prepareTraining` empty
- Have Talent sheets inherit the same styling as archetype & taxonomy sheets. As far as I can tell there shouldn't be any harmful overlap here, and this is the simplest way of getting proper styling for "Required Proficiencies" without duplicating a chunk of style code