### PR TITLE
add tooltip for defense section on actor sheet

### DIFF
--- a/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
+++ b/_source/rules/Combat_QhZgmBrdLAGwYy5c.yml
@@ -763,8 +763,9 @@ pages:
         Combatants that you can simultaneously battle against without becoming
         more vulnerable. The base Engagement for <strong>Hero</strong>
         characters is <strong>1</strong>, while the base Engagement for
-        <strong>Adversary</strong> characters is equal to their <strong>Size -
-        2</strong> with a minimum of <strong>1</strong>.</p><p>When a character
+        <strong>Adversary</strong> characters starts at <strong>1</strong> and
+        adds <strong>+1 for every 2 Size above 4</strong>, rounded
+        up.</p><p>When a character
         is adjacent to multiple enemies where the number of engaged enemies
         equals or exceeds their Engagement score, that character is said to be
         <strong>Fully Engaged</strong>. Some conditions or action prerequisites

--- a/lang/de.json
+++ b/lang/de.json
@@ -637,9 +637,10 @@
       "movement": {
         "engagement": {
           "base": "Basisbindung",
+          "hint": "Anzahl gebundener Feinde",
           "label": "Bindung",
           "labelShort": "Bind.",
-          "tooltip": "Anzahl gebundener Feinde<br>(Größe - 2) + Bindungsbonus"
+          "tooltip": "Bindung beschreibt, gegen wie viele gegnerische Kämpfer du gleichzeitig vorgehen kannst, ohne verwundbarer zu werden. Helden haben eine Basis von 1. Widersacher starten bei 1 und erhalten +1 für je 2 Größe über 4, aufgerundet.<br>Basisbindung + Bindungsbonus"
         },
         "engagementBonus": {
           "hint": "Ein additiver Modifikator auf die Basisbindung.",
@@ -656,8 +657,9 @@
         },
         "stride": {
           "base": "Basis-Bewegungsrate",
+          "hint": "Bewegungsdistanz pro ausgegebenem Aktionspunkt.",
           "label": "Bewegungsrate",
-          "tooltip": "Bewegungsdistanz pro ausgegebenem Aktionspunkt."
+          "tooltip": "Bewegungsaktionen erlauben dir, dich um eine Distanz bis zu deiner Bewegungsrate in Fuß zu bewegen. Diese Bewegung kann nicht unterbrochen werden, und restliche Distanz wird nicht über Aktionen hinweg gespeichert, wenn du weniger als deine Bewegungsrate zurücklegst.<br>Abstammungs-/Taxonomie-Basisbewegungsrate + Bewegungsbonus"
         },
         "strideBonus": {
           "hint": "Ein additiver Modifikator auf die Bewegungsrate der Figur, definiert durch Abstammung oder Taxonomie.",
@@ -1334,11 +1336,16 @@
   },
   "DEFENSES": {
     "TOOLTIPS": {
-      "Fortitude": "{base} + ((Stärke + Weisheit) / 4)",
-      "Madness": "{base} + (Wahnsinn / 10)",
-      "Reflex": "{base} + ((Geschicklichkeit + Intelligenz) / 4)",
-      "Willpower": "{base} + ((Zähigkeit + Präsenz) / 4)",
-      "Wounds": "{base} + (Wunden / 10)"
+      "Armor": "Schutz durch getragene Ausrüstung oder natürliche Eigenschaften wie Schuppen oder Chitin. Treffer, die nicht ausgewichen, pariert oder geblockt werden, werden bei einem Streiftreffer zu einem Treffer mit reduziertem Schaden oder bei einem kritischen Fehlschlag vollständig absorbiert.<br>Rüstungsbasis + Qualitätsbonus",
+      "Block": "Schutz durch Abwehr eines Angriffs mit einem ausgerüsteten Schild oder einer blockenden Waffe. Blockierte Angriffe verursachen keinen Schaden und ermöglichen Reaktionen auf Basis von Block.<br>Summe des Blocks aller ausgerüsteten Waffen",
+      "Dodge": "Schutz durch körperliche Schnelligkeit und Gewandtheit. Ausgewichene Angriffe verursachen keinen Schaden und ermöglichen Reaktionen auf Basis von Ausweichen.<br>Rüstungs-Basisausweichen + max(Geschicklichkeit - Skalierung, 0) + Verzauberung",
+      "Fortitude": "Standhaftigkeit beschreibt die Fähigkeit eines Charakters, körperlichen Schaden auszuhalten. Sie wird durch Stärke und Weisheit modifiziert, die für körperliche Widerstandskraft bzw. mentale Belastbarkeit stehen.<br>{base} + ((Stärke + Weisheit) / 4)",
+      "Madness": "Die Mobilisierungsschwelle beschreibt, wie schwierig es ist, die Moral einer Kreatur wiederherzustellen. Je stärker eine Kreatur psychisch belastet ist, desto schwieriger lässt sie sich wieder aufrichten.<br>{base} + (Wahnsinn / 10)",
+      "Parry": "Schutz durch Abwehr eines Angriffs mit einer ausgerüsteten Waffe. Parierte Angriffe verursachen keinen Schaden und ermöglichen Reaktionen auf Basis von Parade.<br>Summe der Parade aller ausgerüsteten Waffen",
+      "Physical": "Physische Verteidigung beschreibt, wie schwierig es ist, eine Kreatur mit physischen Angriffen zu treffen, typischerweise mit Nahkampf- oder Fernkampfwaffen.<br>Rüstung + Ausweichen + Parieren + Block",
+      "Reflex": "Reflexverteidigung beschreibt die Fähigkeit eines Charakters, Schaden zu vermeiden, der andernfalls einen bestimmten Bereich betreffen würde. Sie wird durch Geschicklichkeit und Intellekt modifiziert, die für körperliche Schnelligkeit bzw. die Geschwindigkeit des Denkens stehen.<br>{base} + ((Geschicklichkeit + Intellekt) / 4)",
+      "Willpower": "Die Willenskraft beschreibt die Fähigkeit, mentalen oder emotionalen Angriffen standzuhalten. Sie wird durch Zähigkeit und Präsenz modifiziert, die körperliche Hartnäckigkeit und geistige Entschlossenheit darstellen.<br>{base} + ((Zähigkeit + Präsenz) / 4)",
+      "Wounds": "Die Heilungsschwelle beschreibt, wie schwierig es ist, die Gesundheit einer Kreatur wiederherzustellen. Je schwerer verwundet eine Kreatur ist, desto schwieriger wird sie zu heilen.<br>{base} + (Wunden / 10)"
     },
     "Armor": "Rüstung",
     "Block": "Block",

--- a/lang/en.json
+++ b/lang/en.json
@@ -759,9 +759,10 @@
       "movement": {
         "engagement": {
           "base": "Base Engagement",
+          "hint": "Number of Enemies able to be Engaged",
           "label": "Engagement",
           "labelShort": "Engage",
-          "tooltip": "Number of Enemies able to be Engaged<br>(Size - 2) + Engagement Bonus"
+          "tooltip": "Engagement describes the total number of opposing Combatants that you can simultaneously battle against without becoming more vulnerable. Heroes have a base of 1. Adversaries start at 1 and add +1 for every 2 Size above 4, rounded up.<br>Base Engagement + Engagement Bonus"
         },
         "engagementBonus": {
           "hint": "An additive modifier to base engagement.",
@@ -778,8 +779,9 @@
         },
         "stride": {
           "base": "Base Stride",
+          "hint": "Movement distance per spent Action Point.",
           "label": "Stride",
-          "tooltip": "Movement distance per spent Action Point."
+          "tooltip": "Movement actions allow you to move a number of feet up to your Stride. This movement cannot be broken up, and leftover distance is not saved across actions if you move less than your Stride.<br>Ancestry/Taxonomy Base Stride + Stride Bonus"
         },
         "strideBonus": {
           "hint": "An additive modifier to Stride speed of the Actor defined by Ancestry or Taxonomy.",
@@ -1526,11 +1528,16 @@
   },
   "DEFENSES": {
     "TOOLTIPS": {
-      "Fortitude": "{base} + ((Strength + Wisdom) / 4)",
-      "Madness": "{base} + (Madness / 10)",
-      "Reflex": "{base} + ((Dexterity + Intellect) / 4)",
-      "Willpower": "{base} + ((Toughness + Presence) / 4)",
-      "Wounds": "{base} + (Wounds / 10)"
+      "Armor": "Protection offered by worn equipment or organic attributes like scales or chitin. Misses that are not Dodged, Parried, or Blocked become a Glance (reduced damage) or are fully absorbed on a Critical Failure.<br>Armor Base + Quality Bonus",
+      "Block": "Protection offered by guarding against an attack using an equipped shield or blocking weapon. Blocked attacks deal no damage and provide opportunity for block-based reactions.<br>Sum of equipped weapon Block",
+      "Dodge": "Protection offered by physical quickness and agility. Dodged attacks deal no damage and provide opportunity for dodge-based reactions.<br>Armor Base Dodge + max(Dexterity - Scaling, 0) + Enchantment",
+      "Fortitude": "Fortitude Defense describes a character's ability to withstand bodily harm. It is modified by Strength and Wisdom, representing physical resistance and mental resilience respectively.<br>{base} + ((Strength + Wisdom) / 4)",
+      "Madness": "Rallying Threshold describes how difficult it is to restore the Morale of a creature. As creatures become more psychologically damaged they become more difficult to rally.<br>{base} + (Madness / 10)",
+      "Parry": "Protection offered by guarding against an attack using an equipped weapon. Parried attacks deal no damage and provide opportunity for parry-based reactions.<br>Sum of equipped weapon Parry",
+      "Physical": "Physical Defense describes how difficult the creature is to hit with physical attacks, typically melee or ranged weapon strikes.<br>Armor + Dodge + Parry + Block",
+      "Reflex": "Reflex Defense describes a character's ability to avoid harm that would otherwise occur in a specific area. It is modified by Dexterity and Intellect, representing quickness of body and rapidity of thought respectively.<br>{base} + ((Dexterity + Intellect) / 4)",
+      "Willpower": "Willpower Defense describes a character's ability to withstand mental or emotional attacks. It is modified by Toughness and Presence, representing physical grit and mental determination respectively.<br>{base} + ((Toughness + Presence) / 4)",
+      "Wounds": "Healing Threshold describes how difficult it is to restore the Health of a creature. As creatures become more severely wounded, they grow more difficult to heal.<br>{base} + (Wounds / 10)"
     },
     "Armor": "Armor",
     "Block": "Block",

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -271,11 +271,13 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       physical: {
         value: data.physical.total,
         label: SYSTEM.DEFENSES.physical.label,
+        tooltip: SYSTEM.DEFENSES.physical.tooltip,
         subtitle: this.actor.equipment.armor.name,
         components: {
           armor: {
             value: data.armor.total,
             label: SYSTEM.DEFENSES.armor.label,
+            tooltip: SYSTEM.DEFENSES.armor.tooltip,
             pct: Math.round(data.armor.total * 100 / safeTotal),
             cssClass: data.armor.total > 0 ? "active" : "inactive",
             separator: "="
@@ -283,6 +285,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
           dodge: {
             value: data.dodge.total,
             label: SYSTEM.DEFENSES.dodge.label,
+            tooltip: SYSTEM.DEFENSES.dodge.tooltip,
             pct: Math.round(data.dodge.total * 100 / safeTotal),
             cssClass: data.dodge.total > 0 ? "active" : "inactive",
             separator: "+"
@@ -290,6 +293,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
           parry: {
             value: data.parry.total,
             label: SYSTEM.DEFENSES.parry.label,
+            tooltip: SYSTEM.DEFENSES.parry.tooltip,
             pct: Math.round(data.parry.total * 100 / safeTotal),
             cssClass: data.parry.total > 0 ? "active" : "inactive",
             separator: "+"
@@ -297,6 +301,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
           block: {
             value: data.block.total,
             label: SYSTEM.DEFENSES.block.label,
+            tooltip: SYSTEM.DEFENSES.block.tooltip,
             pct: Math.round(data.block.total * 100 / safeTotal),
             cssClass: data.block.total > 0 ? "active" : "inactive",
             separator: "+"
@@ -315,7 +320,6 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
         const sign = d.bonus > 0 ? "+" : "-";
         d.tooltip += ` ${sign} ${Math.abs(d.bonus)}`;
       }
-      if ( ["wounds", "madness"].includes(id) ) d.tooltip = `${d.label}<br>${d.tooltip}`;
       defenses[id] = d;
     }
     return defenses;
@@ -1128,7 +1132,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       minValue: 0,
       editLabel: "ACTOR.ACTIONS.EditEngagement",
       baseLabel: "ACTOR.FIELDS.movement.engagement.base",
-      baseHint: _loc("ACTOR.FIELDS.movement.engagement.tooltip").split("<br>")[0]
+      baseHint: "ACTOR.FIELDS.movement.engagement.hint"
     });
   }
 
@@ -1164,7 +1168,7 @@ export default class CrucibleBaseActorSheet extends api.HandlebarsApplicationMix
       minValue: 0,
       editLabel: "ACTOR.ACTIONS.EditMovement",
       baseLabel: "ACTOR.FIELDS.movement.stride.base",
-      baseHint: "ACTOR.FIELDS.movement.stride.tooltip"
+      baseHint: "ACTOR.FIELDS.movement.stride.hint"
     });
   }
 

--- a/module/const/attributes.mjs
+++ b/module/const/attributes.mjs
@@ -269,26 +269,31 @@ export const DEFENSES = {
   physical: {
     id: "physical",
     label: "DEFENSES.Physical",
+    tooltip: "DEFENSES.TOOLTIPS.Physical",
     type: "physical"
   },
   armor: {
     id: "armor",
     label: "DEFENSES.Armor",
+    tooltip: "DEFENSES.TOOLTIPS.Armor",
     type: "physical"
   },
   block: {
     id: "block",
     label: "DEFENSES.Block",
+    tooltip: "DEFENSES.TOOLTIPS.Block",
     type: "physical"
   },
   dodge: {
     id: "dodge",
     label: "DEFENSES.Dodge",
+    tooltip: "DEFENSES.TOOLTIPS.Dodge",
     type: "physical"
   },
   parry: {
     id: "parry",
     label: "DEFENSES.Parry",
+    tooltip: "DEFENSES.TOOLTIPS.Parry",
     type: "physical"
   },
   fortitude: {

--- a/templates/sheets/actor/adversary-attributes.hbs
+++ b/templates/sheets/actor/adversary-attributes.hbs
@@ -105,13 +105,13 @@
         <h3>{{localize "ACTOR.SHEET.Defenses"}}</h3>
         <div class="physical flexrow">
             <div class="defense total">
-                <h4 class="label">{{defenses.physical.label}}</h4>
+                <h4 class="label" data-tooltip="{{defenses.physical.tooltip}}">{{defenses.physical.label}}</h4>
                 <span class="value">{{defenses.physical.value}}</span>
             </div>
             {{#each defenses.physical.components as |c id|}}
             <span class="sep">{{c.separator}}</span>
             <div class="defense component {{id}} {{c.cssClass}}">
-                <h4 class="label">{{c.label}}</h4>
+                <h4 class="label" data-tooltip="{{c.tooltip}}">{{c.label}}</h4>
                 <span class="value">{{c.value}}</span>
                 <span class="pct">{{c.pct}}%</span>
             </div>

--- a/templates/sheets/actor/hero-attributes.hbs
+++ b/templates/sheets/actor/hero-attributes.hbs
@@ -113,13 +113,13 @@
         <h3>{{localize "ACTOR.SHEET.Defenses"}}</h3>
         <div class="physical flexrow">
             <div class="defense total">
-                <h4 class="label">{{defenses.physical.label}}</h4>
+                <h4 class="label" data-tooltip="{{defenses.physical.tooltip}}">{{defenses.physical.label}}</h4>
                 <span class="value">{{defenses.physical.value}}</span>
             </div>
             {{#each defenses.physical.components as |c id|}}
             <span class="sep">{{c.separator}}</span>
             <div class="defense component {{id}} {{c.cssClass}}">
-                <h4 class="label">{{c.label}}</h4>
+                <h4 class="label" data-tooltip="{{c.tooltip}}">{{c.label}}</h4>
                 <span class="value">{{c.value}}</span>
                 <span class="pct">{{c.pct}}%</span>
             </div>


### PR DESCRIPTION
Fixes #1469

bonus: combat description for size engagement bonus seems to have been changed in the meantime and is now adopted

<img width="366" height="257" alt="grafik" src="https://github.com/user-attachments/assets/817db1be-96a7-4ba8-b08b-d5677bf63f20" />
