### PR TITLE
993 cursed affixes

### DIFF
--- a/_source/affixes/Cursed_Acid_Resistance_acidResCursed00.yml
+++ b/_source/affixes/Cursed_Acid_Resistance_acidResCursed00.yml
@@ -1,0 +1,49 @@
+name: Cursed Acid Resistance
+type: affix
+duration:
+  value: null
+  units: seconds
+  expiry: null
+  expired: false
+system:
+  adjective: Acid-Warding
+  identifier: acidResistance
+  changes: []
+  cursed: true
+  affixType: prefix
+  tier:
+    min: 1
+    max: 3
+    value: 1
+  itemTypes:
+    - armor
+    - accessory
+_id: acidResCursed00
+img: icons/magic/death/undead-skeleton-energy-green.webp
+disabled: false
+start: null
+description: >-
+  <p>A mockery of true enchantment. To all inspection this affix appears as a
+  genuine <strong>Acid-Warding</strong> blessing, but once the item is
+  <strong>Invested</strong> the curse takes hold: <strong>Acid</strong>
+  resistance is <em>reduced</em> by 3 for each <strong>Tier</strong> of this
+  prefix, leaving the bearer vulnerable to acid.</p>
+origin: null
+tint: '#ffffff'
+transfer: false
+statuses: []
+showIcon: 1
+folder: ye7FSz6vOcgm2RY8
+sort: 500000
+flags: {}
+_stats:
+  coreVersion: '14.359'
+  systemId: crucible
+  systemVersion: 0.9.1
+  createdTime: 1775502000000
+  modifiedTime: 1775502000000
+  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+_key: '!effects!acidResCursed00'

--- a/_source/affixes/Cursed_Acid_Resistance_acidResCursed00.yml
+++ b/_source/affixes/Cursed_Acid_Resistance_acidResCursed00.yml
@@ -23,11 +23,9 @@ img: icons/magic/death/undead-skeleton-energy-green.webp
 disabled: false
 start: null
 description: >-
-  <p>A mockery of true enchantment. To all inspection this affix appears as a
-  genuine <strong>Acid-Warding</strong> blessing, but once the item is
-  <strong>Invested</strong> the curse takes hold: <strong>Acid</strong>
-  resistance is <em>reduced</em> by 3 for each <strong>Tier</strong> of this
-  prefix, leaving the bearer vulnerable to acid.</p>
+  <p>Decrease <strong>Acid</strong> resistance by 3 for each
+  <strong>Tier</strong> of this prefix. This curse is indistinguishable from
+  its uncorrupted blessing until the item is <strong>Invested</strong>.</p>
 origin: null
 tint: '#ffffff'
 transfer: false

--- a/_source/affixes/Cursed_Beast_Bane_beastBaneCursed.yml
+++ b/_source/affixes/Cursed_Beast_Bane_beastBaneCursed.yml
@@ -1,0 +1,49 @@
+name: Cursed Beast Bane
+type: affix
+duration:
+  value: null
+  units: seconds
+  expiry: null
+  expired: false
+system:
+  adjective: Beast-Bane
+  identifier: beastBane
+  changes: []
+  cursed: true
+  affixType: prefix
+  tier:
+    min: 1
+    max: 3
+    value: 1
+  itemTypes:
+    - weapon
+_id: beastBaneCursed0
+img: icons/creatures/unholy/demon-fire-horned-mask.webp
+disabled: false
+start: null
+description: >-
+  <p>A corrupted hunter's blessing. To all inspection this affix appears as a
+  genuine <strong>Beast-Bane</strong> enchantment, but once the weapon is
+  <strong>Invested</strong> the curse takes hold: <strong>Strikes</strong>
+  made against <strong>Beast</strong> creatures suffer a penalty of
+  <strong>Banes</strong> equal to the <strong>Tier</strong> of this
+  prefix.</p>
+origin: null
+tint: '#ffffff'
+transfer: false
+statuses: []
+showIcon: 1
+folder: creatureBane0000
+sort: 500000
+flags: {}
+_stats:
+  coreVersion: '14.359'
+  systemId: crucible
+  systemVersion: 0.9.1
+  createdTime: 1775502000000
+  modifiedTime: 1775502000000
+  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+_key: '!effects!beastBaneCursed0'

--- a/_source/affixes/Cursed_Beast_Bane_beastBaneCursed.yml
+++ b/_source/affixes/Cursed_Beast_Bane_beastBaneCursed.yml
@@ -22,12 +22,10 @@ img: icons/creatures/unholy/demon-fire-horned-mask.webp
 disabled: false
 start: null
 description: >-
-  <p>A corrupted hunter's blessing. To all inspection this affix appears as a
-  genuine <strong>Beast-Bane</strong> enchantment, but once the weapon is
-  <strong>Invested</strong> the curse takes hold: <strong>Strikes</strong>
-  made against <strong>Beast</strong> creatures suffer a penalty of
-  <strong>Banes</strong> equal to the <strong>Tier</strong> of this
-  prefix.</p>
+  <p><strong>Strikes</strong> made against <strong>Beast</strong> creatures
+  suffer a penalty of <strong>Banes</strong> equal to the <strong>Tier</strong>
+  of this prefix. This curse is indistinguishable from its uncorrupted
+  blessing until the item is <strong>Invested</strong>.</p>
 origin: null
 tint: '#ffffff'
 transfer: false

--- a/_source/affixes/Cursed_Potency_potencyCursed000.yml
+++ b/_source/affixes/Cursed_Potency_potencyCursed000.yml
@@ -1,0 +1,48 @@
+name: Cursed Potency
+type: affix
+duration:
+  value: null
+  units: seconds
+  expiry: null
+  expired: false
+system:
+  adjective: Power
+  identifier: weaponPotency
+  changes: []
+  cursed: true
+  affixType: suffix
+  tier:
+    min: 1
+    max: 3
+    value: 1
+  itemTypes:
+    - weapon
+_id: potencyCursed000
+img: icons/magic/unholy/orb-beam-pink.webp
+disabled: false
+start: null
+description: >-
+  <p>A hollow promise of strength. To all inspection this affix appears as a
+  genuine <strong>Potency</strong> enchantment, but once the weapon is
+  <strong>Invested</strong> the curse takes hold: <strong>Strikes</strong>
+  made with this weapon suffer an <strong>Enchantment Penalty</strong> equal
+  to the <strong>Tier</strong> of this suffix.</p>
+origin: null
+tint: '#ffffff'
+transfer: false
+statuses: []
+showIcon: 1
+folder: 64872phWO5b24xSh
+sort: 200000
+flags: {}
+_stats:
+  coreVersion: '14.359'
+  systemId: crucible
+  systemVersion: 0.9.1
+  createdTime: 1775502000000
+  modifiedTime: 1775502000000
+  lastModifiedBy: WRGzDgYAt3ZuX6TU
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+_key: '!effects!potencyCursed000'

--- a/_source/affixes/Cursed_Potency_potencyCursed000.yml
+++ b/_source/affixes/Cursed_Potency_potencyCursed000.yml
@@ -22,11 +22,10 @@ img: icons/magic/unholy/orb-beam-pink.webp
 disabled: false
 start: null
 description: >-
-  <p>A hollow promise of strength. To all inspection this affix appears as a
-  genuine <strong>Potency</strong> enchantment, but once the weapon is
-  <strong>Invested</strong> the curse takes hold: <strong>Strikes</strong>
-  made with this weapon suffer an <strong>Enchantment Penalty</strong> equal
-  to the <strong>Tier</strong> of this suffix.</p>
+  <p><strong>Strikes</strong> made with this weapon suffer an
+  <strong>Enchantment Penalty</strong> equal to the <strong>Tier</strong> of
+  this suffix. This curse is indistinguishable from its uncorrupted blessing
+  until the item is <strong>Invested</strong>.</p>
 origin: null
 tint: '#ffffff'
 transfer: false

--- a/lang/en.json
+++ b/lang/en.json
@@ -1014,10 +1014,16 @@
           "label": "Affix Tier",
           "hint": "The tier of this affix applied to the item."
         }
+      },
+      "cursed": {
+        "label": "Cursed",
+        "hint": "A cursed affix inverts its benefit and hinders the bearer instead: numeric bonuses are applied negatively, and affixes which grant Boons inflict Banes. The curse takes hold once the item is invested."
       }
     },
     "ConfigIdentity": "Affix Identity",
     "ConfigTier": "Tier Configuration",
+    "ConfigCurse": "Curse",
+    "Cursed": "Cursed",
     "TierRestriction": "Tier Range",
     "Prefixes": "Prefixes",
     "Suffixes": "Suffixes",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1017,7 +1017,7 @@
       },
       "cursed": {
         "label": "Cursed",
-        "hint": "A cursed affix inverts its benefit and hinders the bearer instead: numeric bonuses are applied negatively, and affixes which grant Boons inflict Banes. The curse takes hold once the item is invested."
+        "hint": "Cursed affixes invert their benefit and hinder the bearer instead. The curse takes hold once the item is invested."
       }
     },
     "ConfigIdentity": "Affix Identity",

--- a/module/applications/sheets/effect-affix-sheet.mjs
+++ b/module/applications/sheets/effect-affix-sheet.mjs
@@ -161,6 +161,7 @@ export default class CrucibleAffixEffectSheet extends api.HandlebarsApplicationM
    */
   #prepareTags() {
     const tags = {};
+    if ( this.document.system.cursed ) tags.cursed = _loc("AFFIX.Cursed");
     const affixType = SYSTEM.ITEM.AFFIX_TYPES[this.document.system.affixType];
     if ( affixType ) tags.affixType = _loc(affixType);
     const tier = this.document.system.tier;

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -350,7 +350,6 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         description: await editorCls.enrichHTML(affix.description, {relativeTo: affix, secrets: this.document.isOwner}),
         tier: tierValue,
         tierRoman: ["", "I", "II", "III"][tierValue] ?? tierValue,
-        // Only reveal cursed affixes to GMs, preserving the surprise for players until the item is invested
         cursed: game.user.isGM && affix.system.cursed
       };
       if ( affix.system.affixType === "prefix" ) prefixes.push(data);

--- a/module/applications/sheets/item-base-sheet.mjs
+++ b/module/applications/sheets/item-base-sheet.mjs
@@ -349,7 +349,9 @@ export default class CrucibleBaseItemSheet extends api.HandlebarsApplicationMixi
         img: affix.img,
         description: await editorCls.enrichHTML(affix.description, {relativeTo: affix, secrets: this.document.isOwner}),
         tier: tierValue,
-        tierRoman: ["", "I", "II", "III"][tierValue] ?? tierValue
+        tierRoman: ["", "I", "II", "III"][tierValue] ?? tierValue,
+        // Only reveal cursed affixes to GMs, preserving the surprise for players until the item is invested
+        cursed: game.user.isGM && affix.system.cursed
       };
       if ( affix.system.affixType === "prefix" ) prefixes.push(data);
       else suffixes.push(data);

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -257,7 +257,7 @@ export default class StandardCheck extends Roll {
 
     // Construct the formula
     const terms = pool.map(p => `1d${p}`).concat([data.ability, data.skill]);
-    if ( data.enchantment > 0 ) terms.push(data.enchantment);
+    if ( data.enchantment !== 0 ) terms.push(data.enchantment);
     const formula = terms.join(" + ");
     return super.parse(formula, data);
   }

--- a/module/hooks/affix.mjs
+++ b/module/hooks/affix.mjs
@@ -6,19 +6,6 @@ import {GESTURES, INFLECTIONS, RUNES} from "../const/spellcraft.mjs";
 const HOOKS = {};
 
 /* -------------------------------------------- */
-/*  Cursed Affixes                              */
-/* -------------------------------------------- */
-
-/**
- * Affixes with the `cursed` flag invert their benefit, hindering the bearer instead of helping them. Because cursed
- * variants of an affix share its identifier, each hook implementation reads the flag from the applied affix effect at
- * runtime and inverts its contribution. Numeric bonuses apply their sign; "best-of" bonuses apply a negative best-of;
- * boon-granting affixes grant banes instead. Affixes whose effect has no meaningful inverse (e.g. Returning, damage
- * type Conversion, Spellcraft knowledge) ignore the flag.
- * ---------------------------------------------
- */
-
-/* -------------------------------------------- */
 /*  Damage Type Affixes                         */
 /* -------------------------------------------- */
 
@@ -125,7 +112,6 @@ for ( const skillId of Object.keys(SKILLS) ) {
 
 /**
  * Keen: reduce the critical success threshold by 1 per tier for attacks with this weapon, stacking with other reducers.
- * Cursed: the threshold is instead increased, making critical hits harder to score.
  */
 HOOKS.keen = {
   prepareAttack(item, action, target, rollData) {
@@ -164,7 +150,7 @@ HOOKS.vicious = {
 /* -------------------------------------------- */
 
 /**
- * Tenacity: Increase Fortitude defense by the affix tier. Cursed: decrease it instead.
+ * Tenacity: Increase Fortitude defense by the affix tier.
  */
 HOOKS.tenacity = {
   prepareDefenses(item, defenses) {
@@ -185,9 +171,6 @@ HOOKS.reach = {
 
 /* -------------------------------------------- */
 
-/**
- * Reliable: reduce the critical failure threshold for attacks with this weapon. Cursed: increase it instead.
- */
 HOOKS.reliable = {
   prepareAttack(item, action, target, rollData) {
     const affix = item.system.affixes.reliable.system;
@@ -220,9 +203,6 @@ HOOKS.weaponPotency = {
 
 /* -------------------------------------------- */
 
-/**
- * Deflection: Increase Parry defense by the affix tier. Cursed: decrease it instead.
- */
 HOOKS.deflection = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.deflection.system;
@@ -254,9 +234,6 @@ HOOKS.luminous = {
 
 /* -------------------------------------------- */
 
-/**
- * Guarding: Increase Block defense by the affix tier. Cursed: decrease it instead.
- */
 HOOKS.guarding = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.guarding.system;
@@ -268,9 +245,6 @@ HOOKS.guarding = {
 /*  Accessory and Armor Affixes                 */
 /* -------------------------------------------- */
 
-/**
- * Determination: Increase Willpower defense by the affix tier. Cursed: decrease it instead.
- */
 HOOKS.determination = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.determination.system;
@@ -280,9 +254,6 @@ HOOKS.determination = {
 
 /* -------------------------------------------- */
 
-/**
- * Evasion: Increase Dodge defense by the affix tier. Cursed: decrease it instead.
- */
 HOOKS.evasion = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.evasion.system;
@@ -292,9 +263,6 @@ HOOKS.evasion = {
 
 /* -------------------------------------------- */
 
-/**
- * Nimbleness: Increase Reflex defense by the affix tier. Cursed: decrease it instead.
- */
 HOOKS.nimbleness = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.nimbleness.system;
@@ -304,9 +272,6 @@ HOOKS.nimbleness = {
 
 /* -------------------------------------------- */
 
-/**
- * Reinforcement: Increase Armor defense by the affix tier. Cursed: decrease it instead.
- */
 HOOKS.reinforcement = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.reinforcement.system;
@@ -314,9 +279,6 @@ HOOKS.reinforcement = {
   }
 };
 
-/**
- * Hale: Increase Health maximum by 6 per tier. Cursed: decrease it instead.
- */
 HOOKS.hale = {
   prepareResources(item, resources) {
     const affix = item.system.affixes.hale.system;
@@ -326,9 +288,6 @@ HOOKS.hale = {
 
 /* -------------------------------------------- */
 
-/**
- * Spirited: Increase Morale maximum by 6 per tier. Cursed: decrease it instead.
- */
 HOOKS.spirited = {
   prepareResources(item, resources) {
     const affix = item.system.affixes.spirited.system;
@@ -340,10 +299,6 @@ HOOKS.spirited = {
 /*  Armor-Only Affixes                          */
 /* -------------------------------------------- */
 
-/**
- * Mending: Reduce the Wounds threshold, making the wearer easier to heal from wounds.
- * Cursed: raise the threshold instead.
- */
 HOOKS.mending = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.mending.system;
@@ -353,10 +308,6 @@ HOOKS.mending = {
 
 /* -------------------------------------------- */
 
-/**
- * Nonchalant: raise the attacker's critical success threshold when defending with Morale.
- * Cursed: lower the threshold instead, making critical hits against the wearer easier.
- */
 HOOKS.nonchalant = {
   defendAttack(item, action, attacker, rollData) {
     const resource = action.usage?.resource || action.rune?.resource || "health";
@@ -369,10 +320,6 @@ HOOKS.nonchalant = {
 
 /* -------------------------------------------- */
 
-/**
- * Rallying: Reduce the Madness threshold, making the wearer easier to heal from madness.
- * Cursed: raise the threshold instead.
- */
 HOOKS.rallying = {
   prepareDefenses(item, defenses) {
     const affix = item.system.affixes.rallying.system;
@@ -382,10 +329,6 @@ HOOKS.rallying = {
 
 /* -------------------------------------------- */
 
-/**
- * Unshakeable: raise the attacker's critical success threshold when defending with Health.
- * Cursed: lower the threshold instead, making critical hits against the wearer easier.
- */
 HOOKS.unshakeable = {
   defendAttack(item, action, attacker, rollData) {
     const resource = action.usage?.resource || action.rune?.resource || "health";
@@ -400,9 +343,6 @@ HOOKS.unshakeable = {
 /*  Accessory-Only Affixes                      */
 /* -------------------------------------------- */
 
-/**
- * Luminary: grant Boons to composed spell actions. Cursed: inflict Banes instead.
- */
 HOOKS.luminary = {
   prepareAction(item, action) {
     if ( !action.tags.has("composed") || !action.inflection?.id ) return;

--- a/module/hooks/affix.mjs
+++ b/module/hooks/affix.mjs
@@ -6,6 +6,19 @@ import {GESTURES, INFLECTIONS, RUNES} from "../const/spellcraft.mjs";
 const HOOKS = {};
 
 /* -------------------------------------------- */
+/*  Cursed Affixes                              */
+/* -------------------------------------------- */
+
+/**
+ * Affixes with the `cursed` flag invert their benefit, hindering the bearer instead of helping them. Because cursed
+ * variants of an affix share its identifier, each hook implementation reads the flag from the applied affix effect at
+ * runtime and inverts its contribution. Numeric bonuses apply their sign; "best-of" bonuses apply a negative best-of;
+ * boon-granting affixes grant banes instead. Affixes whose effect has no meaningful inverse (e.g. Returning, damage
+ * type Conversion, Spellcraft knowledge) ignore the flag.
+ * ---------------------------------------------
+ */
+
+/* -------------------------------------------- */
 /*  Damage Type Affixes                         */
 /* -------------------------------------------- */
 
@@ -13,15 +26,15 @@ for ( const [type, cfg] of Object.entries(DAMAGE_TYPES) ) {
   const dmgId = `${type}Damage`;
   HOOKS[dmgId] = {
     prepareWeapons(item) {
-      const tier = item.system.affixes[dmgId].system.tier.value;
-      item.system.damage.bonus += (2 * tier);
+      const affix = item.system.affixes[dmgId].system;
+      item.system.damage.bonus += (2 * affix.tier.value * affix.sign);
     }
   };
   const resId = `${type}Resistance`;
   HOOKS[resId] = {
     prepareResistances(item, resistances) {
-      const tier = item.system.affixes[resId].system.tier.value;
-      resistances[type].bonus += (3 * tier);
+      const affix = item.system.affixes[resId].system;
+      resistances[type].bonus += (3 * affix.tier.value * affix.sign);
     }
   };
   if ( !["bludgeoning", "piercing", "slashing"].includes(type) ) {
@@ -43,8 +56,10 @@ for ( const runeId of Object.keys(RUNES) ) {
   HOOKS[id] = {
     prepareAttack(item, action, target, rollData) {
       if ( action.rune?.id !== runeId ) return;
-      const tier = item.system.affixes[id].system.tier.value;
-      rollData.enchantment = Math.max(rollData.enchantment, tier);
+      const affix = item.system.affixes[id].system;
+      rollData.enchantment = affix.cursed
+        ? Math.min(rollData.enchantment, -affix.tier.value)
+        : Math.max(rollData.enchantment, affix.tier.value);
     }
   };
 }
@@ -98,8 +113,10 @@ for ( const skillId of Object.keys(SKILLS) ) {
   const id = `${skillId}Skill`;
   HOOKS[id] = {
     prepareSkills(item, skills) {
-      const tier = item.system.affixes[id].system.tier.value;
-      skills[skillId].enchantmentBonus = Math.max(skills[skillId].enchantmentBonus, tier);
+      const affix = item.system.affixes[id].system;
+      skills[skillId].enchantmentBonus = affix.cursed
+        ? Math.min(skills[skillId].enchantmentBonus, -affix.tier.value)
+        : Math.max(skills[skillId].enchantmentBonus, affix.tier.value);
     }
   };
 }
@@ -108,12 +125,13 @@ for ( const skillId of Object.keys(SKILLS) ) {
 
 /**
  * Keen: reduce the critical success threshold by 1 per tier for attacks with this weapon, stacking with other reducers.
+ * Cursed: the threshold is instead increased, making critical hits harder to score.
  */
 HOOKS.keen = {
   prepareAttack(item, action, target, rollData) {
     if ( rollData.itemId !== item.id ) return; // Only apply to the correct weapon
-    const tier = item.system.affixes.keen.system.tier.value;
-    rollData.criticalSuccessThreshold = (rollData.criticalSuccessThreshold ?? 6) - tier;
+    const affix = item.system.affixes.keen.system;
+    rollData.criticalSuccessThreshold = (rollData.criticalSuccessThreshold ?? 6) - (affix.tier.value * affix.sign);
   }
 };
 
@@ -146,12 +164,12 @@ HOOKS.vicious = {
 /* -------------------------------------------- */
 
 /**
- * Tenacity: Increase Fortitude defense by the affix tier.
+ * Tenacity: Increase Fortitude defense by the affix tier. Cursed: decrease it instead.
  */
 HOOKS.tenacity = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.tenacity.system.tier.value;
-    defenses.fortitude.bonus += tier;
+    const affix = item.system.affixes.tenacity.system;
+    defenses.fortitude.bonus += (affix.tier.value * affix.sign);
   }
 };
 
@@ -159,18 +177,21 @@ HOOKS.tenacity = {
 
 HOOKS.reach = {
   prepareWeapons(item, weapons) {
-    const tier = item.system.affixes.reach.system.tier.value;
+    const affix = item.system.affixes.reach.system;
     const category = item.system.config.category;
-    item.system.range += category.ranged ? (10 * tier) : tier;
+    item.system.range += (category.ranged ? 10 : 1) * affix.tier.value * affix.sign;
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Reliable: reduce the critical failure threshold for attacks with this weapon. Cursed: increase it instead.
+ */
 HOOKS.reliable = {
   prepareAttack(item, action, target, rollData) {
-    const tier = item.system.affixes.reliable.system.tier.value;
-    rollData.criticalFailureThreshold = 6 - tier;
+    const affix = item.system.affixes.reliable.system;
+    rollData.criticalFailureThreshold = 6 - (affix.tier.value * affix.sign);
   }
 };
 
@@ -192,17 +213,20 @@ HOOKS.returning = {
 
 HOOKS.weaponPotency = {
   prepareWeapons(item, weapons) {
-    const tier = item.system.affixes.weaponPotency.system.tier.value;
-    item.system.actionBonuses.enchantment += tier;
+    const affix = item.system.affixes.weaponPotency.system;
+    item.system.actionBonuses.enchantment += (affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Deflection: Increase Parry defense by the affix tier. Cursed: decrease it instead.
+ */
 HOOKS.deflection = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.deflection.system.tier.value;
-    defenses.parry.bonus += tier;
+    const affix = item.system.affixes.deflection.system;
+    defenses.parry.bonus += (affix.tier.value * affix.sign);
   }
 };
 
@@ -230,10 +254,13 @@ HOOKS.luminous = {
 
 /* -------------------------------------------- */
 
+/**
+ * Guarding: Increase Block defense by the affix tier. Cursed: decrease it instead.
+ */
 HOOKS.guarding = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.guarding.system.tier.value;
-    defenses.block.bonus += tier;
+    const affix = item.system.affixes.guarding.system;
+    defenses.block.bonus += (affix.tier.value * affix.sign);
   }
 };
 
@@ -241,53 +268,71 @@ HOOKS.guarding = {
 /*  Accessory and Armor Affixes                 */
 /* -------------------------------------------- */
 
+/**
+ * Determination: Increase Willpower defense by the affix tier. Cursed: decrease it instead.
+ */
 HOOKS.determination = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.determination.system.tier.value;
-    defenses.willpower.bonus += tier;
+    const affix = item.system.affixes.determination.system;
+    defenses.willpower.bonus += (affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Evasion: Increase Dodge defense by the affix tier. Cursed: decrease it instead.
+ */
 HOOKS.evasion = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.evasion.system.tier.value;
-    defenses.dodge.bonus += tier;
+    const affix = item.system.affixes.evasion.system;
+    defenses.dodge.bonus += (affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Nimbleness: Increase Reflex defense by the affix tier. Cursed: decrease it instead.
+ */
 HOOKS.nimbleness = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.nimbleness.system.tier.value;
-    defenses.reflex.bonus += tier;
+    const affix = item.system.affixes.nimbleness.system;
+    defenses.reflex.bonus += (affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Reinforcement: Increase Armor defense by the affix tier. Cursed: decrease it instead.
+ */
 HOOKS.reinforcement = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.reinforcement.system.tier.value;
-    defenses.armor.bonus += tier;
+    const affix = item.system.affixes.reinforcement.system;
+    defenses.armor.bonus += (affix.tier.value * affix.sign);
   }
 };
 
+/**
+ * Hale: Increase Health maximum by 6 per tier. Cursed: decrease it instead.
+ */
 HOOKS.hale = {
   prepareResources(item, resources) {
-    const tier = item.system.affixes.hale.system.tier.value;
-    resources.health.bonus += (6 * tier);
+    const affix = item.system.affixes.hale.system;
+    resources.health.bonus += (6 * affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Spirited: Increase Morale maximum by 6 per tier. Cursed: decrease it instead.
+ */
 HOOKS.spirited = {
   prepareResources(item, resources) {
-    const tier = item.system.affixes.spirited.system.tier.value;
-    resources.morale.bonus += (6 * tier);
+    const affix = item.system.affixes.spirited.system;
+    resources.morale.bonus += (6 * affix.tier.value * affix.sign);
   }
 };
 
@@ -295,42 +340,58 @@ HOOKS.spirited = {
 /*  Armor-Only Affixes                          */
 /* -------------------------------------------- */
 
+/**
+ * Mending: Reduce the Wounds threshold, making the wearer easier to heal from wounds.
+ * Cursed: raise the threshold instead.
+ */
 HOOKS.mending = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.mending.system.tier.value;
-    defenses.wounds.bonus -= tier;
+    const affix = item.system.affixes.mending.system;
+    defenses.wounds.bonus -= (affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Nonchalant: raise the attacker's critical success threshold when defending with Morale.
+ * Cursed: lower the threshold instead, making critical hits against the wearer easier.
+ */
 HOOKS.nonchalant = {
   defendAttack(item, action, attacker, rollData) {
     const resource = action.usage?.resource || action.rune?.resource || "health";
     if ( resource === "morale" ) {
-      const tier = item.system.affixes.nonchalant.system.tier.value;
-      rollData.criticalSuccessThreshold = (rollData.criticalSuccessThreshold ?? 6) + tier;
+      const affix = item.system.affixes.nonchalant.system;
+      rollData.criticalSuccessThreshold = (rollData.criticalSuccessThreshold ?? 6) + (affix.tier.value * affix.sign);
     }
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Rallying: Reduce the Madness threshold, making the wearer easier to heal from madness.
+ * Cursed: raise the threshold instead.
+ */
 HOOKS.rallying = {
   prepareDefenses(item, defenses) {
-    const tier = item.system.affixes.rallying.system.tier.value;
-    defenses.madness.bonus -= tier;
+    const affix = item.system.affixes.rallying.system;
+    defenses.madness.bonus -= (affix.tier.value * affix.sign);
   }
 };
 
 /* -------------------------------------------- */
 
+/**
+ * Unshakeable: raise the attacker's critical success threshold when defending with Health.
+ * Cursed: lower the threshold instead, making critical hits against the wearer easier.
+ */
 HOOKS.unshakeable = {
   defendAttack(item, action, attacker, rollData) {
     const resource = action.usage?.resource || action.rune?.resource || "health";
     if ( resource === "health" ) {
-      const tier = item.system.affixes.unshakeable.system.tier.value;
-      rollData.criticalSuccessThreshold = (rollData.criticalSuccessThreshold ?? 6) + tier;
+      const affix = item.system.affixes.unshakeable.system;
+      rollData.criticalSuccessThreshold = (rollData.criticalSuccessThreshold ?? 6) + (affix.tier.value * affix.sign);
     }
   }
 };
@@ -339,11 +400,15 @@ HOOKS.unshakeable = {
 /*  Accessory-Only Affixes                      */
 /* -------------------------------------------- */
 
+/**
+ * Luminary: grant Boons to composed spell actions. Cursed: inflict Banes instead.
+ */
 HOOKS.luminary = {
   prepareAction(item, action) {
     if ( !action.tags.has("composed") || !action.inflection?.id ) return;
-    const tier = item.system.affixes.luminary.system.tier.value;
-    action.usage.boons[item.system.identifier] = {label: item.name, number: tier};
+    const affix = item.system.affixes.luminary.system;
+    const pool = affix.cursed ? action.usage.banes : action.usage.boons;
+    pool[item.system.identifier] = {label: item.name, number: affix.tier.value};
   }
 };
 
@@ -358,8 +423,9 @@ for ( const categoryId of Object.keys(CREATURE_CATEGORIES) ) {
     prepareAttack(item, action, target, rollData) {
       if ( item.id !== rollData.itemId ) return;
       if ( target.system.details.taxonomy?.category !== categoryId ) return;
-      const tier = item.system.affixes[id].system.tier.value;
-      rollData.boons[id] = {label: item.name, number: tier};
+      const affix = item.system.affixes[id].system;
+      const pool = affix.cursed ? rollData.banes : rollData.boons;
+      pool[id] = {label: item.name, number: affix.tier.value};
     }
   };
 }

--- a/module/models/effect-affix.mjs
+++ b/module/models/effect-affix.mjs
@@ -8,6 +8,7 @@ import * as crucibleFields from "./fields.mjs";
  * @property {string} affixType               The affix category, "prefix" or "suffix"
  * @property {Set<string>} itemTypes          Item types this affix may be applied to, empty allows any
  * @property {{min: number, max: number, value: number}} tier   The power tier with configurable range (1-3)
+ * @property {boolean} cursed                 Whether this affix is cursed, inverting its benefit to hinder the bearer
  * @property {CrucibleActionData[]} actions   Actions granted to items that bear this affix
  */
 
@@ -33,12 +34,24 @@ export default class CrucibleAffixActiveEffect extends foundry.data.ActiveEffect
       max: new fields.NumberField({required: true, nullable: false, integer: true, min: 1, max: 3, initial: 3}),
       value: new fields.NumberField({required: true, nullable: false, integer: true, min: 1, max: 3, initial: 1})
     });
+    schema.cursed = new fields.BooleanField({required: false, initial: false});
     schema.actions = new fields.ArrayField(new crucibleFields.CrucibleActionField());
     return schema;
   }
 
   /** @override */
   static LOCALIZATION_PREFIXES = ["ACTIVE_EFFECT", "AFFIX"];
+
+  /* -------------------------------------------- */
+
+  /**
+   * The sign of this affix's numeric contributions. Cursed affixes invert their benefit, applying numeric
+   * bonuses against the bearer instead of in their favor.
+   * @type {number}
+   */
+  get sign() {
+    return this.cursed ? -1 : 1;
+  }
 
   /* -------------------------------------------- */
 

--- a/styles/item.less
+++ b/styles/item.less
@@ -150,6 +150,14 @@
   }
 }
 
+// Cursed affix indicator on item sheets
+.crucible .affix.line-item {
+  .cursed-indicator {
+    flex: none;
+    color: var(--color-result-verybad);
+  }
+}
+
 /* ----------------------------------------- */
 /*  Armor                                    */
 /* ----------------------------------------- */

--- a/templates/sheets/effect/affix-config.hbs
+++ b/templates/sheets/effect/affix-config.hbs
@@ -21,4 +21,9 @@
             <p class="hint">{{fields.tier.hint}}</p>
         </div>
     </fieldset>
+
+    <fieldset {{fieldDisabled}}>
+        <legend>{{localize "AFFIX.ConfigCurse"}}</legend>
+        {{formGroup fields.cursed value=source.system.cursed}}
+    </fieldset>
 </section>

--- a/templates/sheets/item/included-affix.hbs
+++ b/templates/sheets/item/included-affix.hbs
@@ -3,6 +3,9 @@
     <div class="title">
         <h4>{{affix.name}} {{affix.tierRoman}}</h4>
     </div>
+    {{#if affix.cursed}}
+    <i class="cursed-indicator fa-solid fa-skull" data-tooltip="{{localize "AFFIX.Cursed"}}"></i>
+    {{/if}}
     {{#if isEditable}}
     <div class="controls">
         <a class="button icon fa-solid fa-edit" data-action="affixEdit" aria-label="{{localize "ACTIVE_EFFECT.ACTIONS.Edit"}}" data-tooltip></a>


### PR DESCRIPTION
Cursed affixes are the inverse of their regular counterparts: they hinder the bearer instead
of helping them. This implements the mechanism discussed in #993, including the "looks like
a good affix until you invest the item" fantasy — a cursed affix is embedded, named, and
capacity-charged exactly like its regular counterpart, but its benefits are inverted once
the item is invested.

### Mechanism

A cursed affix is any affix effect with the new `system.cursed` flag set. Cursed variants
**share the identifier** of the regular affix, so each module hook in
`crucible.api.hooks.affix` reads the flag from the applied effect at runtime and inverts
itself — every invertible affix family gains cursed support automatically, with no duplicate
hook code:

- **Numeric bonuses** (damage, resistance, defenses, health/morale, reach, weapon potency)
  apply negatively via the new `AffixData#sign` helper (`1`, or `-1` when cursed).
  *Examples: a cursed Acid Resistance lowers Acid resistance by 3 per tier; a cursed
  Resistance can push a character into vulnerability.*
- **Best-of bonuses** (rune potency, skill enchantment) apply a negative best-of instead of
  a positive one.
- **Bane affixes** inflict **Banes** on Strikes against the targeted creature category
  instead of granting Boons.
- **Threshold affixes** invert direction: Keen makes criticals *harder*, Reliable makes
  critical failures *easier*, Nonchalant/Unshakeable make critical hits against the wearer
  *easier*, Mending/Rallying raise the healing thresholds.
- **Luminary** inflicts Banes on composed spells instead of granting Boons.
- Affixes with no meaningful inverse (Returning, damage-type Conversion, Spellcraft
  knowledge grants, Vicious, Luminous) ignore the flag.

`StandardCheck` now applies **negative enchantment** values to the dice formula (previously
values ≤ 0 were silently dropped), so cursed potencies genuinely reduce rolls.

### UI & data

- The affix configuration sheet gains a **Curse** section with the `cursed` checkbox and the
  header shows a **Cursed** tag.
- Item sheets reveal cursed affixes to **GMs only** (a red skull indicator), keeping the
  surprise intact for players until the item is invested and the curse takes hold.
- Three example cursed affixes ship in the Affixes compendium, one per use case from the
  issue: **Cursed Acid Resistance** (inverted Resistance), **Cursed Beast Bane** (inverted
  Bane), and **Cursed Potency** (inverted Potency). Their adjectives match their regular
  counterparts (e.g. "Acid-Warding", "Power"), so cursed items name deceptively normally.

### Testing

- Live-verified on Foundry VTT v14 build 367 against an invested item on an unlinked token:
  - Cursed Acid Resistance (tier 2): Acid resistance fell by exactly 6 (resistance bonus 0 → −6).
  - Cursed Beast Bane (tier 2): Strikes vs. a Beast-taxonomy actor gained `banes.beastBane`
    (2 banes) instead of boons.
  - Cursed Potency (tier 2): weapon attack enchantment went negative (derived +1 − 2 = −1)
    and the attack formula rendered the subtraction (`… + 2 + 3 − 2`).
  - Procedural naming composed normally from the cursed adjective ("Beast-Bane Spear of
    Power"), with no visible curse hint in the item name.
  - Affix capacity validation, item name composition, and non-cursed affixes are unaffected.
- Regular (non-cursed) affix behavior is unchanged: the flag defaults to `false` and every
  hook's non-cursed branch is identical to its previous implementation.

### Considerations for reviewers

- Cursed affixes currently consume prefix/suffix capacity at full tier value like regular
  affixes. If cursed affixes should instead be "free" (hidden cost of the curse), that's a
  one-line change in the capacity accounting — feedback welcome.
- A natural follow-up would be enchanting-workflow integration (e.g. a chance for
  enchanting rolls to produce a cursed variant), or a way to identify curse items, remove the cursed item from equipment etc. 