### PR TITLE
[#1403] Require a resolved natural weapon strike for Natural-tagged a…

### DIFF
--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -931,7 +931,7 @@ export const TAGS = {
     propagate: ["melee"],
     priority: 9,
     canUse() {
-      if ( !this.usage.strikes.every(w => w.system.properties.has("natural")) ) {
+      if ( !this.usage.strikes.length || !this.usage.strikes.every(w => w.system.properties.has("natural")) ) {
         throw new Error(_loc("ACTION.WARNINGS.RequiresNatural"));
       }
     },


### PR DESCRIPTION
Resolves #1403

## Summary

A `natural`-tagged Action whose weapon choices contain no viable natural weapon resolves an
empty strike sequence, and the `natural` tag's `canUse` check passes *vacuously* on the empty
array (`[].every(...)` is `true`). Wild Strike — whose cost is `action: -1` — could therefore
be activated by any actor with the Natural Weapon Training talent but no natural weapon,
producing a chat message which **refunds 1 Action on confirmation without performing any
attack**.

## Root cause

1. `natural.prepare()` marks every weapon choice lacking the `natural` item property as not
   viable.
2. `strike.prepare()` resolves `usage.weapon` and the strike sequence only from *viable*
   choices — so an actor without a natural weapon ends up with an empty `usage.strikes`.
3. `natural.canUse()` only checked
   `usage.strikes.every(w => w.system.properties.has("natural"))`, which an empty array
   satisfies vacuously — so the action passed the prerequisite check and activated, with no
   dice, no attack, and a free Action refund.

## The change

One line — the `natural` tag now also requires that at least one natural-weapon strike
actually resolved:

```js
canUse() {
  if ( !this.usage.strikes.length || !this.usage.strikes.every(w => w.system.properties.has("natural")) ) {
    throw new Error(_loc("ACTION.WARNINGS.RequiresNatural"));
  }
},
```

This implements the general requirement suggested in the issue ("Natural Attack-tagged actions
must either have a natural weapon selected or have some other tag which will provide dice to
roll"): every `natural`-tagged action draws its dice from the strike sequence
(`strike.roll` → `Actor#weaponAttack`), so when no natural weapon resolves the action could
never do anything. Such actions are now refused with the existing
`ACTION.WARNINGS.RequiresNatural` warning and are hidden from the sheet, consistent with the
other requirement tags (`melee`, `twohanded`, `offhand`, ...).

## Demo

Run this macro with a token controlled that has the Natural Weapon Training talent but no
natural weapon (in the screenshots below: the adversary **Kern**, who carries only a
"Kern's Mushroom Walking Stick"), targeting an adjacent enemy:

```js
const token = canvas.tokens.controlled[0];
if ( !token ) return ui.notifications.error("Control a token first.");
const actor = token.actor;
const target = game.user.targets.first();
if ( !target ) return ui.notifications.error("Target an adjacent enemy.");
const getActions = () => actor.system.resources.action.value;

// A confirmed basic Strike so the afterStrike requirement is satisfied
await actor.system.actions.strike.use({token: token.document, dialog: false});
const strikeMsg = game.messages.contents.findLast(m => m.flags?.crucible?.action?.id === "strike" && !m.flags?.crucible?.confirmed);
if ( strikeMsg ) await crucible.api.models.CrucibleAction.confirmMessage(strikeMsg);

// Attempt Wild Strike (requires a natural weapon)
const before = getActions();
const wildStrike = await actor.system.actions.wildStrike.use({token: token.document, dialog: false});
const after = getActions();

const verdict = wildStrike
  ? `Wild Strike activated with no natural weapon: Actions ${before} → ${after} (refund, no attack).`
  : "Wild Strike was refused — see warning. No Action was refunded.";
ui.notifications.info(verdict);
```

**Before this PR** — Wild Strike activates with no attack roll. Its chat card is created and,
on confirmation, the actor's Action pool is *refunded* (3 → 4):
<img width="1600" height="900" alt="before-wild-strike-refund" src="https://github.com/user-attachments/assets/e995993e-c165-4bff-9400-a75cd7a75f32" />


**After this PR** — Wild Strike is refused with a clear warning, no chat card is created, and
no Action is refunded (the confirmed Strike above it is the only card):
<img width="1600" height="900" alt="after-wild-strike-blocked" src="https://github.com/user-attachments/assets/7bb6439a-ccf6-43fd-8f55-d29545070bb3" />


## Regression checks

All performed against a live world:

- Actor **with** a natural weapon (Broken Aedir Sentinel, "Sword-Arm"): Wild Strike still
  activates and strikes with the natural weapon.
- Noxious Spit on a creature that has natural weapons (Afflicted Pallid Drake): unaffected —
  still resolves its Bite for dice.
- A creature with a `natural`-tagged attack but **no** natural weapon at all (Jurtak Warrior
  with Acid Spit): previously the action activated silently, rolled nothing, and still cost
  its resources; it is now refused with the same clear warning and hidden from the sheet.

---
