### PR TITLE
enhance requestRoll actors to toggle between online party members (default) and all party members in roll request

### DIFF
--- a/module/dice/hazard-dialog.mjs
+++ b/module/dice/hazard-dialog.mjs
@@ -272,18 +272,15 @@ export default class HazardDialog extends ActionUseDialog {
   /* -------------------------------------------- */
 
   /**
-   * Add the configured party members to the targets list.
+   * Toggle party members in the targets list, online-first.
    * @this {HazardDialog}
    * @param {Event} _event
    */
   static async #onTargetsParty(_event) {
-    const members = crucible.party?.system.actors;
-    if ( !members?.size ) {
-      ui.notifications.warn(_loc("WARNING.NoParty"));
-      return;
-    }
+    const party = crucible.api.models.CrucibleGroupActor.getParty();
+    if ( !party ) return;
     const current = new Set(this.action.usage.forcedTargets ?? []);
-    for ( const a of members ) current.add(a);
+    party.toggleOnlineActors(current);
     this.action.usage.forcedTargets = Array.from(current);
     this.action.acquireTargets({strict: false});
     await this.render({window: {title: this.title}});
@@ -343,6 +340,6 @@ export default class HazardDialog extends ActionUseDialog {
     const expand = crucible.api.documents.CrucibleActor.expandGroups;
     if ( game.user.targets?.size ) return expand(Array.from(game.user.targets).map(t => t.actor));
     if ( canvas.ready && canvas.tokens.controlled.length ) return expand(canvas.tokens.controlled.map(t => t.actor));
-    return crucible.party?.system.members.map(m => m.actor).filter(Boolean) ?? [];
+    return crucible.party?.system?.getPreferredActors() ?? [];
   }
 }

--- a/module/dice/standard-check-dialog.mjs
+++ b/module/dice/standard-check-dialog.mjs
@@ -565,18 +565,18 @@ export default class StandardCheckDialog extends DialogV2 {
   /* -------------------------------------------- */
 
   /**
-   * Handle clicks to add party to requested actors
+   * Toggle the request tray between online party members and the full party.
+   * Online-first: an incomplete tray fills with connected players; a second click expands to everyone;
+   * a further click collapses back to online only. If nobody is online the tray is filled with everyone.
+   * Non-party actors already in the tray are left untouched.
    * @this StandardCheckDialog
    * @param {PointerEvent} _event
    * @returns {Promise<void>}
    */
   static async #onRequestParty(_event) {
-    const members = crucible.party?.system.actors;
-    if ( !members?.size ) {
-      ui.notifications.warn(_loc("WARNING.NoParty"));
-      return;
-    }
-    for ( const m of members ) this.#requestActors.add(m);
+    const party = crucible.api.models.CrucibleGroupActor.getParty();
+    if ( !party ) return;
+    party.toggleOnlineActors(this.#requestActors);
     await this.render({window: {title: this.title}});
   }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -614,16 +614,27 @@ export default class CrucibleActor extends Actor {
   /* -------------------------------------------- */
 
   /**
+   * Find a connected player who can roll for this actor, preferring an assigned character match then any
+   * non-GM owner. Unlike {@link CrucibleActor#getDesignatedUser}, this does not fall back to the GM.
+   * @returns {User|null}    The active player, or null if none is connected
+   */
+  getActivePlayerUser() {
+    const assigned = game.users.find(user => user.active && (user.character === this));
+    return assigned ?? game.users.getDesignatedUser(user => {
+      if ( !user.active || user.isGM ) return false;
+      return this.testUserPermission(user, "OWNER");
+    }) ?? null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Find the best active user to roll on this actor's behalf, preferring an assigned character match then any
    * owner, falling back to the active GM.
    * @returns {User|null}    The designated user, or null if none is found
    */
   getDesignatedUser() {
-    const assigned = game.users.find(user => user.active && (user.character === this));
-    return assigned ?? game.users.getDesignatedUser(user => {
-      if ( !user.active || user.isGM ) return false;
-      return this.testUserPermission(user, "OWNER");
-    }) ?? game.users.activeGM;
+    return this.getActivePlayerUser() ?? game.users.activeGM;
   }
 
   /* -------------------------------------------- */

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -488,10 +488,13 @@ function renderMilestone(element) {
  */
 async function onClickMilestone(event) {
   event.preventDefault();
-  if ( !crucible.party ) return ui.notifications.warn(_loc("WARNING.NoParty"));
+  if ( !game.user.isGM ) return ui.notifications.warn(_loc("AWARD.WARNINGS.RequiresGM"));
+
+  const party = crucible.api.models.CrucibleGroupActor.getParty();
+  if ( !party ) return;
 
   const quantity = event.currentTarget.dataset.quantity;
-  await crucible.party.system.awardMilestoneDialog(quantity);
+  await party.awardMilestoneDialog(quantity);
 }
 
 /* -------------------------------------------- */
@@ -816,27 +819,13 @@ function onClickGroupCheck(event) {
   if ( !game.user.isGM ) return ui.notifications.warn(_loc("DICE.GROUP_CHECK.RequiresGM"));
   let requestedActors = inferEnricherActors();
   if ( !requestedActors.length ) {
-    requestedActors = getPartyActors();
-    if ( !requestedActors ) return;
+    const party = crucible.api.models.CrucibleGroupActor.getParty();
+    if ( !party ) return;
+    requestedActors = Array.from(party.actors);
   }
   const {check} = prepareSkillCheck(event);
   const dialogOptions = {request: true, requestedActors};
   return check.dialog(dialogOptions);
-}
-
-/* -------------------------------------------- */
-
-/**
- * Get party actors as an array for request-based group checks.
- * @returns {CrucibleActor[]|null}
- */
-function getPartyActors() {
-  const members = crucible.party?.system.actors;
-  if ( !members?.size ) {
-    ui.notifications.warn(_loc("WARNING.NoParty"));
-    return null;
-  }
-  return Array.from(members);
 }
 
 /* -------------------------------------------- */

--- a/module/models/actor-group.mjs
+++ b/module/models/actor-group.mjs
@@ -137,6 +137,61 @@ export default class CrucibleGroupActor extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------- */
 
   /**
+   * The configured primary party, or `null` after warning if none is set or it has no members.
+   * @returns {CrucibleGroupActor|null}
+   */
+  static getParty() {
+    const party = crucible.party?.system;
+    if ( party?.actors?.size ) return party;
+    ui.notifications.warn(_loc("WARNING.NoParty"));
+    return null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Members of this group whose player is currently connected.
+   * @returns {CrucibleActor[]}
+   */
+  getOnlineActors() {
+    const online = [];
+    for ( const actor of this.actors ) {
+      if ( actor.getActivePlayerUser() ) online.push(actor);
+    }
+    return online;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Members for an initial party fill: connected players, or everyone if nobody is online.
+   * @returns {CrucibleActor[]}
+   */
+  getPreferredActors() {
+    const online = this.getOnlineActors();
+    return online.length ? online : Array.from(this.actors);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Replace this group's members in `selected` with the next online-first fill.
+   * Incomplete → preferred; preferred complete → everyone; everyone → preferred.
+   * Unrelated actors are left in place.
+   * @param {Set<CrucibleActor>} selected
+   */
+  toggleOnlineActors(selected) {
+    const has = actors => actors.length > 0 && actors.every(actor => selected.has(actor));
+    const preferred = this.getPreferredActors();
+    const all = Array.from(this.actors);
+    const keep = has(preferred) && !has(all) ? all : preferred;
+    for ( const actor of this.actors ) selected.delete(actor);
+    for ( const actor of keep ) selected.add(actor);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Add a new member to this group.
    * If the new member is a single Actor (hero or adversary), the group gains `quantity` that Actor.
    * If the new member is a group, this group is merged with the membership of the other group.


### PR DESCRIPTION
Fixes #1467

Also refactors the party retrieval into a static method getParty which inclludes the "party has no members" warning and thus reducing code duplication

Adds everyone to a roll if nobody is active mainly for debugging or testing issues for gm and dev