### PR TITLE
[#1256] Use an Emanation region for Pulse targeting

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -431,7 +431,7 @@
         }
       },
       "AlreadyConfirmed": "The action against you has already been confirmed and can no longer be reacted to.",
-      "AuraNoToken": "You cannot use an Aura-target action without having a token on the scene!",
+      "AuraNoToken": "You cannot use an area-target action without having a token on the scene!",
       "BadStatus": "You may not perform {action} while {status}.",
       "CannotAffordCost": "{name} has insufficient {resource} to use {action}!",
       "CannotAffordHands": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -431,7 +431,7 @@
         }
       },
       "AlreadyConfirmed": "The action against you has already been confirmed and can no longer be reacted to.",
-      "AuraNoToken": "You cannot use an area-target action without having a token on the scene!",
+      "AuraNoToken": "You cannot use a self-emanating action without having a token on the scene!",
       "BadStatus": "You may not perform {action} while {status}.",
       "CannotAffordCost": "{name} has insufficient {resource} to use {action}!",
       "CannotAffordHands": {

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -110,9 +110,9 @@ export const TARGET_TYPES = defineEnum({
   pulse: {
     label: "ACTION.TARGET_TYPES.Pulse",
     region: {
-      shape: "circle",
+      shape: "emanation",
       anchor: "self",
-      addSize: true,
+      addSize: false, // Accounted for directly by emanation shape
       ephemeral: true
     },
     scope: TARGET_SCOPES.ALL

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -579,6 +579,10 @@ export default class ActionUseDialog extends StandardCheckDialog {
         shape.anchorX = shape.anchorY = 0;
         elevation.top = elevation.bottom + size;
         break;
+      case "pulse":
+        elevation.bottom -= baseRange;
+        elevation.top += baseRange;
+        break;
       case "ray":
         if ( target.size ) shape.width = target.size * d;
         break;


### PR DESCRIPTION
Pulse-targeted actions currently use a **Circle** region anchored on the acting token's
*center*, with half the token's width added to the radius to compensate for the caster's
footprint. As discussed in #1256, this produces two inaccuracies:

- The circle bulges past the token's edges on the orthogonal axes while **clipping through
  the corners of the token's own footprint** — large creatures don't even cover themselves
  at the corners.
- Coverage near the diagonal corners doesn't match "every enemy within range" (e.g.
  Dervish's Whirlwind), because the radius is measured from a center point instead of from
  the creature's actual space.

This PR switches the `pulse` target type to use an **Emanation** region, the same shape the
`aura` target type already uses. The radius is measured from the token's footprint, so the
token's size is accounted for natively (no more manual `addSize` half-width offset) and the
area follows the creature's actual shape. If the pulse targeting type had been created in a
post-v14 world, this is the shape it would have used.

### Changes

- `module/const/action.mjs` — `TARGET_TYPES.pulse.region`: `circle` → `emanation`,
  `addSize: true` → `addSize: false` (mirroring the `aura` config).
- `module/dice/action-use-dialog.mjs` — preserve the pulse's vertical reach by extending the
  region elevation range by the pulse radius in the target-type switch (previously done by
  the `circle` shape branch).
- `lang/en.json` — generalize the `AuraNoToken` warning to "area-target" actions, since
  Pulses now share the Emanation placement path.

### Before / After

Scenario: a size-4 (4×4 pace) automaton uses a pulse with range 2 against dummy tokens.
Dummies sit orthogonally adjacent/2 out, diagonally adjacent/2 out, and at the two
discriminator positions just beyond the footprint corners.


*Before — Circle region: the area is centered on the token center, overreaching the edges
orthogonally while clipping the token's own corners. Only 3 targets acquired, and the
corner dummies (within 2 paces of the creature's corner) are missed.*

*After — Emanation region: the area hugs the token footprint with a uniform 2-pace reach
around every edge and rounded corners. The corner dummies are now correctly acquired
(5 targets).*

Side-by-side comparison: 
<img width="1600" height="1912" alt="image" src="https://github.com/user-attachments/assets/97c2dcfb-3be6-46d9-bd81-58cc4dbc04c2" />


