### PR TITLE
[#1028] Prevent turn start workflows from re-triggering on Combat rewind

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1301,6 +1301,12 @@ export default class CrucibleActor extends Actor {
     const {round, from, to} = this.flags.crucible?.delay || {};
     if ( from && (round === game.combat.round) && (game.combat.combatant?.initiative === to) ) return;
 
+    // Skip turn start workflows which have already been performed for this round & turn, so rewinding the Combat and
+    // advancing again does not trigger effects such as damage-over-time multiple times (GH #1028)
+    const turnMarker = `${context.round}.${context.turn}`;
+    const startedTurns = this.getFlag("crucible", "turnStarts") ?? [];
+    if ( startedTurns.includes(turnMarker) ) return;
+
     // Plan actor changes
     const statusText = [];
     const resourceChanges = {action: [{label: null, amount: Infinity}]};
@@ -1311,7 +1317,8 @@ export default class CrucibleActor extends Actor {
     });
 
     // Plan turn start workflows
-    const actorUpdates = {system: {status: null}, flags: {crucible: {actionHistory: []}}};
+    const actorUpdates = {system: {status: null},
+      flags: {crucible: {actionHistory: [], turnStarts: [...startedTurns, turnMarker]}}};
     const effectChanges = {toCreate: [], toUpdate: [], toDelete: [], toExpire: []};
     const turnStartConfig = /** @type {CrucibleTurnChangeConfig & {dot: CrucibleActiveEffect[]}} */ {resourceChanges,
       actorUpdates, effectChanges, statusText, dot: []};


### PR DESCRIPTION
### Root cause

Rewinding the Combat (`previousTurn` / `previousRound`) fires no turn events — but advancing
again re-dispatches the turn start for every crossed turn. `CrucibleActor#onStartTurn` had no
memory of turns it had already processed, so its full workflow ran a second time for a
round & turn that had already started: damage-over-time effects such as Bleeding applied
again (once per rewind), and recovery, expiry checks, and unaware removal re-ran.

### Fix

`onStartTurn` now records the round & turn it last ran for (`flags.crucible.turnStarts`) and
skips turn starts which have already been performed. Rewinding and advancing again therefore
cannot trigger effects multiple times — the first of the two approaches offered in #1028.
End-of-turn workflows are untouched: their operations (resource recovery to maximum, expiry
of already-removed effects) are idempotent when re-run.

### Before / After

Bleeding (3 Health per turn) on a combatant at round 2, with exactly one legitimate tick
applied (Health 68 → 65):


*Before: rewinding to round 1 and re-advancing re-triggers the turn start — Bleeding applies
a second time (Health 62) while the Combat is still on round 2.*


*After: the same rewind + re-advance leaves Health at 65. The re-fired turn start is
skipped.*


<img width="1600" height="1912" alt="before-after-comparison" src="https://github.com/user-attachments/assets/55f8bfc5-bd91-4907-ab2e-5222f413d2c8" />

### Testing

Live-verified on Foundry VTT v14 build 367 with a two-combatant combat and a Bleeding effect
(3 Health damage per turn):

- Round 1 → 2 advance: Bleeding ticks once (68 → 65).
- Rewind to round 1 and re-advance: no additional tick (stays 65).
- Round 2 → 3 advance: Bleeding ticks again (65 → 62) — genuine turns still trigger.
- Deep rewind (round 3 → round 1) then re-advancing through rounds 2 and 3: neither turn
  start re-triggers (stays 62) — the visited-turn record covers multi-round rewinds.
- The Delay mechanic's own turn-skip runs before this guard and is unaffected.

### Considerations for reviewers

- The issue's preferred solution ("revert them") would require journaling and reversing all
  turn-start changes (DoT damage, recovery, expired effects, unaware removal) when the
  combat rewinds. This PR implements the guard approach instead: rewound time keeps the
  effects that already applied rather than reverting them, but they can never multiply.
  If full reversal is wanted later, `turnStarts` could be extended to journal the applied
  resource deltas per turn.
- The `turnStarts` flag grows by one short entry per actor-turn (e.g. `"2.0"`); it resets
  when the actor's flag is cleared or the combat ends.
