### PR TITLE
Ensure all Ancestry characteristics are carried through when generating Taxonomy

### DIFF
--- a/module/models/item-ancestry.mjs
+++ b/module/models/item-ancestry.mjs
@@ -123,7 +123,7 @@ export default class CrucibleAncestryItem extends foundry.abstract.TypeDataModel
       characteristics: {
         equipment: true,
         spells: true,
-        temperature: characteristics.temperature
+        ...characteristics
       },
       talents
     };


### PR DESCRIPTION
Forgot to add `blooded` to `CrucibleAncestryItem#toTaxonomy` when I added it to characteristics for both. Figure we'll _probably_ be having taxonomy characteristics as a superset of ancestry characteristics for the foreseeable future so just spreading `characteristics` should be safe. If not, can change it to explicitly pass each, shared characteristic, but that does raise the possibility for a future footgun just like this one.