### PR TITLE
[#1427] Keep dialog window content scrollable so submit buttons remai…

### DIFF
--- a/styles/applications.less
+++ b/styles/applications.less
@@ -50,6 +50,13 @@
     -webkit-backdrop-filter: none;
   }
 
+  // Browser zoom or a short viewport can clamp a dialog window to the available height, leaving the
+  // window content taller than the window and the footer with its submit buttons clipped offscreen.
+  // Keep dialog content scrollable so those buttons remain reachable.
+  &.dialog .window-content {
+    overflow: hidden auto;
+  }
+
   // Buttons
   button,
   .button,


### PR DESCRIPTION
…n reachable when browser zoom clamps the window height

Fixes #1427

## Problem

Browser zoom (or any short viewport) can make the action-use dialog unusable: the window is clamped to the available viewport height and its footer — containing the **Use** button — is painted off-screen with no way to scroll it back into view.

Reproduced on Foundry 14.367, Crucible 0.10.2: in a 1280×900 window at 150% browser zoom (an 853×600 CSS viewport), the Dawn Beacon dialog is clamped to 600px tall while its natural height is ~734px. The footer with the submit button sits at y 694–734 — entirely below the screen edge.

## Root cause

Foundry v14 ApplicationV2 windows carry the `application` class, not the V1 `window-app` class, so:

- Core clamps every app window to the available height (`.application { max-height: calc(100vh - 1.5 * var(--hotbar-height)) }`). Browser zoom shrinks the CSS viewport, and the dialog's natural content height exceeds what remains — so the window "fits" by being cut.
- The scrollable content rule (`.window-app .window-content { overflow: hidden auto }`) never matches an ApplicationV2 dialog. The effective rule is `.application .window-content { overflow: hidden }`, so the clamped overflow is simply clipped: no scrollbar exists and the footer cannot be reached.

## Fix

One declaration, scoped to Crucible's dialogs (all of which subclass `DialogV2` and carry the `crucible dialog` classes):

```less
// Browser zoom or a short viewport can clamp a dialog window to the available height, leaving the
// window content taller than the window and the footer with its submit buttons clipped offscreen.
// Keep dialog content scrollable so those buttons remain reachable.
&.dialog .window-content {
  overflow: hidden auto;
}
```

The content only scrolls when the window is actually clamped. At normal sizes there is no visual change — no scrollbar appears because the content fits.

## Testing

- [x] Reproduced pre-fix: at a 853×600 CSS viewport the action dialog's footer was fully offscreen (`overflowY: hidden`, unscrollable).
- [x] Post-fix at the same size: content scrolls (themed scrollbar visible), the Use button is fully visible after scrolling, and a real click submits the action end-to-end.
- [x] No regression at full viewport size: the dialog renders at its natural height, centered, no scrollbar, footer in its usual position.
- [x] Standard-check dialogs and spell-cast dialogs share the same classes and get the same protection.

## Screenshots

<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/0c67805c-75e7-4826-ba8f-2fa83b01fc80" />


### Direct comparison: 

Before: 
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/19ec6f59-b019-4afe-9b63-c4d719b02634" />


After: 
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/1dcb3be4-f491-4f6a-a79c-0728e75d00d6" />

