### PR TITLE
Genericize `applyMoraleWave`, implement Swashbuckler

### DIFF
--- a/_source/talent/Swashbuckler_swashbuckler0000.yml
+++ b/_source/talent/Swashbuckler_swashbuckler0000.yml
@@ -5,12 +5,12 @@ system:
   description: >-
     <p>Your bravado inspires your allies and cowes your enemies. When you Dodge
     or Parry a Strike, the attacker loses Morale equal to your Presence
-    attribute. When you achieve a Critical Hit, all nearby allies who can see
-    you gain Morale equal to your Presence attribute.</p>
+    attribute. When you achieve a Critical Hit, all allies within 30 feet who
+    can see you gain Morale equal to your Presence attribute.</p>
   actions: []
   nodes:
-    - sig3.presence
     - sig3.dexterity
+    - sig3.presence
   rune: ''
   gesture: ''
   inflection: ''
@@ -23,11 +23,11 @@ flags:
   core: {}
 _stats:
   systemId: crucible
-  systemVersion: 0.9.0
-  coreVersion: '14.356'
+  systemVersion: 0.10.2
+  coreVersion: '14.367'
   createdTime: 1772307160150
-  modifiedTime: 1773514792620
-  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  modifiedTime: 1788896071443
+  lastModifiedBy: ZXJsFnFZuf21WDAk
   compendiumSource: Item.swashbuckler0000
   duplicateSource: null
   exportSource: null

--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -28,48 +28,58 @@ function applyRuneCritEffect(actor, action, runeId, effectFactory, {condition}={
 /* -------------------------------------------- */
 
 /**
- * Damage the Morale of enemies who witness a foe fall to this Action.
- * Resource deltas are only realized once `_resolveEventStream` has run, so this must be called from `finalizeAction`.
- * A witness is affected at most once however many foes fell, and the fallen never witness one another.
- * @param {CrucibleActor} actor                                       The Actor whose talent is reacting
- * @param {CrucibleAction} action                                     The Action which felled a foe
- * @param {object} options
- * @param {(target: CrucibleActor, deltas: Record<string, number>) => boolean} options.test  Did this target just fall?
- * @param {number} options.radius                                     Radius in feet around each fallen foe
- * @param {string} options.wallType                                   The wall restriction which obstructs the wave
- * @param {number} options.amount                                     Morale damage inflicted upon each witness
- * @param {string} options.label                                      Scrolling status text shown on each witness
+ * @typedef {(actor: CrucibleActor, deltas: Record<string, number>) => boolean} MoraleWaveTest
  */
-function applyMoraleWave(actor, action, {test, radius, wallType, amount, label}) {
+
+/**
+ * Damage or restore the Morale of enemies or allies who witness a specific outcome from an Action.
+ * Resource deltas are only realized once `_resolveEventStream` has run, so this must be called from `finalizeAction`.
+ * A witness is affected at most once for a given wave, though if the action results in multiple waves, they may
+ * potentially be affected by each. A wave source is never considered a witness to its wave, nor is the originator of
+ * the action.
+ * @param {CrucibleActor} actor                         The Actor whose talent is reacting
+ * @param {CrucibleAction} action                       The Action which prompts the wave
+ * @param {object} options
+ * @param {MoraleWaveTest} options.test                 Is this actor a wave source?
+ * @param {number} options.radius                       Radius in feet around each wave source
+ * @param {number} options.amount                       Morale damage/recovery applied to each witness
+ * @param {string} options.label                        Scrolling status text shown on each witness
+ * @param {string} [options.wallType]                   The wall restriction which obstructs the wave
+ * @param {"ally"|"enemy"|"all"} [options.disposition]  Which disposition (relative to action-taking token) to affect
+ * @param {boolean} [options.restoration]               Whether the morale change should be restoration
+ */
+function applyMoraleWave(actor, action, {
+  test, radius, amount, label, wallType="sight", disposition="enemy", restoration=false
+}) {
   if ( !action.token || !(amount > 0) ) return;
+  const delta = amount * (restoration ? 1 : -1);
 
   // Identify which targets this Action drove into the state, from the deltas it actually realized
-  const fallen = new Set();
-  for ( const [target, events] of action.eventsByTarget ) {
-    if ( target === actor ) continue;
+  const sources = new Set();
+  for ( const [target, events] of action.eventsByActor ) {
     const deltas = {};
     for ( const event of events.all ) {
       for ( const {resource, delta} of event.resources ) deltas[resource] = (deltas[resource] ?? 0) + delta;
     }
-    if ( test(target, deltas) ) fallen.add(target);
+    if ( test(target, deltas) ) sources.add(target);
   }
-  if ( !fallen.size ) return;
+  if ( !sources.size ) return;
 
-  // Spread the wave outward from each body, never striking the same witness twice
+  // Spread the wave outward from each source, never affecting the same witness twice
   const affected = new Set();
-  for ( const target of fallen ) {
-    const token = action.targets.get(target)?.token ?? target.getActiveTokens(true, true)[0]?.document;
+  for ( const target of sources ) {
+    const token = action.targets.get(target)?.token ?? target.getActiveTokens(true, true)[0];
     if ( !token ) continue;
     const witnesses = crucible.api.canvas.grid.getTokensInRange(token, radius, {
       wallType,
-      disposition: "enemy",
+      disposition,
       relativeTo: action.token,
-      exclude: t => (t.actor === actor) || fallen.has(t.actor) || affected.has(t.actor)
+      exclude: t => (t.actor === actor) || sources.has(t.actor) || affected.has(t.actor)
     });
     for ( const {token: witness} of witnesses ) {
       affected.add(witness.actor);
-      action.recordEvent({target: witness.actor, resources: [{resource: "morale", delta: -amount}],
-        statusText: [{text: label, fillColor: SYSTEM.RESOURCES.morale.color.high.css}]});
+      action.recordEvent({target: witness.actor, resources: [{resource: "morale", delta}],
+        statusText: [{text: label, fillColor: SYSTEM.RESOURCES.morale.color[restoration ? "heal" : "high"].css}]});
     }
   }
 }
@@ -359,6 +369,7 @@ HOOKS.brutalDisplay000 = {
   finalizeAction(item, action) {
     applyMoraleWave(this, action, {
       test: (target, deltas) => {
+        if ( !action.targets.has(target) ) return false;
         const {health, wounds} = target.system.resources;
         if ( target.system.isDead ) return false; // Already a corpse before this Action landed
         if ( wounds ) return (wounds.value + (deltas.wounds ?? 0)) >= wounds.max;
@@ -1536,6 +1547,7 @@ HOOKS.rout000000000000 = {
   finalizeAction(item, action) {
     applyMoraleWave(this, action, {
       test: (target, deltas) => {
+        if ( !action.targets.has(target) ) return false;
         const {morale, madness} = target.system.resources;
         const broke = (morale.value > 0) && ((morale.value + (deltas.morale ?? 0)) <= 0);
         const maddened = !!madness && (madness.value < madness.max)
@@ -1896,6 +1908,26 @@ HOOKS.swashbuckler0000 = {
       target: attacker,
       resources: [{resource: "morale", delta: -morale}],
       statusText: [{text: item.name, fillColor: SYSTEM.RESOURCES.morale.color.high.css}]
+    });
+  },
+  finalizeAction(item, action) {
+    let isCrit = false;
+    for ( const [target, events] of action.eventsByTarget ) {
+      if ( !events.isCriticalSuccess || (target === action.actor) ) continue;
+      isCrit = true;
+      break;
+    }
+    if ( !isCrit ) return;
+    applyMoraleWave(this, action, {
+      test: actor => {
+        return actor === action.actor;
+      },
+      radius: 30,
+      wallType: "sight",
+      amount: this.abilities.presence.value,
+      label: item.name,
+      disposition: "ally",
+      restoration: true
     });
   }
 };


### PR DESCRIPTION
Couple things here worth calling out:
- I decided "nearby allies" can be "within 30 feet" for Swashbuckler
- I decided that "achieve a Critical Hit" means any action-driven critical success targeting _not_ oneself. A Swashbuckler who crits with a spell, or a skill attack, will trigger the morale wave currently
- All 3 currently implemented morale wave talents are "X who can see Y" - we only check sight-blocking _walls_, not detection. Not sure if we'd want to roll that into `wallType` being "sight" or do something else, for now I've not addressed it
- Because we're now iterating over `eventsByActor` rather than `eventsByTarget` (necessary in order to accommodate the acting token being a source of the wave), disallowing downstream waves to occur as a result of side effects is something that must be handled in the `test` parameter. What I mean by that is that previously, Brutal Display could proc, damaging the morale of nearby enemies. If any of them became Broken, that would have no impact on Rout firing, because none of them were targets of the original action. Now, that may not be the case. I've added a check to both Brutal Display's and Rout's `test`s to continue excluding non-targets from consideration as a wave source, but this is something worth keeping in mind for future implementations
- Line 61 (now 71) of `talent.mjs` was a mostly-silent bug, but was accessing `document` on what was already a Token Document 