### PR TITLE
add ability tooltip to actor sheet, hero creation, talenttree

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -5,6 +5,14 @@
       "Resilience": "Widerstand",
       "Speed": "Geschwindigkeit"
     },
+    "TOOLTIPS": {
+      "Dexterity": "<h3 class=\"tooltip-title divider\">Geschicklichkeit</h3><p>Geschicklichkeit ist ein körperliches Attribut für Schnelligkeit, das Beweglichkeit und Präzision der Bewegung widerspiegelt. Geschicklichkeit beeinflusst die <strong>Initiative</strong> beim Handeln, die <strong>Ausweichen</strong>-Komponente der körperlichen Verteidigung, die <strong>Reflex</strong>-Verteidigung sowie den Einsatz von Waffen mit dem Merkmal <strong>Finesse</strong>.</p>",
+      "Intellect": "<h3 class=\"tooltip-title divider\">Intellekt</h3><p>Intellekt ist ein geistiges Attribut für Schnelligkeit, das die Geschwindigkeit des Denkens und die Entschlossenheit beim Handeln widerspiegelt. Intellekt beeinflusst die <strong>Initiative</strong> beim Handeln, die <strong>Reflex</strong>-Verteidigung und die Größe des <strong>Fokus</strong>-Pools.</p>",
+      "Presence": "<h3 class=\"tooltip-title divider\">Präsenz</h3><p>Präsenz ist ein geistiges Attribut für Widerstandsfähigkeit, das die Ausstrahlung, Entschlossenheit und das Selbstvertrauen eines Wesens beschreibt. Präsenz beeinflusst die <strong>Willenskraft</strong>-Verteidigung und die Größe des <strong>Fokus</strong>-Pools. Jeder Punkt Präsenz erhöht die Basis-<strong>Moral</strong> um 4.</p>",
+      "Strength": "<h3 class=\"tooltip-title divider\">Stärke</h3><p>Stärke ist ein körperliches Attribut für Kraft, das die körperliche Leistungsfähigkeit, Muskelkraft und Macht eines Wesens beschreibt. Stärke beeinflusst die <strong>Standhaftigkeit</strong>-Verteidigung, die Tragfähigkeit und den Einsatz von Waffen mit dem Merkmal <strong>Brutal</strong>. Jeder Punkt Stärke erhöht die Basis-<strong>Gesundheit</strong> um 2.</p>",
+      "Toughness": "<h3 class=\"tooltip-title divider\">Zähigkeit</h3><p>Zähigkeit ist ein körperliches Attribut für Widerstandsfähigkeit, das körperliche Robustheit und Ausdauer beschreibt. Zähigkeit beeinflusst die <strong>Standhaftigkeit</strong>-Verteidigung. Jeder Punkt Zähigkeit erhöht die Basis-<strong>Gesundheit</strong> um 4.</p>",
+      "Wisdom": "<h3 class=\"tooltip-title divider\">Weisheit</h3><p>Weisheit ist ein geistiges Attribut für Kraft, das die Überzeugungskraft, Wissenstiefe und Geduld eines Wesens beschreibt. Weisheit beeinflusst die <strong>Willenskraft</strong>-Verteidigung und die Größe des <strong>Fokus</strong>-Pools. Jeder Punkt Weisheit erhöht die Basis-<strong>Moral</strong> um 2.</p>"
+    },
     "Dexterity": "Geschicklichkeit",
     "DexterityAbbr": "GE",
     "Intellect": "Intelligenz",

--- a/lang/en.json
+++ b/lang/en.json
@@ -5,6 +5,14 @@
       "Resilience": "Resilience",
       "Speed": "Speed"
     },
+    "TOOLTIPS": {
+      "Dexterity": "<h3 class=\"tooltip-title divider\">Dexterity</h3><p>Dexterity is a physical quickness attribute that reflects agility and precision of movement. Dexterity affects <strong>Initiative</strong> in taking action, the <strong>Dodge</strong> component of Physical Defense, <strong>Reflex</strong> defense, and the use of weaponry with the <strong>Finesse</strong> trait.</p>",
+      "Intellect": "<h3 class=\"tooltip-title divider\">Intellect</h3><p>Intellect is a mental quickness attribute that reflects speed of thought and decisiveness of action. Intellect affects <strong>Initiative</strong> in taking action, the <strong>Reflex</strong> defense, and the size of <strong>Focus</strong> pool.</p>",
+      "Presence": "<h3 class=\"tooltip-title divider\">Presence</h3><p>Presence is a mental resilience attribute describing a creature's force of personality, resolve, and self-belief. Presence affects <strong>Willpower</strong> defense and the size of <strong>Focus</strong> pool. Each point of Presence increases base <strong>Morale</strong> by 4.</p>",
+      "Strength": "<h3 class=\"tooltip-title divider\">Strength</h3><p>Strength is a physical power attribute describing a creature's potency, brawn and might. Strength affects <strong>Fortitude</strong> defense, carrying <strong>Capacity</strong>, and the use of weaponry with the <strong>Brute</strong> trait. Each point of Strength increases base <strong>Health</strong> by 2.</p>",
+      "Toughness": "<h3 class=\"tooltip-title divider\">Toughness</h3><p>Toughness is a physical resilience attribute describing physical hardiness and tenacity. Toughness affects the <strong>Fortitude</strong> defense. Each point of Toughness increases base <strong>Health</strong> by 4.</p>",
+      "Wisdom": "<h3 class=\"tooltip-title divider\">Wisdom</h3><p>Wisdom is a mental power attribute describing a creature's force of conviction, depth of knowledge, and patience. Wisdom affects <strong>Willpower</strong> defense and size of <strong>Focus</strong> pool. Each point of Wisdom increases base <strong>Morale</strong> by 2.</p>"
+    },
     "Dexterity": "Dexterity",
     "DexterityAbbr": "Dex",
     "Intellect": "Intellect",

--- a/module/applications/sheets/hero-creation-sheet.mjs
+++ b/module/applications/sheets/hero-creation-sheet.mjs
@@ -635,6 +635,7 @@ export default class CrucibleHeroCreationSheet extends HandlebarsApplicationMixi
       abilities.push({
         id: abilityId,
         label: cfg.label,
+        tooltip: cfg.tooltip,
         group: cfg.groupInternal,
         order: cfg.sheetOrder,
         total: value,

--- a/module/canvas/tree/talent-hud.mjs
+++ b/module/canvas/tree/talent-hud.mjs
@@ -28,12 +28,15 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
     talent: {
       template: "systems/crucible/templates/hud/talent-tree-talent.hbs",
       templates: ["systems/crucible/templates/sheets/item/talent-summary.hbs"]
+    },
+    ability: {
+      template: "systems/crucible/templates/hud/talent-tree-ability.hbs"
     }
   };
 
   /**
-   * The target of the HUD, either a Node or a Talent
-   * @type {CrucibleTalentTreeNode|CrucibleTalentTreeTalent}
+   * The target of the HUD: a Node, a Talent, or an ability score text.
+   * @type {CrucibleTalentTreeNode|CrucibleTalentTreeTalent|foundry.canvas.containers.PreciseText}
    */
   target;
 
@@ -42,8 +45,18 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
   /** @override */
   _configureRenderParts(options) {
     const parts = foundry.utils.deepClone(this.constructor.PARTS);
-    if ( this.target instanceof CrucibleTalentTreeNode ) delete parts.talent;
-    else delete parts.node;
+    if ( this.target instanceof CrucibleTalentTreeNode ) {
+      delete parts.talent;
+      delete parts.ability;
+    }
+    else if ( this.target instanceof CrucibleTalentTreeTalent ) {
+      delete parts.node;
+      delete parts.ability;
+    }
+    else {
+      delete parts.node;
+      delete parts.talent;
+    }
     return parts;
   }
 
@@ -52,7 +65,8 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
   /** @inheritDoc */
   async _prepareContext(_options) {
     if ( this.target instanceof CrucibleTalentTreeNode ) return this.#getNodeContext();
-    else return this.#getTalentContext();
+    if ( this.target instanceof CrucibleTalentTreeTalent ) return this.#getTalentContext();
+    return this.#getAbilityContext();
   }
 
   /* -------------------------------------------- */
@@ -98,6 +112,21 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
       tags: reqTags
     });
     return {id: node.id, tagGroups};
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context data for an ability score.
+   * @returns {object}
+   */
+  #getAbilityContext() {
+    const cfg = SYSTEM.ABILITIES[this.target.abilityId];
+    const tooltipHTML = _loc(cfg.tooltip);
+    return {
+      label: cfg.label,
+      descriptionHTML: tooltipHTML.replace(/^<h3[\s\S]*?<\/h3>\s*/, "")
+    };
   }
 
   /* -------------------------------------------- */
@@ -175,7 +204,7 @@ export default class CrucibleTalentHUD extends HandlebarsApplicationMixin(Applic
 
   /**
    * Activate this HUD element, binding it to a target.
-   * @param {CrucibleTalentTreeNode|CrucibleTalentTreeTalent} target    The target for the HUD
+   * @param {CrucibleTalentTreeNode|CrucibleTalentTreeTalent|foundry.canvas.containers.PreciseText} target
    * @returns {Promise<*>}
    */
   async activate(target) {

--- a/module/canvas/tree/talent-tree.mjs
+++ b/module/canvas/tree/talent-tree.mjs
@@ -224,6 +224,8 @@ export default class CrucibleTalentTree extends PIXI.Container {
       const angle = 30 + (i * 60);
       const r = foundry.canvas.geometry.Ray.fromAngle(0, 0, Math.toRadians(angle), 220);
       text.position.set(r.B.x, r.B.y);
+      text.abilityId = abilityId;
+      text.hitArea = new PIXI.Circle(0, 0, 24);
       this.background.addChild(text);
       scores[abilityId] = text;
     }
@@ -590,6 +592,7 @@ export default class CrucibleTalentTree extends PIXI.Container {
     this.nodes.eventMode = "passive";       // Capture hover/click events on nodes
     this.background.backdrop.eventMode = "static"; // Capture drag events on the backdrop
     this.foreground.eventMode = "passive";  // Capture hover/click events on the wheel
+    this.#activateAbilityScoreTooltips();
 
     // Mouse Interaction Manager
     this.interactionManager = new foundry.canvas.interaction.MouseInteractionManager(this, this, {}, {
@@ -607,6 +610,44 @@ export default class CrucibleTalentTree extends PIXI.Container {
     window.addEventListener("resize", this.#onResize.bind(this));
     window.addEventListener("wheel", this.#onWheel.bind(this), {passive: false});
     this.#onResize();  // Set initial dimensions
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Activate pointer events on talent-tree ability score numbers.
+   */
+  #activateAbilityScoreTooltips() {
+    for ( const abilityId of CrucibleTalentTree.#SEXTANT_ABILITIES ) {
+      const text = this.abilities[abilityId];
+      text.removeAllListeners();
+      text.eventMode = "static";
+      text.cursor = "pointer";
+      text.on("pointerover", this.#onAbilityPointerOver.bind(this));
+      text.on("pointerout", this.#onAbilityPointerOut.bind(this));
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle pointer-over events on an ability score.
+   * @param {PIXI.FederatedEvent} event
+   */
+  #onAbilityPointerOver(event) {
+    if ( !this.rendering || (event.nativeEvent.target !== this.canvas) || this.hud.target?.isLocked ) return;
+    this.hud.activate(event.currentTarget);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle pointer-out events on an ability score.
+   * @param {PIXI.FederatedEvent} event
+   */
+  #onAbilityPointerOut(event) {
+    if ( !this.rendering || (event.nativeEvent.target !== this.canvas) || this.hud.target?.isLocked ) return;
+    this.hud.clear();
   }
 
   /* -------------------------------------------- */

--- a/module/const/attributes.mjs
+++ b/module/const/attributes.mjs
@@ -3,12 +3,12 @@ import {defineEnum} from "./enum.mjs";
 /**
  * The primary attributes which are called abilities.
  * @type {{
- *   strength: {id: string, label: string, abbreviation: string},
- *   toughness: {id: string, label: string, abbreviation: string},
- *   dexterity: {id: string, label: string, abbreviation: string},
- *   intellect: {id: string, label: string, abbreviation: string},
- *   presence: {id: string, label: string, abbreviation: string},
- *   wisdom: {id: string, label: string, abbreviation: string}
+ *   strength: {id: string, label: string, abbreviation: string, tooltip: string},
+ *   toughness: {id: string, label: string, abbreviation: string, tooltip: string},
+ *   dexterity: {id: string, label: string, abbreviation: string, tooltip: string},
+ *   intellect: {id: string, label: string, abbreviation: string, tooltip: string},
+ *   presence: {id: string, label: string, abbreviation: string, tooltip: string},
+ *   wisdom: {id: string, label: string, abbreviation: string, tooltip: string}
  * }}
  */
 export const ABILITIES = Object.freeze({
@@ -16,6 +16,7 @@ export const ABILITIES = Object.freeze({
     id: "wisdom",
     label: "ABILITIES.Wisdom",
     abbreviation: "ABILITIES.WisdomAbbr",
+    tooltip: "ABILITIES.TOOLTIPS.Wisdom",
     type: "mental",
     group: "ABILITIES.GROUPS.Power",
     groupInternal: "power",
@@ -27,6 +28,7 @@ export const ABILITIES = Object.freeze({
     id: "presence",
     label: "ABILITIES.Presence",
     abbreviation: "ABILITIES.PresenceAbbr",
+    tooltip: "ABILITIES.TOOLTIPS.Presence",
     type: "mental",
     group: "ABILITIES.GROUPS.Resilience",
     groupInternal: "resilience",
@@ -38,6 +40,7 @@ export const ABILITIES = Object.freeze({
     id: "intellect",
     label: "ABILITIES.Intellect",
     abbreviation: "ABILITIES.IntellectAbbr",
+    tooltip: "ABILITIES.TOOLTIPS.Intellect",
     type: "mental",
     group: "ABILITIES.GROUPS.Speed",
     groupInternal: "speed",
@@ -49,6 +52,7 @@ export const ABILITIES = Object.freeze({
     id: "strength",
     label: "ABILITIES.Strength",
     abbreviation: "ABILITIES.StrengthAbbr",
+    tooltip: "ABILITIES.TOOLTIPS.Strength",
     type: "physical",
     group: "ABILITIES.GROUPS.Power",
     groupInternal: "power",
@@ -60,6 +64,7 @@ export const ABILITIES = Object.freeze({
     id: "toughness",
     label: "ABILITIES.Toughness",
     abbreviation: "ABILITIES.ToughnessAbbr",
+    tooltip: "ABILITIES.TOOLTIPS.Toughness",
     type: "physical",
     group: "ABILITIES.GROUPS.Resilience",
     groupInternal: "resilience",
@@ -71,6 +76,7 @@ export const ABILITIES = Object.freeze({
     id: "dexterity",
     label: "ABILITIES.Dexterity",
     abbreviation: "ABILITIES.DexterityAbbr",
+    tooltip: "ABILITIES.TOOLTIPS.Dexterity",
     type: "physical",
     group: "ABILITIES.GROUPS.Speed",
     groupInternal: "speed",

--- a/templates/hud/talent-tree-ability.hbs
+++ b/templates/hud/talent-tree-ability.hbs
@@ -1,0 +1,10 @@
+<div class="line-item">
+    <header class="flexrow">
+        <div class="title">
+            <h2>{{label}}</h2>
+        </div>
+    </header>
+    {{#if descriptionHTML}}
+    <section class="description">{{{descriptionHTML}}}</section>
+    {{/if}}
+</div>

--- a/templates/sheets/actor/adversary-attributes.hbs
+++ b/templates/sheets/actor/adversary-attributes.hbs
@@ -95,8 +95,8 @@
         <h3>{{localize "ACTOR.SHEET.Abilities"}}</h3>
         {{#each abilityScores as |ability|}}
         <div class="ability {{ability.id}} {{ability.type}} flexcol" data-ability="{{ability.id}}">
-            <h4 class="label">{{ability.label}}</h4>
-            <span class="input score">{{ability.value}}</span>
+            <h4 class="label" data-tooltip="{{ability.tooltip}}" data-tooltip-class="crucible crucible-tooltip">{{ability.label}}</h4>
+            <span class="input score" data-tooltip="{{ability.tooltip}}" data-tooltip-class="crucible crucible-tooltip">{{ability.value}}</span>
         </div>
         {{/each}}
     </div>

--- a/templates/sheets/actor/hero-attributes.hbs
+++ b/templates/sheets/actor/hero-attributes.hbs
@@ -85,8 +85,8 @@
         <h3>{{localize "ACTOR.SHEET.Abilities"}}</h3>
         {{#each abilityScores as |ability|}}
         <div class="ability {{ability.id}} {{ability.type}} flexcol" data-ability="{{ability.id}}">
-            <h4 class="label">{{ability.label}}</h4>
-            <span class="input score">{{ability.value}}</span>
+            <h4 class="label" data-tooltip="{{ability.tooltip}}" data-tooltip-class="crucible crucible-tooltip">{{ability.label}}</h4>
+            <span class="input score" data-tooltip="{{ability.tooltip}}" data-tooltip-class="crucible crucible-tooltip">{{ability.value}}</span>
             {{#if ability.canDecrease}}
             <a class="button icon fa-solid fa-caret-down decrease" data-action="abilityDecrease"
                aria-label="{{localize "ACTOR.ACTIONS.DecreaseAbilitySpecific" ability=ability.label}}" data-tooltip data-tooltip-direction="LEFT"></a>

--- a/templates/sheets/creation/background.hbs
+++ b/templates/sheets/creation/background.hbs
@@ -48,8 +48,8 @@
         <p id="ability-points"><span class="points">{{abilities.points.pool}}</span> {{localize "TALENT.LABELS.Points.other"}}</p>
         {{#each abilities.abilities as |ability|}}
         <div class="ability flexrow" data-ability="{{ability.id}}">
-            <h4>{{ability.label}}</h4>
-            <span class="score hex {{ability.group}}">{{ability.total}}</span>
+            <h4 data-tooltip="{{ability.tooltip}}" data-tooltip-class="crucible crucible-tooltip">{{ability.label}}</h4>
+            <span class="score hex {{ability.group}}" data-tooltip="{{ability.tooltip}}" data-tooltip-class="crucible crucible-tooltip">{{ability.total}}</span>
             <span class="increases">{{ability.increases}}</span>
             <div class="buttons flexcol">
                 <button type="button" class="plain icon fa-solid fa-caret-up" data-action="abilityIncrease"


### PR DESCRIPTION
Fixes #1462

Adds tooltip for abilities to:

* actor sheet
* hero creation
* talenttree

tooltip is taken from game journal

<img width="843" height="521" alt="grafik" src="https://github.com/user-attachments/assets/de9ae03b-64d6-47af-ab3b-801e8800344f" />

<img width="480" height="490" alt="grafik" src="https://github.com/user-attachments/assets/e10bf152-aed0-4de7-8663-3de28ca70855" />

<img width="593" height="589" alt="grafik" src="https://github.com/user-attachments/assets/104cdfc1-1c04-43c3-bcf6-e8a4c0bd058c" />
