### PR TITLE
Ensure blood sense blindness offset obeys bloodedness of target

### DIFF
--- a/module/hooks/talent.mjs
+++ b/module/hooks/talent.mjs
@@ -288,7 +288,10 @@ HOOKS.bloodmagic000000 = {
 HOOKS.bloodSense000000 = {
   prepareAttack(_item, action, target, rollData) {
     if ( !["strike", "skill"].some(t => action.tags.has(t)) ) return;
-    if ( target.resources.health.value < target.resources.health.max ) delete rollData.banes.blind;
+    const targetToken = action.targets.get(target)?.token?.object;
+    if ( targetToken && action.token?.object?.canDetect(targetToken, {modes: ["bloodSense"]}) ) {
+      delete rollData.banes.blind;
+    }
   },
   prepareToken(_item, token) {
     token.detectionModes.bloodSense ??= {enabled: true, range: 20};


### PR DESCRIPTION
Forgot when implementing Blood Sense to amend the existing `prepareAttack` hook to actually _use_ the new detection mode rather than still relying just on health.