### PR TITLE
[#452] Add a Maintain action for sustaining maintained effects

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,10 @@
         "Description": "Spend 10 minutes outside of Combat recovering from exertion to fully restore Health, Morale, Action, and Focus.",
         "Name": "Recover"
       },
+      "Maintain": {
+        "Description": "Spend the Focus cost of a maintained effect to sustain it for another round.",
+        "Name": "Maintain"
+      },
       "Reload": {
         "Description": "Reload a ranged weapon which features a reloading time.",
         "Name": "Reload Weapon"
@@ -434,6 +438,7 @@
       "AuraNoToken": "You cannot use an Aura-target action without having a token on the scene!",
       "BadStatus": "You may not perform {action} while {status}.",
       "CannotAffordCost": "{name} has insufficient {resource} to use {action}!",
+      "NoMaintainedEffect": "You have no effect which can be maintained!",
       "CannotAffordHands": {
         "zero": "{name} must have {hands} free hands to use {action}!",
         "one": "{name} must have {hands} free hand to use {action}!",
@@ -520,8 +525,8 @@
     "DurationSeconds": "{value}S",
     "DurationUntilEnded": "Until Ended",
     "EffectSpecific": "Effect: {effect}",
-    "MaintainContent": "<p>Spend {cost} Focus to maintain {effect}?</p>",
-    "MaintainTitle": "Maintain Focus: {effect}",
+    "MaintainReplaceContent": "<p>Using {action} will end your maintained {effect} at the end of this action.</p>",
+    "MaintainReplaceTitle": "Replace Maintained Effect",
     "NoTargets": "No Targets",
     "Overview": "Action Overview",
     "PlanMovement": "Plan Movement",
@@ -1387,7 +1392,6 @@
       "EffectGainedDuration": "Gained ({duration})",
       "HeaderEnd": "{actor} - Turn End",
       "HeaderStart": "{actor} - Turn Start",
-      "Maintaining": "{effect} (Maintaining)",
       "TableTitleEffects": "Effect Changes",
       "TableTitleResources": "Resource Changes"
     },

--- a/module/const/action.mjs
+++ b/module/const/action.mjs
@@ -1238,7 +1238,15 @@ export const TAGS = {
       const selfEffectEvent = this.events.find(e => (e.target === this.actor) && e.effects.length);
       if ( !selfEffectEvent ) return;
       const maintainedCost = this.actor.actions[this.id]?.cost.focus ?? this.gesture?.cost.focus ?? 1;
-      selfEffectEvent.effects[0].system.maintenance = {cost: maintainedCost};
+      const effect = selfEffectEvent.effects[0];
+      effect.system.maintenance = {cost: maintainedCost};
+
+      // Maintained effects expire at the start of the Actor's turn after next unless sustained by the Maintain action
+      effect.duration = {value: 2, units: "rounds", expiry: "turnStart"};
+
+      // Only one effect may be maintained at a time; end any currently maintained effect
+      const current = this.actor.maintainedEffect;
+      if ( current ) selfEffectEvent.effects.push({_id: current.id, _action: "delete"});
     }
   },
 
@@ -1566,6 +1574,24 @@ export const DEFAULT_ACTIONS = Object.freeze([
       const r = action.actor.system.resources;
       return (r.health.value < r.health.max) || (r.morale.value < r.morale.max) || (r.focus.value < r.focus.max);
     }
+  },
+
+  // Maintain (only added while the Actor has a maintained effect; its focus cost is drawn from that effect)
+  {
+    id: "maintain",
+    name: "ACTION.DEFAULT_ACTIONS.Maintain.Name",
+    img: "icons/magic/time/clock-stopwatch-white-blue.webp",
+    description: "ACTION.DEFAULT_ACTIONS.Maintain.Description",
+    target: {
+      type: "self",
+      number: 0,
+      scope: 1
+    },
+    cost: {
+      action: 0
+    },
+    tags: [],
+    autoFavorite: true
   },
 
   // Reload

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -1,3 +1,4 @@
+const {DialogV2} = foundry.applications.api;
 import StandardCheckDialog from "./standard-check-dialog.mjs";
 
 /**
@@ -280,6 +281,22 @@ export default class ActionUseDialog extends StandardCheckDialog {
       event.stopImmediatePropagation();
       ui.notifications.warn(_loc("ACTION.WARNINGS.NoViewedScene"));
       return;
+    }
+    if ( this.action.tags.has("maintained") ) {
+
+      // Confirm replacement when using a maintained action while another effect is already maintained
+      const current = this.actor.maintainedEffect;
+      if ( current ) {
+        const replace = await DialogV2.confirm({
+          window: {title: _loc("ACTION.MaintainReplaceTitle")},
+          content: _loc("ACTION.MaintainReplaceContent", {effect: current.name, action: this.action.name})
+        });
+        if ( !replace ) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          return;
+        }
+      }
     }
     if ( this.action.requiresRegion || this.action.requiresMovement ) {
       event.preventDefault();

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -187,6 +187,14 @@ export default class CrucibleActor extends Actor {
   }
 
   /**
+   * The singleton effect which this Actor is maintaining, if any.
+   * @type {CrucibleActiveEffect|null}
+   */
+  get maintainedEffect() {
+    return this.system.maintainedEffect;
+  }
+
+  /**
    * The prepared object of actor status data
    * @returns {ActorRoundStatus}
    */
@@ -1368,14 +1376,14 @@ export default class CrucibleActor extends Actor {
   /**
    * Identify changes to ActiveEffects which occur at the start of a Combatant's turn.
    * Damage-over-time effects are identified.
-   * Effects which core will expire are identified.
+   * Effects which core will expire are identified, including maintained effects which were not sustained by the
+   * Maintain action.
    * Unaware effect is primed for deletion.
-   * Effects with a maintenance cost are checked here; effects without sufficient focus are primed for deletion.
    * @param {CrucibleTurnChangeConfig & {dot: CrucibleActiveEffect[]}} turnStartConfig
    * @param {CombatTurnEventContext} context
    */
   async #prepareTurnStartConfig(turnStartConfig, context) {
-    const {effectChanges, resourceChanges, dot} = turnStartConfig;
+    const {effectChanges, dot} = turnStartConfig;
     for ( const effect of this.effects ) {
 
       // Gather damage-over-time effects
@@ -1384,37 +1392,13 @@ export default class CrucibleActor extends Actor {
       // Gather effects which are about to expire naturally
       if ( (effect.updateDuration(context).remaining <= 0) && effect.isExpiryEvent("turnStart", context) ) {
         effectChanges.toExpire.push(effect.id);
-        continue; // No need to maintain an effect which is about to expire naturally
+        continue;
       }
 
       // Remove unaware at turn start
       if ( effect.isStatusOnly("unaware") ) {
         effectChanges.toDelete.push(effect.id);
         continue;
-      }
-
-      // Identify maintained effects (only base-type effects carry maintenance data)
-      if ( effect.type !== "base" ) continue;
-      const maintainedCost = effect.system.maintenance.cost;
-      if ( maintainedCost ) {
-        if ( maintainedCost > this.resources.focus.value ) {
-          effectChanges.toDelete.push(effect.id);
-          continue;
-        }
-        const confirm = await DialogV2.query(this.getDesignatedUser(), "confirm", {
-          window: {
-            title: _loc("ACTION.MaintainTitle", {effect: effect.name})
-          },
-          content: _loc("ACTION.MaintainContent", {cost: maintainedCost, effect: effect.name})
-        });
-        if ( confirm ) {
-          resourceChanges.focus.push({
-            label: _loc("COMBAT.SUMMARY.Maintaining", {effect: effect.name}),
-            amount: -maintainedCost
-          });
-        } else {
-          effectChanges.toDelete.push(effect.id);
-        }
       }
     }
   }

--- a/module/hooks/action.mjs
+++ b/module/hooks/action.mjs
@@ -1820,6 +1820,25 @@ HOOKS.rest = {
   }
 };
 
+/* -------------------------------------------- */
+
+HOOKS.maintain = {
+  canUse() {
+    if ( !this.actor.maintainedEffect ) throw new Error(_loc("ACTION.WARNINGS.NoMaintainedEffect"));
+  },
+  postActivate() {
+    const effect = this.actor.maintainedEffect;
+    const combat = game.combat;
+    if ( !effect || !combat?.started ) return;
+
+    // Re-anchor the maintained effect's duration to this round, deferring its expiry until the start of the next turn
+    const combatant = combat.getCombatantsByActor(this.actor)[0];
+    const activation = this.selfEvents.activation;
+    activation.effects.push({_id: effect.id, _action: "update",
+      start: {combat: combat.id, combatant: combatant?.id ?? null, round: combat.round, turn: combat.turn}});
+  }
+};
+
 /**
  * Shared event recorder used by the rest and recover action postActivate hooks.
  * @param {CrucibleAction} action

--- a/module/models/actor-base.mjs
+++ b/module/models/actor-base.mjs
@@ -153,6 +153,12 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
   equipment = this.equipment;
 
   /**
+   * The singleton effect currently being maintained by this Actor, or null.
+   * @type {CrucibleActiveEffect|null}
+   */
+  maintainedEffect = null;
+
+  /**
    * The grimoire of known spellcraft components.
    * @type {CrucibleActorGrimoire}
    */
@@ -810,6 +816,9 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
     this.#finalizeGrimoire();
     this.parent.callActorHooks("prepareSpells", this.grimoire);
 
+    // Maintained Effect
+    this.#prepareMaintainedEffect();
+
     // Prepare Equipped Items
     this.#prepareEquippedItems();
 
@@ -1107,6 +1116,21 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Identify the singleton effect which this Actor is maintaining, if any.
+   * Maintained effects expire at the start of the Actor's turn unless sustained through the Maintain action.
+   */
+  #prepareMaintainedEffect() {
+    this.maintainedEffect = null;
+    for ( const effect of this.parent.effects ) {
+      if ( !effect.active || (effect.type !== "base") ) continue;
+      if ( effect.system.maintenance.cost ) {
+        this.maintainedEffect = effect;
+        break;
+      }
+    }
+  }
+
+  /**
    * Prepare Actions which this Actor may actively use.
    */
   #prepareActions() {
@@ -1131,6 +1155,9 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
         case "cast":
           if ( !(this.grimoire.gestures.size && this.grimoire.runes.size) ) continue;
           break;
+        case "maintain":
+          if ( !this.maintainedEffect ) continue;
+          break;
         case "reload":
           if ( !w.reload ) continue;
           break;
@@ -1142,6 +1169,9 @@ export default class CrucibleBaseActor extends foundry.abstract.TypeDataModel {
       // Action data
       ad = foundry.utils.deepClone(ad);
       ad.tags ||= [];
+
+      // The Maintain action incurs the focus cost of the effect it sustains
+      if ( ad.id === "maintain" ) ad.cost.focus = this.maintainedEffect.system.maintenance.cost ?? 0;
 
       // Customize strike tags
       if ( ["strike", "reactiveStrike"].includes(ad.id) ) {


### PR DESCRIPTION
### How it works

- **Natural expiry.** Effects created by actions with the `maintained` tag now carry a real
  duration (2 rounds, expiring at the start of the Actor's turn) alongside their maintenance
  cost. A maintained effect persists through the round it was cast and the following round,
  giving the player one full turn to sustain it before it expires naturally.
- **Singleton maintained effect.** Actor preparation resolves `actor.maintainedEffect` (or
  null) once during prep — the issue's "singleton maintainedEffect" — so nothing needs to
  iterate over all effects hunting for maintenance costs.
- **The Maintain action.** A general action that only appears while a maintained effect
  exists, with its focus cost drawn from that effect's maintenance cost. Confirming it
  re-anchors the effect's duration to the current round, deferring expiry. Since it is a
  real action, talents can now hook `prepareAction` / `useAction` / `confirmAction` against
  the `maintain` action id to modify its cost or add riders ("when you maintain an effect…").
- **Singleton enforcement + replacement warning.** Using another action with the
  `maintained` tag while an effect is already maintained prompts a confirmation ("Using X
  will end your maintained Y"); on activation the old effect ends.
- **Turn-start cleanup.** The per-effect DialogV2 confirm and the automatic focus
  affordability deletion are removed from `#prepareTurnStartConfig`; an unmaintained effect
  simply expires through the standard duration pipeline.

### Testing

Live-verified on Foundry VTT v14 build 367 with a combat running:

- With no maintained effect, the Maintain action is absent from the actor's actions.
- Creating a maintained effect (cost 2 focus): `maintainedEffect` resolves to it, and the
  Maintain action appears with `cost.focus: 2`.
- Using the Maintain action: focus paid 3 → 1 via the event stream, and the effect's
  duration re-anchored to the current round.
- Survival/expiry cadence: maintained in round N → alive at round N+1 turn start (remaining
  1) → skipping the Maintain action in round N+1 → the effect is deleted at the round N+2
  turn start, its statuses clear, `maintainedEffect` resets, and the Maintain action
  disappears.
- Hands-only maintenance (grapple effects, `maintenance.hands` without a cost) is untouched.

<img width="1600" height="900" alt="maintain-action-available" src="https://github.com/user-attachments/assets/3cc6c6ff-ec4f-4616-b1a0-c4f71f7ed556" />
*The Maintain action appears under Favorite Actions with its cost chips (Self · 0 Action ·
2 Focus) while the Chessman maintains an Invisibility effect. Focus pool: 3.*

<img width="1600" height="900" alt="maintain-action-used" src="https://github.com/user-attachments/assets/89dea5dd-77a3-48df-a82e-619ec6a338c8" />
*After confirming the Maintain action: the focus pool dropped 3 → 1 (the maintenance cost
paid through the event stream) and the effect's duration was re-anchored to the current
round. The focus cost chip highlights red while focus is too low to sustain again.*

### Considerations for reviewers

- The 2-round duration is what gives the player their "one full turn to sustain" window; a
  1-round duration would expire at the start of the very next turn before the Maintain
  action could be taken. Happy to revisit the exact cadence.
- Point 5 of the issue ("prompt you to use the Maintain action at the start of your turn")
  is future work — the action is auto-favorited so it surfaces while available.
- Existing maintained effects created before this change carry indefinite durations; they
  will no longer be prompted for maintenance and should be removed manually (they are
  visible on the actor's effects list).
- Pre-existing quirk noticed while testing: effects created on unlinked tokens via the API
  are not registered in core's ActiveEffect expiry registry, so core's turn-start expiry
  pass skips them until registration. This affects all effect durations equally (including
  Defend's guarded) and is not introduced by this PR.
