### PR TITLE
Enhance talent node refund logic to allow refunds for isolated empty …

### DIFF
--- a/module/canvas/tree/talent-tree-node.mjs
+++ b/module/canvas/tree/talent-tree-node.mjs
@@ -178,9 +178,7 @@ export default class CrucibleTalentTreeNode extends CrucibleTalentIcon {
     if ( this.node.id === "origin" ) return;
     const actor = game.system.tree.actor;
     const purchased = this.node.isPurchased(actor);
-
-    // Refunding an isolated empty node is always permitted so points may be recovered, but purchasing
-    // requires available Talent points, a purchased neighbor node, and met tier prerequisites
+    // Special case checks when purchasing an empty node
     if ( !purchased ) {
       if ( !actor.points.talent.available ) return;
       const {unlocked} = this.node.getState(actor);

--- a/module/canvas/tree/talent-tree-node.mjs
+++ b/module/canvas/tree/talent-tree-node.mjs
@@ -178,7 +178,15 @@ export default class CrucibleTalentTreeNode extends CrucibleTalentIcon {
     if ( this.node.id === "origin" ) return;
     const actor = game.system.tree.actor;
     const purchased = this.node.isPurchased(actor);
-    if ( !purchased && !actor.points.talent.available ) return;
+
+    // Refunding an isolated empty node is always permitted so points may be recovered, but purchasing
+    // requires available Talent points, a purchased neighbor node, and met tier prerequisites
+    if ( !purchased ) {
+      if ( !actor.points.talent.available ) return;
+      const {unlocked} = this.node.getState(actor);
+      if ( !unlocked || !this.node.isConnected(actor) ) return;
+    }
+
     const talents = new Set(actor.system.advancement.talentNodes);
     const msgKey = purchased ? "TALENT.ACTIONS.PurchaseNodeReverse" : "TALENT.ACTIONS.PurchaseNode";
     const confirm = await foundry.applications.api.DialogV2.confirm({


### PR DESCRIPTION
Closes #1455

Clicking any empty node on the Talent tree displayed the "Spend talent point to purchase empty
node" prompt regardless of where the node was or whether the Actor met the node's prerequisites.
Purchasing a *Talent* has always been gated by `CrucibleTalentItem#assertPrerequisites`, but
purchasing the *node itself* was only gated on available Talent points, so points could be sunk
into arbitrary isolated nodes on the far side of the tree.

Purchasing an empty node now requires the same standard as purchasing a Talent on it:

- The node is unlocked by neighbors: at least one adjacent node is purchased
  (`CrucibleTalentNode#isConnected`).
- The node's tier prerequisites are met: character level and ability scores
  (`CrucibleTalentNode#getState`).

Only things worth calling out:

- Refunding is intentionally left ungated — a previously purchased empty node which no longer
  borders purchased territory (say, after refunding a connecting node) can still be refunded so
  the spent point isn't stranded.
- No special case is needed for tier-0 nodes: they border the always-purchased origin, so
  `isConnected` passes for them, mirroring the `node.tier === 0` exemption in
  `assertPrerequisites`.
- As with the existing "no Talent points" case, clicking an unpurchasable empty node now does
  nothing silently rather than raising an error.

**Testing:** ran a macro which simulates empty-node clicks against four scenarios (table below)
before and after the change. Scenario A (legitimately purchasable) and D (refund) still prompt;
B and C no longer do. The macro is `test-empty-node-purchase.mjs` in the branch if wanted.

| Scenario | Node condition                            | Before        | After     |
| -------- | ----------------------------------------- | ------------- | --------- |
| A        | Neighbor purchased, prerequisites met     | dialog        | dialog    |
| B        | Neighbor purchased, prerequisites unmet   | dialog        | no dialog |
| C        | No purchased neighbors                    | dialog        | no dialog |
| D        | Refund of a stranded empty node           | dialog        | dialog    |

Before: 
<img width="756" height="414" alt="image" src="https://github.com/user-attachments/assets/4067a884-b869-47f2-9b5f-dd528aa65416" />
After: 
<img width="745" height="415" alt="image" src="https://github.com/user-attachments/assets/8008d3e4-0e3a-487c-8966-01a93ad71e0c" />



Better visual: 
Before: 
<img width="483" height="355" alt="image" src="https://github.com/user-attachments/assets/b4621899-5773-4663-89b3-e62af190344a" />
After:
<img width="628" height="318" alt="image" src="https://github.com/user-attachments/assets/e57da7f9-a9df-4ef7-b4e8-e5f9026d8dd0" />
